### PR TITLE
Register Lotus applications

### DIFF
--- a/test/application_test.rb
+++ b/test/application_test.rb
@@ -21,6 +21,39 @@ describe Lotus::Application do
     end
   end
 
+  describe 'subclasses' do
+    before do
+      Lotus::Application.applications.clear
+
+      module Foo
+        class Application < Lotus::Application
+          def self.load!(application = self)
+            @@loaded = true
+          end
+
+          def self.loaded?
+            @@loaded
+          end
+
+          configure { }
+        end
+      end
+    end
+
+    after do
+      Object.__send__(:remove_const, :Foo)
+    end
+
+    it 'register subclasses' do
+      Lotus::Application.applications.must_include(Foo::Application)
+    end
+
+    it 'preloads registered subclasses' do
+      Lotus::Application.preload!
+      Foo::Application.must_be :loaded?
+    end
+  end
+
   describe '#configuration' do
     it 'returns class configuration' do
       @application.configuration.must_equal @application.class.configuration


### PR DESCRIPTION
## Registry

When `Lotus::Application` is inherited, register the subclass.
The set of the subclasses are available at `Lotus::Application.applications` (private API).
## Preload

This PR introduces `Lotus::Application.preload!`. This API triggers `.load!` an all the registered applications.

The reason is simple. In full stack applications if we want to test components such as actions or views in isolation, because they reference `Bookshelf::Action` or `Bookshelf::View` and those modules are created at the runtime, we need to trigger the mechanism that preloads the frameworks (`Bookshelf::Application.load!`).

In the _container_ architecture, we have multiple applications, so from `test_helper.rb` we preload all the frameworks in bulk.

Close #30 
