### PR TITLE
Extracting method #load_configuration_load_paths!

### DIFF
--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -36,8 +36,12 @@ module Lotus
     end
 
     def load_frameworks!
-      config = configuration
+      _load_controller_framework!
+      _load_view_framework!
+    end
 
+    def _load_controller_framework!
+      config = configuration
       unless application_module.const_defined?('Controller')
         controller = Lotus::Controller.duplicate(application_module) do
           handle_exceptions config.handle_exceptions
@@ -48,7 +52,10 @@ module Lotus
 
         application_module.const_set('Controller', controller)
       end
+    end
 
+    def _load_view_framework!
+      config = configuration
       unless application_module.const_defined?('View')
         view = Lotus::View.duplicate(application_module) do
           root   config.templates
@@ -71,9 +78,13 @@ module Lotus
 
     def load_rack!
       return if application.is_a?(Class)
+      _assign_rack_routes!
+      _load_rack_middleware!
+      _assign_routes_to_application_module!
+    end
 
+    def _assign_rack_routes!
       namespace = configuration.namespace || application_module
-
       resolver    = Lotus::Routing::EndpointResolver.new(pattern: configuration.controller_pattern, namespace: namespace)
       default_app = Lotus::Routing::Default.new
       application.routes = Lotus::Router.new(
@@ -84,9 +95,14 @@ module Lotus
         port:        configuration.port,
         &configuration.routes
       )
+    end
 
+    def _load_rack_middleware!
+      namespace = configuration.namespace || application_module
       configuration.middleware.load!(application, namespace)
+    end
 
+    def _assign_routes_to_application_module!
       unless application_module.const_defined?('Routes')
         routes = Lotus::Routes.new(application.routes)
         application_module.const_set('Routes', routes)


### PR DESCRIPTION
The #load_application! method's body had two levels of abstraction.
Extracting #load_configuration_load_paths!

Given that #load_application! then had two methods and was called in a
singular place (i.e. #load!), moved the #load_rack!
and #load_configuration_load_paths! up into the #load! method.
