### PR TITLE
Add `--version' and `-v' as aliases to `version'

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -15,6 +15,7 @@ module Hanami
       require 'hanami/version'
       puts "v#{ Hanami::VERSION }"
     end
+    map %w{--version -v} => :version
 
     desc 'server', 'starts a hanami server'
     long_desc <<-EOS

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -194,6 +194,35 @@ describe Hanami::Cli do
     end
   end
 
+  describe 'version' do
+    describe 'when `version` command' do
+      it 'prints Hanami version' do
+        assert_output("v#{Hanami::VERSION}\n") do
+          ARGV.replace(%w{version})
+          Hanami::Cli.start
+        end
+      end
+    end
+
+    describe 'when passing --version to hanami command, with no subcommand' do
+      it 'prints Hanami version' do
+        assert_output("v#{Hanami::VERSION}\n") do
+          ARGV.replace(%w{--version})
+          Hanami::Cli.start
+        end
+      end
+    end
+
+    describe 'when passing -v to hanami command, with no subcommand' do
+      it 'prints Hanami version' do
+        assert_output("v#{Hanami::VERSION}\n") do
+          ARGV.replace(%w{-v})
+          Hanami::Cli.start
+        end
+      end
+    end
+  end
+
   def setup_container_app
     File.open('.hanamirc', 'w') { |file| file << "architecture=container"}
   end


### PR DESCRIPTION
Just upgraded to 0.6.1, and tried to run:
```
$ lotus -v
Could not find command "_v".
```
And then:
```
$ lotus --version
Could not find command "__version".
```
Finally I typed `lotus` to see that the correct command is `lotus version`. 

This patch allows either of those alternate forms, and adds a test for `lotus version` as well.
I wouldn't be against adding `-V` too, but I don't think it's necessary.