### PR TITLE
Prepare Lotus for Rubinius support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ rvm:
   - 2.1.0
   - 2.1.1
   - 2.1.2
+  - rbx-2
+
+matrix:
+  allow_failures:
+    - rvm: rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 if !ENV['TRAVIS']
-  gem 'byebug',           require: false, platforms: :ruby if RUBY_VERSION >= '2.1.0'
+  gem 'byebug',           require: false, platforms: :mri if RUBY_VERSION >= '2.1.0'
   gem 'yard',             require: false
 end
 


### PR DESCRIPTION
Even Rubinius doesn't support keyword arguments yet, I think it's a good idea to include Rubinius even now into the Testing process (and allow failure for now).

Keyword Arguments should be shipped with Rubinius soon :)

Cheers
