### PR TITLE
Allows custom and default body parsers to be set.

### DIFF
--- a/lib/lotus/configuration.rb
+++ b/lib/lotus/configuration.rb
@@ -653,6 +653,76 @@ module Lotus
       end
     end
 
+    # Body parsing configuration.
+    #
+    # Specify a set of parsers for specific mime types that your application will use. This method will
+    # return the application's parsers which you can use to add existing and new custom parsers for your
+    # application to use.
+    #
+    # By default it's an empty `Array`
+    #
+    # This is part of a DSL, for this reason when this method is called with
+    # an argument, it will set the corresponding instance variable. When
+    # called without, it will return the already set value, or the default.
+    #
+    # @overload body_parsers(parsers)
+    #   Specify a set of body parsers.
+    #   @param parsers [Array] the body parser definitions
+    #
+    # @overload body_parsers
+    #   Gets the value
+    #   @return [Array] the set of parsers
+    #
+    # @since 0.2.0
+    #
+    # @example Getting the value
+    #   require 'lotus'
+    #
+    #   module Bookshelf
+    #     class Application < Lotus::Application
+    #     end
+    #   end
+    #
+    #   Bookshelf::Application.configuration.body_parsers
+    #     # => []
+    #
+    # @example Setting the value
+    #   require 'lotus'
+    #
+    #   module Bookshelf
+    #     class Application < Lotus::Application
+    #       configure do
+    #         body_parsers :json, XmlParser.new
+    #       end
+    #     end
+    #   end
+    #
+    #   Bookshelf::Application.configuration.body_parsers
+    #     # => [:json, XmlParser.new]
+    #
+    # @example Setting a new value after one is set.
+    #   require 'lotus'
+    #
+    #   module Bookshelf
+    #     class Application < Lotus::Application
+    #       configure do
+    #         body_parsers :json
+    #         body_parsers XmlParser.new
+    #       end
+    #     end
+    #   end
+    #
+    #   Bookshelf::Application.configuration.body_parsers
+    #     # => [XmlParser.new]
+    #
+    def body_parsers(*parsers)
+      if parsers.empty?
+        @body_parsers ||= []
+      else
+        @body_parsers = parsers
+      end
+    end
+
     # Application middleware.
     #
     # Specify middleware that your application will use. This method will return

--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -139,6 +139,7 @@ module Lotus
       resolver    = Lotus::Routing::EndpointResolver.new(pattern: configuration.controller_pattern, namespace: namespace)
       default_app = Lotus::Routing::Default.new
       application.routes = Lotus::Router.new(
+        parsers:     configuration.body_parsers,
         resolver:    resolver,
         default_app: default_app,
         scheme:      configuration.scheme,

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -238,6 +238,42 @@ describe Lotus::Configuration do
     end
   end
 
+  describe "#body_parsers" do
+    describe "when not previously set" do
+      it "defaults to nil" do
+        @configuration.body_parsers.must_equal []
+      end
+    end
+
+    describe "when set" do
+      before do
+        @configuration.body_parsers :json, :xml
+      end
+
+      it "returns the configured values" do
+        @configuration.body_parsers.must_equal [:json, :xml]
+      end
+    end
+
+    describe "when already set" do
+      before do
+        @configuration.body_parsers :json
+      end
+
+      describe "if I set a new value" do
+        before do
+          @configuration.body_parsers :xml
+        end
+
+        it "returns it" do
+          @configuration.body_parsers.must_equal [:xml]
+        end
+      end
+    end
+
+  end
+
+
   describe '#middleware' do
     it 'returns a new instance of Lotus::Middleware' do
       @configuration.middleware.must_be_instance_of Lotus::Middleware

--- a/test/fixtures/body_parsers/application.rb
+++ b/test/fixtures/body_parsers/application.rb
@@ -1,0 +1,50 @@
+require 'rexml/document'
+require 'lotus/routing/parsing/parser'
+
+class XmlParser < Lotus::Routing::Parsing::Parser
+  def mime_types
+    ['application/xml', 'text/xml']
+  end
+
+  def parse(body)
+    result = {}
+
+    xml = ::REXML::Document.new(body)
+    xml.elements.each('*') {|el| result[el.name] = el.text }
+
+    result
+  end
+end
+
+module BodyParsersApp
+  class Application < Lotus::Application
+    configure do
+      body_parsers :json, XmlParser.new
+
+      routes do
+        post '/json_parser', to: 'body_parsers#json'
+        patch '/xml_parser', to: 'body_parsers#xml'
+      end
+    end
+
+    load!
+  end
+
+  module Controllers::BodyParsers
+
+    class Json
+      include BodyParsersApp::Action
+      def call(params)
+        self.body = params[:success]
+      end
+    end
+
+    class Xml
+      include BodyParsersApp::Action
+      def call(params)
+        self.body = params[:success]
+      end
+    end
+
+  end
+end

--- a/test/integration/body_parsers_test.rb
+++ b/test/integration/body_parsers_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+require 'rack/test'
+require 'fixtures/body_parsers/application'
+
+describe 'Sessions' do
+  include Rack::Test::Methods
+
+  before do
+    @current_dir = Dir.pwd
+    Dir.chdir FIXTURES_ROOT.join('body_parsers')
+    @app = BodyParsersApp::Application.new
+  end
+
+  after do
+    Dir.chdir @current_dir
+    @current_dir = nil
+  end
+
+  def app
+    @app
+  end
+
+  def response
+    last_response
+  end
+
+  def request
+    last_request
+  end
+
+  it 'is successfuly parsing a JSON body' do
+    post '/json_parser', %({"success": "ok"}),  { 'CONTENT_TYPE' => 'application/json' }
+
+    response.body.must_equal 'ok'
+  end
+
+  it 'is successfuly parsing a XML body' do
+    patch '/xml_parser', %(<success>ok</success>), { "CONTENT_TYPE" => "application/xml" }
+
+    response.body.must_equal 'ok'
+  end
+
+  it 'is successfuly parsing a XML aliased mime' do
+    patch '/xml_parser', %(<success>ok</success>), { 'CONTENT_TYPE' => 'text/xml' }
+
+    response.body.must_equal 'ok'
+  end
+
+end


### PR DESCRIPTION
Hook up to the `Lotus::Router` for allowing router defined and custom body parsing.

Resolves #69.
