### PR TITLE
Console engine fallback to DEFAULT_ENGINE

### DIFF
--- a/lib/hanami/commands/console.rb
+++ b/lib/hanami/commands/console.rb
@@ -22,7 +22,7 @@ module Hanami
         'irb'  => 'IRB'
       }.freeze
 
-      DEFAULT_ENGINE = 'irb'.freeze
+      DEFAULT_ENGINE = ['irb'].freeze
 
       # @since 0.1.0
       attr_reader :options

--- a/test/commands/console_test.rb
+++ b/test/commands/console_test.rb
@@ -82,8 +82,20 @@ describe Hanami::Commands::Console do
     end
 
     describe 'when nothing is loaded' do
+      module ConsoleLoadEngineStub
+        private
+
+        def load_engine(engine)
+          Object.const_set(
+            Hanami::Commands::Console::ENGINES[engine],
+            Module.new { def self.start; end }
+          )
+        end
+      end
+
       before do
-        stub_engine 'IRB'
+        console.extend ConsoleLoadEngineStub
+        @remove_const = true
       end
 
       after do


### PR DESCRIPTION
Fallback to ```DEFAULT_ENGINE``` should return array, not string ```irb```.
Calling ```#first``` will return ```i``` from DEFAULT_ENGINE as first letter in string.