### PR TITLE
Enable JRuby+Truffle on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,17 @@ rvm:
   - ruby-head
 
 matrix:
+  include:
+    - rvm: jruby-head
+      jdk: oraclejdk8
+      env: JRUBY_OPTS=-X+T
+
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: jruby-9000
     - rvm: jruby-9.0.1.0
     - rvm: jruby-9.0.3.0
+    - rvm: jruby-head
+      jdk: oraclejdk8
+      env: JRUBY_OPTS=-X+T


### PR DESCRIPTION
I believe it's good to test Hanami against JRuby+Truffle even it will fail on Travis for long time. It's promised high-performance implementation of Ruby. It'd be nice Hanami worked on it.