### PR TITLE
fix Hanami::Static for public subdirectories

### DIFF
--- a/lib/hanami/static.rb
+++ b/lib/hanami/static.rb
@@ -32,7 +32,7 @@ module Hanami
 
     def can_serve(path, original = nil)
       destination = Dir[PUBLIC_DIRECTORY].find do |file|
-        file.index(path).to_i > 0
+        file.index(path).to_i > 0 && file.end_with?(path) && File.file?(file)
       end
 
       (super(path) || !!destination) && _fresh?(original, destination)


### PR DESCRIPTION
To reproduce the issue run these commands:
```
hanami new reprod
cd reprod
hanami generate action web home#index --url=/
hanami generate app admin
hanami generate action admin dashboard#index --url=/
hanami s
```

First request will respond as it should.
The second request will be 404 _File not found: /admin_

It depends on reimplemented ```Hanami::Static#can_serve```.
Variable ```destination``` returns false positive result for directories that are not possible to serve.