### PR TITLE
Implement full CSP to enhance security

### DIFF
--- a/lib/hanami/config/security.rb
+++ b/lib/hanami/config/security.rb
@@ -50,7 +50,7 @@ module Hanami
         if value.nil?
           @content_security_policy
         else
-          @content_security_policy = value
+          @content_security_policy = value.split(';').map(&:strip).join('; ')
         end
       end
     end

--- a/lib/hanami/generators/app/application.rb.tt
+++ b/lib/hanami/generators/app/application.rb.tt
@@ -200,7 +200,28 @@ module <%= config[:classified_app_name] %>
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy %{
+        form-action 'self';
+        referrer origin-when-cross-origin;
+        reflected-xss block;
+        frame-ancestors 'self';
+        base-uri 'self';
+        default-src 'none';
+        script-src 'self';
+        connect-src 'self';
+        img-src 'self';
+        style-src 'self';
+        font-src 'self';
+        object-src 'self';
+        plugin-types application/pdf;
+        child-src 'self';
+        frame-src 'self';
+        media-src 'self'
+      }
 
       ##
       # FRAMEWORKS

--- a/lib/hanami/generators/application/app/config/application.rb.tt
+++ b/lib/hanami/generators/application/app/config/application.rb.tt
@@ -197,7 +197,28 @@ module <%= config[:classified_app_name] %>
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy %{
+        form-action 'self';
+        referrer origin-when-cross-origin;
+        reflected-xss block;
+        frame-ancestors 'self';
+        base-uri 'self';
+        default-src 'none';
+        script-src 'self';
+        connect-src 'self';
+        img-src 'self';
+        style-src 'self';
+        font-src 'self';
+        object-src 'self';
+        plugin-types application/pdf;
+        child-src 'self';
+        frame-src 'self';
+        media-src 'self'
+      }
 
       ##
       # FRAMEWORKS

--- a/lib/hanami/loader.rb
+++ b/lib/hanami/loader.rb
@@ -58,8 +58,8 @@ module Hanami
           default_request_format config.default_request_format
           default_response_format config.default_response_format
           default_headers({
-            Hanami::Config::Security::X_FRAME_OPTIONS_HEADER         => config.security.x_frame_options,
-            Hanami::Config::Security::CONTENT_SECURITY_POLICY_HEADER => config.security.content_security_policy
+            Hanami::Config::Security::X_FRAME_OPTIONS_HEADER                     => config.security.x_frame_options,
+            Hanami::Config::Security::CONTENT_SECURITY_POLICY_HEADER             => config.security.content_security_policy,
           })
           default_headers.merge!(STRICT_TRANSPORT_SECURITY_HEADER => STRICT_TRANSPORT_SECURITY_DEFAULT_VALUE) if config.force_ssl
 

--- a/test/config/security_test.rb
+++ b/test/config/security_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+describe Hanami::Config::Security do
+  let(:security) { Hanami::Config::Security.new }
+
+  describe '#content_security_policy' do
+    describe 'when the argument is nil' do
+      before do
+        security.content_security_policy('img-src localhost')
+      end
+
+      it 'returns the value' do
+        security.content_security_policy.must_equal('img-src localhost')
+        security.content_security_policy(nil).must_equal('img-src localhost')
+      end
+    end
+
+    describe 'when the argument is not single line string' do
+      it 'assigns new value' do
+        security.content_security_policy('script-src example')
+        security.content_security_policy.must_equal('script-src example')
+      end
+    end
+
+    describe 'when the argument is multiline string' do
+      it 'concatenates all lines into one and assigns new value' do
+        security.content_security_policy(%{
+          script-src example;
+          img-src localhost
+        })
+        security.content_security_policy.must_equal('script-src example; img-src localhost')
+      end
+    end
+  end
+
+  describe '#x_frame_options' do
+    describe 'when the argument is nil' do
+      before do
+        security.x_frame_options('ALLOW ALL')
+      end
+
+      it 'returns the value' do
+        security.x_frame_options.must_equal('ALLOW ALL')
+        security.x_frame_options(nil).must_equal('ALLOW ALL')
+      end
+    end
+
+    describe 'when the argument is not nil' do
+      it 'assigns new value' do
+        security.x_frame_options('DENY')
+        security.x_frame_options.must_equal('DENY')
+      end
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -40,6 +40,25 @@ module CoffeeShop
 
       default_response_format :html
 
+      security.x_frame_options "DENY"
+      security.content_security_policy %{
+        form-action 'self';
+        referrer origin-when-cross-origin;
+        reflected-xss block;
+        frame-ancestors 'self';
+        base-uri 'self';
+        default-src 'none';
+        connect-src 'self';
+        img-src 'self';
+        style-src 'self';
+        font-src 'self';
+        object-src 'self';
+        plugin-types application/pdf;
+        child-src 'self';
+        frame-src 'self';
+        media-src 'self'
+      }
+
       scheme 'https'
       host   'hanami-coffeeshop.org'
 

--- a/test/fixtures/cdn/cdn/apps/web/application.rb
+++ b/test/fixtures/cdn/cdn/apps/web/application.rb
@@ -177,7 +177,11 @@ module Web
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'"
 
       ##
       # FRAMEWORKS

--- a/test/fixtures/cdn/cdn_app/config/application.rb
+++ b/test/fixtures/cdn/cdn_app/config/application.rb
@@ -174,7 +174,11 @@ module CdnApp
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'"
 
       ##
       # FRAMEWORKS

--- a/test/fixtures/commands/application/new_app/config/application.rb
+++ b/test/fixtures/commands/application/new_app/config/application.rb
@@ -197,7 +197,28 @@ module NewApp
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy %{
+        form-action 'self';
+        referrer origin-when-cross-origin;
+        reflected-xss block;
+        frame-ancestors 'self';
+        base-uri 'self';
+        default-src 'none';
+        script-src 'self';
+        connect-src 'self';
+        img-src 'self';
+        style-src 'self';
+        font-src 'self';
+        object-src 'self';
+        plugin-types application/pdf;
+        child-src 'self';
+        frame-src 'self';
+        media-src 'self'
+      }
 
       ##
       # FRAMEWORKS

--- a/test/fixtures/commands/generate/app/application.rb
+++ b/test/fixtures/commands/generate/app/application.rb
@@ -200,7 +200,28 @@ module Admin
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy %{
+        form-action 'self';
+        referrer origin-when-cross-origin;
+        reflected-xss block;
+        frame-ancestors 'self';
+        base-uri 'self';
+        default-src 'none';
+        script-src 'self';
+        connect-src 'self';
+        img-src 'self';
+        style-src 'self';
+        font-src 'self';
+        object-src 'self';
+        plugin-types application/pdf;
+        child-src 'self';
+        frame-src 'self';
+        media-src 'self'
+      }
 
       ##
       # FRAMEWORKS

--- a/test/fixtures/rake/rake_tasks/apps/web/application.rb
+++ b/test/fixtures/rake/rake_tasks/apps/web/application.rb
@@ -200,7 +200,11 @@ module Web
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'"
 
       ##
       # FRAMEWORKS

--- a/test/fixtures/rake/rake_tasks_app/config/application.rb
+++ b/test/fixtures/rake/rake_tasks_app/config/application.rb
@@ -197,7 +197,11 @@ module RakeTasksApp
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'"
 
       ##
       # FRAMEWORKS

--- a/test/fixtures/static_assets/apps/admin/application.rb
+++ b/test/fixtures/static_assets/apps/admin/application.rb
@@ -176,7 +176,11 @@ module Admin
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'"
 
       ##
       # FRAMEWORKS

--- a/test/fixtures/static_assets/apps/web/application.rb
+++ b/test/fixtures/static_assets/apps/web/application.rb
@@ -177,7 +177,11 @@ module Web
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'"
 
       ##
       # FRAMEWORKS

--- a/test/fixtures/static_assets_app/config/application.rb
+++ b/test/fixtures/static_assets_app/config/application.rb
@@ -173,7 +173,11 @@ module StaticAssetsApp
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
+      # Content Security Policy references:
+      #
+      #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives
+      #
+      security.content_security_policy "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'"
 
       ##
       # FRAMEWORKS

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -45,6 +45,14 @@ describe Hanami::Loader do
         CoffeeShop::Controller.configuration.default_response_format.must_equal(:html)
       end
 
+      it 'configures controller to use default headers' do
+        CoffeeShop::Controller.configuration.default_headers.
+          must_equal({
+            "X-Frame-Options" => "DENY",
+            "Content-Security-Policy" => "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'",
+          })
+      end
+
       it 'generates controllers namespace' do
         assert defined?(CoffeeShop::Controllers), 'expected CoffeeShop::Controllers'
       end


### PR DESCRIPTION
[Content Security Policy](http://www.w3.org/TR/CSP) or CSP is a set of standardised HTTP headers that whitelists valid sources that are allowed. This reduces of risks being attacked with XSS. 

We want to offer the top-notch security practices out of the box for the framework. Currently Hanami has implemented 75% of supported directives. This PR is to complete the full support of directives as specified in CSP Level 3 spec.

## Browser support status

* [CSP 1.0](http://caniuse.com/#feat=contentsecuritypolicy)
* [CSP Level 2](http://caniuse.com/#feat=contentsecuritypolicy2)

## TODO:

* [X] object-src
* [X] child-src
* [X] media-src
* [X] base-uri
* [X] plugin-types
* [X] manifest-src
* [X] frame-ancestors
* [x] reflected-xss
* [x] referrer
* [X] form-action