### PR TITLE
Add section in README on CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,16 @@ module Bookshelf
 end
 ```
 
+## Command-line
+
+Lotus provides a few command-line utilities:
+
+* `lotus server` boots up a server. Assumes you have a `config.ru` file.
+* `lotus console` brings up a REPL. It defaults to IRB but can be configured to
+  use Pry or Ripl via the `--engine` option. By default, the console will try to
+load `config/applications.rb`. You can point it directly to your app via the
+`--applications` flag.
+
 ## The future
 
 Lotus uses different approaches for web development with Ruby than other frameworks. For this reason, it needs to reach a certain degree of maturity.


### PR DESCRIPTION
`lotus server` and `lotus console` were added in
https://github.com/lotus/lotus/commit/f342c2095f79e2c3d354c87b0d3e427eb7c23546 and
https://github.com/lotus/lotus/commit/c5f38376c4e1bc822a29d96005f42bd6f970db25
respectively but are not documented in the README.

This adds a short description of the commands to the README as well as
documenting what the command assumes to be in place.
