### PR TITLE
Add missing file adapter description to generators

### DIFF
--- a/lib/hanami/generators/application/app/lib/app_name.rb.tt
+++ b/lib/hanami/generators/application/app/lib/app_name.rb.tt
@@ -7,6 +7,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/<%= config[:app_name] %>_development'
   #

--- a/lib/hanami/generators/application/container/lib/app_name.rb.tt
+++ b/lib/hanami/generators/application/container/lib/app_name.rb.tt
@@ -8,6 +8,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/<%= config[:app_name] %>_development'
   #

--- a/test/fixtures/commands/application/new_app/lib/new_app.rb
+++ b/test/fixtures/commands/application/new_app/lib/new_app.rb
@@ -7,6 +7,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/new_app_development'
   #

--- a/test/fixtures/commands/application/new_container/lib/new_container.filesystem.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.filesystem.rb
@@ -8,6 +8,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/new_container_development'
   #

--- a/test/fixtures/commands/application/new_container/lib/new_container.memory.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.memory.rb
@@ -8,6 +8,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/new_container_development'
   #

--- a/test/fixtures/commands/application/new_container/lib/new_container.mysql2.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.mysql2.rb
@@ -8,6 +8,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/new_container_development'
   #

--- a/test/fixtures/commands/application/new_container/lib/new_container.postgres.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.postgres.rb
@@ -8,6 +8,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/new_container_development'
   #

--- a/test/fixtures/commands/application/new_container/lib/new_container.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.rb
@@ -8,6 +8,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/new_container_development'
   #

--- a/test/fixtures/commands/application/new_container/lib/new_container.sqlite3.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.sqlite3.rb
@@ -8,6 +8,9 @@ Hanami::Model.configure do
   #
   # Available options:
   #
+  #  * File System adapter
+  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/new_container_development'
   #


### PR DESCRIPTION
I found that this information [described in docs](http://hanamirb.org/guides/models/overview/) but not described in generated files.