### PR TITLE
Add configuration assets examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,19 @@ module Bookshelf
       #
       routes 'config/routes'
 
+      # Enabling serving assets
+      # Argument: boolean, defaults to false
+      #
+      serve_assets true
+
+      # Assets directories
+      # Argument: array, with assets path, default is 'public'
+      #
+      assets << [
+        'public',
+        'vendor/assets'
+      ]
+
       # The layout to be used by all the views (optional)
       # Argument: A Symbol that indicates the name, default to nil
       #


### PR DESCRIPTION
In our project we use dev version of Lotus, so after last updating assets was broken. After search in commits, I found changing in configuration. But didn't find it in readme ;)
