### PR TITLE
Fix Rakefile generation when using RSpec

### DIFF
--- a/lib/hanami/generators/application/app/Rakefile.rspec.tt
+++ b/lib/hanami/generators/application/app/Rakefile.rspec.tt
@@ -1,6 +1,9 @@
 require 'rake'
 require 'hanami/rake_tasks'
-require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
-task default: :spec
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task default: :spec
+rescue LoadError
+end

--- a/lib/hanami/generators/application/container/Rakefile.rspec.tt
+++ b/lib/hanami/generators/application/container/Rakefile.rspec.tt
@@ -1,6 +1,9 @@
 require 'rake'
 require 'hanami/rake_tasks'
-require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
-task default: :spec
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task default: :spec
+rescue LoadError
+end

--- a/test/fixtures/commands/application/new_app/Rakefile.rspec
+++ b/test/fixtures/commands/application/new_app/Rakefile.rspec
@@ -1,6 +1,9 @@
 require 'rake'
 require 'hanami/rake_tasks'
-require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
-task default: :spec
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task default: :spec
+rescue LoadError
+end

--- a/test/fixtures/commands/application/new_container/Rakefile.rspec
+++ b/test/fixtures/commands/application/new_container/Rakefile.rspec
@@ -1,6 +1,9 @@
 require 'rake'
 require 'hanami/rake_tasks'
-require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
-task default: :spec
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task default: :spec
+rescue LoadError
+end


### PR DESCRIPTION
During the deploy (probably production environment) have not rspec, then,
there is an exception because of `require 'rspec/core/rake_task'`

Fix for: #495 