### PR TITLE
Introducing 'lotus/setup'

### DIFF
--- a/lib/lotus/environment.rb
+++ b/lib/lotus/environment.rb
@@ -177,6 +177,18 @@ module Lotus
       @environment ||= ENV[LOTUS_ENV] || ENV[RACK_ENV] || DEFAULT_ENV
     end
 
+    # A set of Bundler groups
+    #
+    # @return [Array] A set of groups
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see http://bundler.io/v1.7/groups.html
+    def bundler_groups
+      [environment]
+    end
+
     # Application's root
     #
     # It defaults to the current working directory.

--- a/lib/lotus/setup.rb
+++ b/lib/lotus/setup.rb
@@ -1,0 +1,7 @@
+require 'rubygems'
+require 'bundler/setup'
+require 'lotusrb'
+
+Bundler.require(
+  *Lotus::Environment.new.bundler_groups
+)

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -117,6 +117,16 @@ describe Lotus::Environment do
     end
   end
 
+  describe '#bundler_groups' do
+    before do
+      @env = Lotus::Environment.new
+    end
+
+    it 'returns a set of groups for Bundler' do
+      @env.bundler_groups.must_equal [@env.environment]
+    end
+  end
+
   describe '#config' do
     describe 'when not specified' do
       before do

--- a/test/lotus_setup_test.rb
+++ b/test/lotus_setup_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+describe 'lotus/setup' do
+  describe 'when required' do
+    before do
+      ENV['LOTUS_ENV'] = ENV['RACK_ENV'] = nil
+
+      Lotus::Utils::IO.silence_warnings do
+        @bundler = Bundler
+
+        Bundler = Module.new do
+          extend self
+
+          def require(groups)
+            @required_groups = groups
+          end
+
+          def required_groups
+            @required_groups
+          end
+        end
+      end
+
+      require 'lotus/setup'
+    end
+
+    after do
+      Lotus::Utils::IO.silence_warnings do
+        Bundler = @bundler
+      end
+    end
+
+    it 'requires Bundler groups' do
+      env = Lotus::Environment.new
+      Bundler.required_groups.must_equal(*env.bundler_groups)
+    end
+  end
+end


### PR DESCRIPTION
This is a file to be required to have all the Lotus libraries loaded and Bundler groups required.
## Use case

``` ruby
# Gemfile
gem 'bundler'
gem 'lotusrb'

group :test do
  gem 'capybara'
end

group :production do
  gem 'puma'
end
```

``` ruby
# config/environment.rb
require 'lotus/setup'
```

Requiring that file will cause:
- Require Rubygems (`require 'rubygems'`)
- Require and setup Bundler's group (`require 'bundler/setup'`). This requires `lotusrb` from the example above)
- Require Bundler's extra groups. This lookups the current environment (`ENV['LOTUS_ENV']` or `ENV['RACK_ENV']`) to determine what to load. In the example above, `capybara` will be loaded if the current env is equal to `test`, or `puma` in case of `production`.
