### PR TITLE
Enable JRuby+Truffle on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,17 @@ rvm:
   - ruby-head
 
 matrix:
+  include:
+    - rvm: jruby-head
+      jdk: oraclejdk8
+      env: TRUFFLE=1
+
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: jruby-9000
     - rvm: jruby-9.0.1.0
     - rvm: jruby-9.0.3.0
+    - rvm: jruby-head
+      jdk: oraclejdk8
+      env: TRUFFLE=1


### PR DESCRIPTION
I believe it's good to test Hanami against JRuby+Truffle. It's promised high-performance implementation of Ruby. It'd be nice Hanami worked on it.