### PR TITLE
Require version file from CLI

### DIFF
--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -1,5 +1,6 @@
 require 'thor'
 require 'lotus/environment'
+require 'lotus/version'
 
 module Lotus
   class Cli < Thor


### PR DESCRIPTION
Not sure if I'm doing something wrong, but when I run the lotus CLI from master, it can not find `Lotus::VERSION`, e.g. when running `lotus new` or `lotus version`.

This simple fix helps.

Output from master:

```
$ ruby -Ilib bin/lotus version
/home/pulver/code/forks/lotus/lib/lotus/cli.rb:10:in `version': uninitialized constant Lotus::VERSION (NameError)
    from /home/pulver/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /home/pulver/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /home/pulver/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /home/pulver/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from bin/lotus:4:in `<main>'
```

Same output when I `bundle exec lotus version` from a dir with a Gemfile pointing to lotus master.
