### PR TITLE
Fix reloading of lotus console

### DIFF
--- a/lib/lotus/commands/console.rb
+++ b/lib/lotus/commands/console.rb
@@ -6,7 +6,7 @@ module Lotus
       module Methods
         def reload!
           puts 'Reloading...'
-          Kernel.exec $0
+          Kernel.exec "#{$0} console"
         end
       end
 

--- a/test/commands/console_test.rb
+++ b/test/commands/console_test.rb
@@ -239,7 +239,7 @@ describe Lotus::Commands::Console::Methods do
 
       @old_kernel = Kernel
       Lotus::Utils::IO.silence_warnings { Kernel = Minitest::Mock.new }
-      Kernel.expect(:exec, true, [$0])
+      Kernel.expect(:exec, true, ["#{$0} console"])
     end
 
     after do


### PR DESCRIPTION
I was playing with console reloading and I see this on current master:

```
$ lotus console
2.1.2 :001 > reload!
Reloading...
Commands:
  lotus console         # starts a lotus console
  lotus help [COMMAND]  # Describe available commands or one specific command
  lotus server          # starts a lotus server
$
```

So here goes the fix that adds `console` argument to the execution path.
