### PR TITLE
Reflect the change made at PR #8 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ module OneFile
 
   module Controllers
     module Home
-      include OneFile::Controller
+      include Lotus::Controller
 
       action 'Index' do
         def call(params)
@@ -115,7 +115,7 @@ module OneFile
   module Views
     module Home
       class Index
-        include OneFile::View
+        include Lotus::View
 
         def render
           'Hello'
@@ -206,7 +206,7 @@ module Backend
     configure do
       # Specify a root here so that load paths, etc. are relative to your microservice.
       root 'apps/backend'
-    
+
       load_paths << [
         'controllers',
         'views'


### PR DESCRIPTION
README of lotus/lotus has to be updated so that it uses `Lotus` namespace rather than `OneFile` in one-file application.
