### PR TITLE
Improve reference for the template of routes.rb

### DIFF
--- a/lib/hanami/generators/app/config/routes.rb.tt
+++ b/lib/hanami/generators/app/config/routes.rb.tt
@@ -2,4 +2,4 @@
 # See: http://hanamirb.org/guides/routing/overview/
 #
 # Example:
-# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }

--- a/lib/hanami/generators/app/config/routes.rb.tt
+++ b/lib/hanami/generators/app/config/routes.rb.tt
@@ -1,2 +1,5 @@
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/
+#
+# Example:
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }

--- a/lib/hanami/generators/application/app/config/routes.rb.tt
+++ b/lib/hanami/generators/application/app/config/routes.rb.tt
@@ -2,4 +2,4 @@
 # See: http://hanamirb.org/guides/routing/overview/
 #
 # Example:
-# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }

--- a/lib/hanami/generators/application/app/config/routes.rb.tt
+++ b/lib/hanami/generators/application/app/config/routes.rb.tt
@@ -1,2 +1,5 @@
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/
+#
+# Example:
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }

--- a/test/fixtures/cdn/cdn_app/config/routes.rb
+++ b/test/fixtures/cdn/cdn_app/config/routes.rb
@@ -1,3 +1,3 @@
 get '/', to: 'home#index'
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/

--- a/test/fixtures/commands/application/new_app/config/routes.rb
+++ b/test/fixtures/commands/application/new_app/config/routes.rb
@@ -2,4 +2,4 @@
 # See: http://hanamirb.org/guides/routing/overview/
 #
 # Example:
-# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }

--- a/test/fixtures/commands/application/new_app/config/routes.rb
+++ b/test/fixtures/commands/application/new_app/config/routes.rb
@@ -1,2 +1,5 @@
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/
+#
+# Example:
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }

--- a/test/fixtures/commands/generate/app/routes.rb
+++ b/test/fixtures/commands/generate/app/routes.rb
@@ -2,4 +2,4 @@
 # See: http://hanamirb.org/guides/routing/overview/
 #
 # Example:
-# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }

--- a/test/fixtures/commands/generate/app/routes.rb
+++ b/test/fixtures/commands/generate/app/routes.rb
@@ -1,2 +1,5 @@
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/
+#
+# Example:
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }

--- a/test/fixtures/rake/rake_tasks/apps/web/config/routes.rb
+++ b/test/fixtures/rake/rake_tasks/apps/web/config/routes.rb
@@ -1,3 +1,3 @@
 get '/users/:id', to: 'users#show'
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/

--- a/test/fixtures/rake/rake_tasks_app/config/routes.rb
+++ b/test/fixtures/rake/rake_tasks_app/config/routes.rb
@@ -1,3 +1,3 @@
 get '/users/:id', to: 'users#show'
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/

--- a/test/fixtures/static_assets/apps/admin/config/routes.rb
+++ b/test/fixtures/static_assets/apps/admin/config/routes.rb
@@ -2,4 +2,4 @@
 # See: http://hanamirb.org/guides/routing/overview/
 #
 # Example:
-# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }

--- a/test/fixtures/static_assets/apps/admin/config/routes.rb
+++ b/test/fixtures/static_assets/apps/admin/config/routes.rb
@@ -1,2 +1,5 @@
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/
+#
+# Example:
+# get '/hello', to: ->(env) { [200, {}, ['Hello from Lotus!']] }

--- a/test/fixtures/static_assets_app/config/routes.rb
+++ b/test/fixtures/static_assets_app/config/routes.rb
@@ -1,4 +1,4 @@
 get '/dashboard', to: 'home#dashboard'
 get '/', to: 'home#index'
 # Configure your routes here
-# See: http://www.rubydoc.info/gems/hanami-router/#Usage
+# See: http://hanamirb.org/guides/routing/overview/


### PR DESCRIPTION
Fixes https://github.com/hanami/hanami/issues/466

Now, when using the generator, the link in the comment will point to
hanami's routing overview which is the context on which the file will be
used, that including an example.