### PR TITLE
Removing unused setup code from Lotus::Loader test

### DIFF
--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -2,10 +2,7 @@ require 'test_helper'
 
 describe Lotus::Loader do
   before do
-    CoffeeShop::Application.configuration.root.join('app/templates').mkpath
-
     @application = CoffeeShop::Application.new
-    @loader      = Lotus::Loader.new(@application)
   end
 
   describe '#load!' do


### PR DESCRIPTION
The test fixture setup and `@loader` assignment aren't required in `loader_test.rb` in order for the test to pass. I suspect this is because the loading occurs on `Lotus::Application.new` but at some stage a different thing was planned.

This test is also strange because it claims to test `Lotus::Loader#load!` but never directly calls that method. It seems marginally related to the original `OneLine` application before #6 was merged where it looked like:

``` ruby
require 'lotus'

module OneFile
  class Application < Lotus::Application
    configure do
      routes do
        get '/', to: 'home#index'
      end
    end
  end
end

# OneFile::Application.new
# we could uncomment this to force framework duplication

module OneFile
  module Controllers
    module Home
      include OneFile::Controller

      action 'Index' do
        def call(params)
        end
      end
    end
  end

  module Views
    module Home
      class Index
        include OneFile::View

        def render
          'Hello'
        end
      end
    end
  end
end
```

This fails because at class declaration time the application has not been loaded and the framework hasn't been duped into the extra modules. Instead we could force this duplication to occur by running `OneFile::Application.new` before declaring our `Controller` and `View` modules but this then requires two instantiations of our application. Once here and once in `config.ru`
