### PR TITLE
Allow configuration of the Middleware stack

### DIFF
--- a/lib/lotus/application.rb
+++ b/lib/lotus/application.rb
@@ -154,7 +154,7 @@ module Lotus
     #
     # @see Lotus::Middleware
     def middleware
-      @middleware ||= Lotus::Middleware.new(self)
+      @middleware ||= configuration.middleware.load!(self)
     end
   end
 end

--- a/lib/lotus/config/assets.rb
+++ b/lib/lotus/config/assets.rb
@@ -5,10 +5,8 @@ module Lotus
     # @since 0.1.0
     # @api private
     class Assets
-      DEFAULT_DIRECTORY = 'public'.freeze
-
       def initialize(root, directory)
-        @path = root.join(directory || DEFAULT_DIRECTORY)
+        @path = root.join(directory)
       end
 
       def entries

--- a/lib/lotus/middleware.rb
+++ b/lib/lotus/middleware.rb
@@ -6,7 +6,7 @@ module Lotus
   class Middleware
     # Instantiate a middleware stack
     #
-    # @param application [Lotus::Application] the application
+    # @param configuration [Lotus::Configuration] the application's configuration
     #
     # @return [Lotus::Middleware] the new stack
     #
@@ -14,16 +14,34 @@ module Lotus
     # @api private
     #
     # @see Lotus::Configuration
-    # @see http://rdoc.info/gems/rack/Rack/Builder
-    def initialize(application)
-      configuration = application.configuration
-      routes        = application.routes
+    def initialize(configuration)
+      # Initialize the default Middleware stack
+      @stack = []
 
+      if configuration.assets
+        use Rack::Static, {
+          urls: configuration.assets.entries,
+          root: configuration.assets
+        }
+      end
+    end
+
+    # Load the middleware stack
+    #
+    # @param application [Lotus::Application] the application loading the middleware
+    #
+    # @return [Lotus::Middleware] the loaded middleware stack
+    #
+    # @since 0.1.0
+    # @api private
+    #
+    # @see http://rdoc.info/gems/rack/Rack/Builder
+    def load!(application)
       @builder = ::Rack::Builder.new
-      @builder.use Rack::Static,
-        urls: configuration.assets.entries,
-        root: configuration.assets
-      @builder.run routes
+      @stack.each { |m, args, block| @builder.use m, *args, &block }
+      @builder.run application.routes
+
+      self
     end
 
     # Process a request.
@@ -37,6 +55,19 @@ module Lotus
     # @api private
     def call(env)
       @builder.call(env)
+    end
+
+    # Add a middleware to the stack.
+    #
+    # @param middleware [Object] a Rack middleware
+    # @param *args [Array] optional arguments to pass to the Rack middleware
+    # @param &blk [Proc] an optional block to pass to the Rack middleware
+    #
+    # @return [Array] the middleware that was added
+    #
+    # @since 0.1.0
+    def use(middleware, *args, &blk)
+      @stack << [middleware, args, blk]
     end
   end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -193,6 +193,12 @@ describe Lotus::Configuration do
     end
   end
 
+  describe '#middleware' do
+    it 'returns a new instance of Lotus::Middleware' do
+      @configuration.middleware.must_be_instance_of Lotus::Middleware
+    end
+  end
+
   # describe '#mapping' do
   #   describe 'when a block is given' do
   #     let(:mapping) { Proc.new { collection :customers do; end } }

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+require 'lotus/middleware'
+
+Lotus::Middleware.class_eval { attr_reader :stack }
+
+describe Lotus::Middleware do
+  before do
+    module MockApp
+      class Application < Lotus::Application; end
+    end
+  end
+
+  let(:configuration) { MockApp::Application.configuration }
+  let(:middleware)    { configuration.middleware }
+
+  it 'contains only Rack::Static by default' do
+    middleware.stack.must_equal [
+      [
+        Rack::Static,
+        [{ urls: configuration.assets.entries, root: configuration.assets }],
+        nil
+      ]
+    ]
+  end
+
+  it 'does not include Rack::Static if configuration.assets is set to false' do
+    configuration.assets false
+    middleware.stack.any? { |m| m.first == Rack::Static }.must_equal false
+  end
+
+  describe '#use' do
+    it 'inserts a middleware into the stack' do
+      middleware.use Rack::ETag
+      middleware.stack.must_include [Rack::ETag, [], nil]
+      MockApp::Application.new.middleware.stack.must_include [Rack::ETag, [], nil]
+    end
+  end
+
+  describe '#load' do
+    it 'loads the middleware into a Rack::Builder' do
+      middleware.use Rack::ETag
+      middleware.load!(MockApp::Application.new)
+      builder = middleware.instance_variable_get(:@builder)
+
+      builder.instance_variable_get(:@use).size.must_equal 2
+    end
+  end
+
+  after do
+    MockApp.send(:remove_const, :Application)
+    Object.send(:remove_const, :MockApp)
+  end
+end


### PR DESCRIPTION
Move the functionality of `Lotus::Middleware` from the application to a
configuration block to allow users to configure the middleware stack.
When the application is loaded, `Lotus::Middleware#load!` will still get
called to load the final middleware stack into the Rack::Builder app
that wraps the router.

Closes #27.

Signed-off-by: David Celis me@davidcel.is
