### PR TITLE
Fixed errors in README related to OneFile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,25 @@ module OneFile
     end
   end
 
-  module Controllers::Home
-    include OneFile::Controller
+  module Controllers
+    module Home
+      include Lotus::Controller
 
-    action 'Index' do
-      def call(params)
+      action 'Index' do
+        def call(params)
+        end
       end
     end
   end
 
-  module Views::Home
-    class Index
-      include OneFile::View
+  module Views
+    module Home
+      class Index
+        include Lotus::View
 
-      def render
-        'Hello'
+        def render
+          'Hello'
+        end
       end
     end
   end


### PR DESCRIPTION
The problem was that `OneFile::Controllers` didn't exist yet and we were trying to create `OneFile::Controllers::Home`.  We had the same problem with `OneFile::Views` and `OneFile::Views::Home`

We also want to include `Lotus::Controller` instead of `OneFile::Controller` and `Lotus::View` instead of `OneFile::View`.

Hopefully this accurately reflects how it should be working.
