### PR TITLE
Fix hanami console call

### DIFF
--- a/lib/hanami/commands/console.rb
+++ b/lib/hanami/commands/console.rb
@@ -22,7 +22,7 @@ module Hanami
         'irb'  => 'IRB'
       }.freeze
 
-      DEFAULT_ENGINE = 'irb'.freeze
+      DEFAULT_ENGINE = ["irb", "IRB"].freeze
 
       # @since 0.1.0
       attr_reader :options


### PR DESCRIPTION
`DEFAULT_ENGINE` returns string and `#first` method return `'i'` char.