### PR TITLE
Add a call to root in the microservices examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ require 'lotus'
 module Backend
   class Application < Lotus::Application
     configure do
+      # Specify a root here so that load paths, etc. are relative to your microservice.
+      root 'apps/backend'
+    
       load_paths << [
         'controllers',
         'views'


### PR DESCRIPTION
The microservices example as documented will currently not work, as the load_paths references `controller` and `views` directories inside the microservice's directory without setting the root of the application properly.

This change updates the example to have it work correctly.
