### PR TITLE
WIP: Allow customising error pages

### DIFF
--- a/lib/lotus/rendering_policy.rb
+++ b/lib/lotus/rendering_policy.rb
@@ -23,6 +23,7 @@ module Lotus
       @controller_pattern = %r{#{ configuration.controller_pattern.gsub(/\%\{(controller|action)\}/) { "(?<#{ $1 }>(.*))" } }}
       @view_pattern       = configuration.view_pattern
       @namespace          = configuration.namespace
+      @templates          = configuration.templates
     end
 
     def render(response)
@@ -35,7 +36,7 @@ module Lotus
           )
         else
           if render_status_page?(response, action)
-            Lotus::Views::Default.render(response: response, format: :html)
+            Lotus::Views::Default.render(@templates, {response: response, format: :html})
           end
         end
 

--- a/lib/lotus/views/default.rb
+++ b/lib/lotus/views/default.rb
@@ -1,3 +1,5 @@
+require 'lotus/views/default_template_finder'
+
 module Lotus
   module Views
     # The default view that is rendered for non successful responses (200 and 201)
@@ -14,6 +16,17 @@ module Lotus
 
       def title
         response[2].first
+      end
+
+      def self.render(root, context)
+        format = context[:format]
+        template_name = context[:response][0].to_s
+
+        if template = DefaultTemplateFinder.new(root, template_name, format).find
+          new(template, context).render
+        else
+          super(context)
+        end
       end
     end
   end

--- a/lib/lotus/views/default_template_finder.rb
+++ b/lib/lotus/views/default_template_finder.rb
@@ -1,0 +1,16 @@
+module Lotus
+  module Views
+    class DefaultTemplateFinder < Lotus::View::Rendering::TemplateFinder
+      def initialize(root, template, format)
+        @root = root
+        @options = {template: template, format: format}
+      end
+
+      private
+
+      def root
+        @root
+      end
+    end
+  end
+end


### PR DESCRIPTION
I long long time ago I said I'd work on this. Ended up being quite a bit different than I imagined and I had to ask quite a bit of poor @jodosha. I haven't had a chance yet to finish the tests (unpushed) but I thought I had better (finally) create a PR.

The issue I was running into with the tests was changing the working directory. It seems the working directory needs to be changed before the application is loaded or it won't be set to the correct location.

``` ruby
describe 'Error page test' do
  include Rack::Test::Methods

  before do
    @current_dir = Dir.pwd
    Dir.chdir FIXTURES_ROOT.join('one_file')
    require 'fixtures/one_file/application' # We have to require this after the `chdir`
    @app = OneFile::Application.new
  end
```

I was using a modified version of the `one_file` application. Any thoughts on the best way to handle this?
