### PR TITLE
Fix template generation when template options is not erb

### DIFF
--- a/lib/hanami/commands/generate/app.rb
+++ b/lib/hanami/commands/generate/app.rb
@@ -7,11 +7,14 @@ module Hanami
     class Generate
       class App < Abstract
 
+        DEFAULT_TEMPLATE_FORMATS = 'erb'.freeze
+
+        APPLICATION_TEMPLATE_FORMATS = %w[erb slim haml].freeze
+
         attr_reader :base_path
 
         def initialize(options, application_name)
           super(options)
-
           assert_application_name!(application_name)
           assert_architecture!
 
@@ -23,7 +26,7 @@ module Hanami
           add_mapping('application.rb.tt', 'application.rb')
           add_mapping('config/routes.rb.tt', 'config/routes.rb')
           add_mapping('views/application_layout.rb.tt', 'views/application_layout.rb')
-          add_mapping('templates/application.html.erb.tt', 'templates/application.html.erb')
+          add_mapping("templates/application.html.#{ template_engine }.tt", "templates/application.html.#{ template_engine }")
           add_mapping('favicon.ico', 'assets/favicon.ico')
 
           add_mapping('.gitkeep', 'controllers/.gitkeep')
@@ -53,6 +56,11 @@ module Hanami
 
         private
 
+        def template_engine
+          engine = super
+          APPLICATION_TEMPLATE_FORMATS.find { |t| t == engine } || DEFAULT_TEMPLATE_FORMATS
+        end
+
         def application_base_url
           options.fetch(:application_base_url, "/#{app_name}")
         end
@@ -77,6 +85,10 @@ module Hanami
               %(#{ upcase_app_name }_SESSIONS_SECRET="#{ SecureRandom.hex(32) }"\n)
             end
           end
+        end
+
+        def hanamirc
+          @hanamirc ||= Hanamirc.new(base_path)
         end
 
         def target_path

--- a/lib/hanami/generators/app/templates/application.html.haml.tt
+++ b/lib/hanami/generators/app/templates/application.html.haml.tt
@@ -1,0 +1,7 @@
+!!!
+%html
+  %head
+    %title <%= config[:classified_app_name] %>
+    = favicon
+  %body
+    = yield

--- a/lib/hanami/generators/app/templates/application.html.slim.tt
+++ b/lib/hanami/generators/app/templates/application.html.slim.tt
@@ -1,0 +1,8 @@
+doctype html
+html
+  head
+    title
+      | <%= config[:classified_app_name] %>
+    - == favicon
+  body
+    - == yield

--- a/lib/hanami/generators/app/templates/application.html.slim.tt
+++ b/lib/hanami/generators/app/templates/application.html.slim.tt
@@ -3,6 +3,6 @@ html
   head
     title
       | <%= config[:classified_app_name] %>
-    - == favicon
+    - = favicon
   body
-    - == yield
+    - = yield

--- a/test/commands/generate/app_test.rb
+++ b/test/commands/generate/app_test.rb
@@ -34,6 +34,30 @@ describe Hanami::Commands::Generate::App do
       end
     end
 
+    it 'generates template file for special engine' do
+      with_temp_dir do |original_wd|
+        setup_container_app(original_wd)
+        File.open('.hanamirc', 'w') { |file| file << "template=slim"}
+        command = Hanami::Commands::Generate::App.new({}, 'admin')
+        capture_io { command.start }
+
+        assert_generated_file(original_wd.join('test', 'fixtures', 'commands', 'generate', 'app', 'layout.html.slim'), 'apps/admin/templates/application.html.slim')
+      end
+    end
+
+    describe 'when template engine not erb, haml or slim' do
+      it 'generates erb template file' do
+        with_temp_dir do |original_wd|
+          setup_container_app(original_wd)
+          File.open('.hanamirc', 'w') { |file| file << "template=wiki"}
+          command = Hanami::Commands::Generate::App.new({}, 'admin')
+          capture_io { command.start }
+
+          assert_generated_file(original_wd.join('test', 'fixtures', 'commands', 'generate', 'app', 'layout.html.erb'), 'apps/admin/templates/application.html.erb')
+        end
+      end
+    end
+
     it 'generate the application with valid ruby syntax for dasherized name' do
       with_temp_dir do |original_wd|
         setup_container_app(original_wd)

--- a/test/fixtures/commands/generate/app/layout.html.slim
+++ b/test/fixtures/commands/generate/app/layout.html.slim
@@ -1,0 +1,8 @@
+doctype html
+html
+  head
+    title
+      | Admin
+    - == favicon
+  body
+    - == yield

--- a/test/fixtures/commands/generate/app/layout.html.slim
+++ b/test/fixtures/commands/generate/app/layout.html.slim
@@ -3,6 +3,6 @@ html
   head
     title
       | Admin
-    - == favicon
+    - = favicon
   body
-    - == yield
+    - = yield


### PR DESCRIPTION
If `template` option differs from `erb` in `.hanamirc` file the `hanami g app` command create `application_layout.html.erb` file.

This patch fix this problem for slim and haml templates. Also this patch fix `#hanamirc` method in `Generate::App`.