### PR TITLE
Document support for Configuration#mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,10 @@ module Bookshelf
       #
       routes 'config/routes'
 
+      # The mapping set (optional) (alternative usage)
+      # Arguement: A relative path where to find the mapping definition for a database.
+      mapping 'config/mapping'
+
       # The layout to be used by all the views (optional)
       # Argument: A Symbol that indicates the name, default to nil
       #


### PR DESCRIPTION
Since we allow a database mapping block to be yielded to the `Configuration#mapping` method, this should be documented in the README.
