### PR TITLE
Fixing default redirect status

### DIFF
--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -112,7 +112,7 @@ describe 'A full stack Lotus application' do
   it "handles redirects from routes" do
     get '/legacy'
 
-    response.status.must_equal 302
+    response.status.must_equal 301
     response.body.must_be_empty
 
     follow_redirect!


### PR DESCRIPTION
With the change in lotus/router@846d1f9c, the tests are failing
locally.
