### PR TITLE
Code reloading with entr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,4 @@ gem 'simplecov', '~> 0.11', require: false
 gem 'coveralls',            require: false
 
 gem 'dotenv', '~> 2.0'
+gem 'shotgun', '~> 0.9'

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hanami-helpers',    '~> 0.4'
   spec.add_dependency 'hanami-mailer',     '~> 0.3'
   spec.add_dependency 'hanami-assets',     '~> 0.3'
-  spec.add_dependency 'shotgun',           '~> 0.9'
   spec.add_dependency 'thor',              '~> 0.19'
   spec.add_dependency 'bundler',           '~> 1.6'
 

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -2,6 +2,7 @@ require 'hanami/version'
 require 'hanami/application'
 require 'hanami/container'
 require 'hanami/environment'
+require 'hanami/server'
 
 # A complete web framework for Ruby
 #

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -45,6 +45,27 @@ module Hanami
       end
     end
 
+    desc 'server', 'starts a hanami server without code reloading'
+    method_option :port, aliases: '-p', desc: 'The port to run the server on, '
+    method_option :server, desc: 'choose a specific Rack::Handler, e.g. webrick, thin etc'
+    method_option :rackup, desc: 'a rackup configuration file path to load (config.ru)'
+    method_option :host, desc: 'the host address to bind to'
+    method_option :debug, desc: 'turn on debug output'
+    method_option :warn, desc: 'turn on warnings'
+    method_option :daemonize, desc: 'if true, the server will daemonize itself (fork, detach, etc)'
+    method_option :pid, desc: 'path to write a pid file after daemonize'
+    method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+    method_option :help, desc: 'displays the usage message'
+    def rackserver
+      if options[:help]
+        invoke :help, ['rackserver']
+      else
+        require 'hanami/server'
+        Hanami::Server.new(options).start
+      end
+    end
+
+
     desc 'console', 'starts a hanami console'
     long_desc <<-EOS
     `hanami console` starts the interactive hanami console.

--- a/lib/hanami/commands/server.rb
+++ b/lib/hanami/commands/server.rb
@@ -1,78 +1,144 @@
 require 'rack'
+require 'hanami/server'
 
 module Hanami
   module Commands
-    # Rack compatible server.
-    #
-    # It is run with:
-    #
-    #   `bundle exec hanami server`
-    #
-    # It runs the application, by using the server specified in your `Gemfile`
-    # (eg. Puma or Unicorn).
-    #
-    # It enables code reloading by default.
-    # This feature is implemented via process fork and requires `shotgun` gem.
-    #
-    # @since 0.1.0
-    # @api private
-    class Server < ::Rack::Server
-      attr_reader :options
+    class Server
 
-      # @param options [Hash] Environment's options
+      # Message text when Shotgun enabled but interpreter does not support `fork`
       #
-      # @since 0.1.0
-      # @see Hanami::Environment#initialize
+      # @since 0.8.0
+      # @api private
+      WARNING_MESSAGE = 'Your platform doesn\'t support code reloading.'.freeze
+
+      ENTR_EXECUTE_COMMAND = 'find ./**/*.rb | entr -r bundle exec hanami rackserver %s'.freeze
+
+      attr_reader :server
+
       def initialize(options)
-        @_env    = Hanami::Environment.new(options)
-        @options = _extract_options(@_env)
-
-        if code_reloading?
-          require 'shotgun'
-          @app = Shotgun::Loader.new(@_env.rackup.to_s)
-        end
+        @options = options
+        detect_strategy!
+        prepare_server!
       end
 
-      # Primarily this removes the ::Rack::Chunked middleware
-      # which is the cause of Safari content-length bugs.
-      #
-      # @since 0.1.0
-      def middleware
-        mw = Hash.new { |e, m| e[m] = [] }
-        mw["deployment"].concat([::Rack::ContentLength, ::Rack::CommonLogger])
-        mw["development"].concat(mw["deployment"] + [::Rack::ShowExceptions, ::Rack::Lint])
-        mw
-      end
-
-      # Kickstart shotgun preloader if code reloading is supported
-      #
-      # @since 0.1.0
       def start
-        if code_reloading?
+        case @strategy
+        when :entr
+          exec ENTR_EXECUTE_COMMAND % server_options
+        when :shotgun
           Shotgun.enable_copy_on_write
           Shotgun.preload
+          @server.start
+        when :rackup
+          @server.start
         end
-
-        super
       end
 
       private
 
-      # @since 0.1.0
-      # @api private
-      def _extract_options(env)
-        env.to_options.merge(
-          config:      env.rackup.to_s,
-          Host:        env.host,
-          Port:        env.port,
-          AccessLog:   []
-        )
+      def server_options
+        _options = @options.dup
+        _options.delete(:code_reloading)
+        _options.inject([]) {|res, (k, v)| res << "--#{k}=#{v}" ; res}.join(" ")
       end
 
-      # @since 0.1.0
+
+      def prepare_server!
+        case @strategy
+        when :rackup
+          @server = Hanami::Server.new(@options)
+        when :shotgun
+          @server = Hanami::Server.new(@options)
+          @server.app = Shotgun::Loader.new(@server.rackup_config)
+        end
+      end
+
+      # Determine server strategy
+      #
+      # In order to decide the value, it looks up the following sources:
+      #
+      #   * CLI option `code_reloading`
+      #
+      # If those are missing it falls back to the following defaults:
+      #
+      #   * :shotgun for development and if Shotgun enabled and `fork supported
+      #   * :entr for development and Shotgun disabled but `entr` installed
+      #   * :rackup for all other cases
+      #
+      # @return [:shotgun,:entr, :rackup] the result of the check
+      #
+      # @since 0.8.0
+      #
+      # @see Hanami::Environment::CODE_RELOADING
+      def detect_strategy!
+        @strategy = :rackup
+        if Hanami::Environment.new(@options).code_reloading?
+          if shotgun_enabled?
+            if fork_supported?
+              @strategy = :shotgun
+            else
+              puts WARNING_MESSAGE
+            end
+          elsif entr_enabled?
+            @strategy = :entr
+          end
+        end
+
+        @strategy
+      end
+
+      # Check if entr(1) is installed
+      #
+      # @return [Boolean]
+      #
+      # @since 0.8.0
       # @api private
-      def code_reloading?
-        @_env.code_reloading?
+      def entr_enabled?
+        !!which('entr')
+      end
+
+
+      # Check if Shotgun is enabled
+      #
+      # @return [Boolean]
+      #
+      # @since 0.8.0
+      # @api private
+      def shotgun_enabled?
+        begin
+        require 'shotgun'
+        true
+        rescue LoadError
+          false
+        end
+      end
+
+      # Check if ruby ineterpreter supports `fork`
+      #
+      # @return [Boolean]
+      #
+      # @since 0.8.0
+      # @api private
+      def fork_supported?
+        Kernel.respond_to?(:fork)
+      end
+
+      # Cross-platform way of finding an executable in the $PATH.
+      #
+      # Usage:
+      #   which('ruby') #=> /usr/bin/ruby
+      #
+      # @since 0.8.0
+      # @api private
+      def which(cmd)
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+        ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+          exts.each { |ext|
+            exe = File.join(path, "#{cmd}#{ext}")
+            return exe if File.executable?(exe) && !File.directory?(exe)
+          }
+        end
+        return nil
       end
     end
   end

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -371,7 +371,7 @@ module Hanami
     # If those are missing it falls back to the following defaults:
     #
     #   * true for development
-    #   * false for all the other environments or if Ruby interpreter is JRuby
+    #   * false for all the other environments
     #
     # @return [TrueClass,FalseClass] the result of the check
     #
@@ -380,13 +380,7 @@ module Hanami
     # @see Hanami::Commands::Server
     # @see Hanami::Environment::CODE_RELOADING
     def code_reloading?
-      # JRuby doesn't implement fork that's why shotgun cannot be used.
-      if Utils.jruby?
-        puts "JRuby doesn't support code reloading."
-        false
-      else
-        @options.fetch(:code_reloading) { !!CODE_RELOADING[environment] }
-      end
+      @options.fetch(:code_reloading) { !!CODE_RELOADING[environment] }
     end
 
     # @since 0.4.0

--- a/lib/hanami/generators/application/app/Gemfile.tt
+++ b/lib/hanami/generators/application/app/Gemfile.tt
@@ -30,6 +30,14 @@ gem 'slim'
 gem 'haml'
 <%- end -%>
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/lib/hanami/generators/application/container/Gemfile.tt
+++ b/lib/hanami/generators/application/container/Gemfile.tt
@@ -30,6 +30,14 @@ gem 'slim'
 gem 'haml'
 <%- end -%>
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/lib/hanami/server.rb
+++ b/lib/hanami/server.rb
@@ -1,0 +1,68 @@
+require 'rack'
+
+module Hanami
+  # Rack compatible server.
+  #
+  # It is run with:
+  #
+  #   `bundle exec hanami server`
+  #
+  # It runs the application, by using the server specified in your `Gemfile`
+  # (eg. Puma or Unicorn).
+  #
+  # @since 0.8.0
+  # @api private
+  class Server < ::Rack::Server
+
+    attr_reader :options
+
+    # @param options [Hash] Environment's options
+    #
+    # @since 0.8.0
+    # @see Hanami::Environment#initialize
+    def initialize(options)
+      @_env    = Hanami::Environment.new(options)
+      @options = _extract_options
+    end
+
+
+    # @since 0.8.0
+    # @api private
+    def rackup_config
+      @_env.rackup.to_s
+    end
+
+
+    # Adds Shotgun Loader
+    #
+    # @since 0.8.0
+    # @api private
+    def app=(shotgun_loader)
+      @app = shotgun_loader
+    end
+
+    # Primarily this removes the ::Rack::Chunked middleware
+    # which is the cause of Safari content-length bugs.
+    #
+    # @since 0.8.0
+    def middleware
+      mw = Hash.new { |e, m| e[m] = [] }
+      mw["deployment"].concat([::Rack::ContentLength, ::Rack::CommonLogger])
+      mw["development"].concat(mw["deployment"] + [::Rack::ShowExceptions, ::Rack::Lint])
+      mw
+    end
+
+    private
+
+    # @since 0.8.0
+    # @api private
+    def _extract_options
+      @_env.to_options.merge(
+        config:      @_env.rackup.to_s,
+        Host:        @_env.host,
+        Port:        @_env.port,
+        AccessLog:   []
+      )
+    end
+  end
+end

--- a/test/commands/server_test.rb
+++ b/test/commands/server_test.rb
@@ -11,7 +11,14 @@ describe Hanami::Commands::Server do
     ENV['HANAMI_ENV']  = nil
     ENV['RACK_ENV']   = nil
 
-    @server = Hanami::Commands::Server.new(opts)
+
+    class Hanami::Commands::Server
+      def entr_enabled?
+        false
+      end
+    end
+
+    @server = Hanami::Commands::Server.new(opts).server
   end
 
   describe '#middleware' do
@@ -120,7 +127,7 @@ describe Hanami::Commands::Server do
       before do
         ENV['HANAMI_ENV'] = nil
         ENV['RACK_ENV']  = 'test'
-        @server = Hanami::Commands::Server.new(opts)
+        @server = Hanami::Commands::Server.new(opts).server
       end
 
       after do
@@ -142,7 +149,7 @@ describe Hanami::Commands::Server do
       before do
         ENV['RACK_ENV']  = nil
         ENV['HANAMI_ENV'] = 'staging'
-        @server = Hanami::Commands::Server.new(opts)
+        @server = Hanami::Commands::Server.new(opts).server
       end
 
       after do
@@ -164,7 +171,7 @@ describe Hanami::Commands::Server do
       before do
         ENV['RACK_ENV']  = 'staging'
         ENV['HANAMI_ENV'] = 'test'
-        @server = Hanami::Commands::Server.new(opts)
+        @server = Hanami::Commands::Server.new(opts).server
       end
 
       it 'gives the precendence to HANAMI_ENV' do
@@ -265,11 +272,51 @@ describe Hanami::Commands::Server do
   end
 
   describe 'code reloading', engine: :mri do
-    describe 'when enabled' do
-      let(:opts) { Hash[code_reloading: true] }
+    describe 'when reloading enabled' do
 
-      it 'uses Shotgun to wrap the application' do
-        @server.instance_variable_get(:@app).must_be_kind_of(Shotgun::Loader)
+      describe 'shotgun disabled' do
+        before do
+          @server_klass = Class.new(Hanami::Commands::Server) do
+            def shotgun_enabled?
+              false
+            end
+          end
+
+          @server = @server_klass.new(opts).server
+        end
+
+        let(:opts) { Hash[code_reloading: true] }
+
+        it "doesn't use Shotgun" do
+          @server.instance_variable_get(:@app).must_be_nil
+        end
+      end
+
+      describe 'shotgun enabled' do
+        let(:opts) { Hash[code_reloading: true] }
+
+        it 'uses Shotgun to wrap the application' do
+          @server.instance_variable_get(:@app).must_be_kind_of(Shotgun::Loader)
+        end
+      end
+
+      describe 'fork not support' do
+        before do
+
+          @server_klass = Class.new(Hanami::Commands::Server) do
+            def fork_supported?
+              false
+            end
+          end
+
+          @server = @server_klass.new(opts).server
+        end
+
+        let(:opts) { Hash[code_reloading: true] }
+
+        it "doesn't use Shotgun" do
+          @server.instance_variable_get(:@app).must_be_nil
+        end
       end
     end
 

--- a/test/fixtures/cdn/cdn/Gemfile
+++ b/test/fixtures/cdn/cdn/Gemfile
@@ -13,6 +13,14 @@ gem 'hanami-mailer',      require: false, github: 'hanami/mailer'
 gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             path: '../../../..'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/cdn/cdn_app/Gemfile
+++ b/test/fixtures/cdn/cdn_app/Gemfile
@@ -13,6 +13,14 @@ gem 'hanami-mailer',      require: false, github: 'hanami/mailer'
 gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             path: '../../../..'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_app/Gemfile.minitest
+++ b/test/fixtures/commands/application/new_app/Gemfile.minitest
@@ -6,6 +6,14 @@ gem 'rake'
 gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_app/Gemfile.rspec
+++ b/test/fixtures/commands/application/new_app/Gemfile.rspec
@@ -6,6 +6,14 @@ gem 'rake'
 gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_app/Gemfile.slim
+++ b/test/fixtures/commands/application/new_app/Gemfile.slim
@@ -8,6 +8,14 @@ gem 'hanami-model', '~> 0.7'
 
 gem 'slim'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.filesystem
+++ b/test/fixtures/commands/application/new_container/Gemfile.filesystem
@@ -6,6 +6,14 @@ gem 'rake'
 gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.head
+++ b/test/fixtures/commands/application/new_container/Gemfile.head
@@ -14,6 +14,14 @@ gem 'hanami-mailer',      require: false, github: 'hanami/mailer'
 gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             github: 'hanami/hanami'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.jdbc:mysql2
+++ b/test/fixtures/commands/application/new_container/Gemfile.jdbc:mysql2
@@ -9,6 +9,14 @@ gem 'hanami-model', '~> 0.7'
 
 gem 'jdbc-mysql'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.memory
+++ b/test/fixtures/commands/application/new_container/Gemfile.memory
@@ -6,6 +6,14 @@ gem 'rake'
 gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.minitest
+++ b/test/fixtures/commands/application/new_container/Gemfile.minitest
@@ -6,6 +6,14 @@ gem 'rake'
 gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.mysql2
+++ b/test/fixtures/commands/application/new_container/Gemfile.mysql2
@@ -9,6 +9,14 @@ gem 'hanami-model', '~> 0.7'
 
 gem 'mysql2'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.postgres
+++ b/test/fixtures/commands/application/new_container/Gemfile.postgres
@@ -9,6 +9,14 @@ gem 'hanami-model', '~> 0.7'
 
 gem 'pg'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.rspec
+++ b/test/fixtures/commands/application/new_container/Gemfile.rspec
@@ -7,6 +7,14 @@ gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.slim
+++ b/test/fixtures/commands/application/new_container/Gemfile.slim
@@ -8,6 +8,14 @@ gem 'hanami-model', '~> 0.7'
 
 gem 'slim'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/commands/application/new_container/Gemfile.sqlite3
+++ b/test/fixtures/commands/application/new_container/Gemfile.sqlite3
@@ -9,6 +9,14 @@ gem 'hanami-model', '~> 0.7'
 
 gem 'sqlite3'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/rake/rake_tasks/Gemfile
+++ b/test/fixtures/rake/rake_tasks/Gemfile
@@ -15,6 +15,14 @@ gem 'hanami-mailer',      require: false, github: 'hanami/mailer'
 gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             path: '../../../..'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/rake/rake_tasks_app/Gemfile
+++ b/test/fixtures/rake/rake_tasks_app/Gemfile
@@ -15,6 +15,14 @@ gem 'hanami-mailer',      require: false, github: 'hanami/mailer'
 gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             path: '../../../..'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/static_assets/Gemfile
+++ b/test/fixtures/static_assets/Gemfile
@@ -15,6 +15,14 @@ gem 'hanami-mailer',      '~> 0.1', github: 'hanami/mailer',      branch: '0.1.x
 gem 'hanami-assets',      '~> 0.1', github: 'hanami/assets',      branch: 'master'
 gem 'hanami',                       path:   '../../..'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end

--- a/test/fixtures/static_assets_app/Gemfile
+++ b/test/fixtures/static_assets_app/Gemfile
@@ -15,6 +15,14 @@ gem 'hanami-mailer',      '~> 0.1', github: 'hanami/mailer',      branch: '0.1.x
 gem 'hanami-assets',      '~> 0.1', github: 'hanami/assets',      branch: 'master'
 gem 'hanami',                       path:   '../../..'
 
+group :development do
+  # Shotgun provides code reloading support for `hanami server`.
+  # If you are on a POSIX system, please use `entr`.
+  # If not possible, please use Shotgun.
+  # Read more at: [LINK TO HANAMI GUIDES]
+  # gem 'shotgun'
+end
+
 group :test, :development do
   gem 'dotenv', '~> 2.0'
 end


### PR DESCRIPTION
Functionality fully described [here](https://github.com/hanami/hanami/issues/249#issuecomment-181797020):

1. Remove `shotgun` as hard dependency from `hanami.gemspec`
2. Generate new projects with this gem in `Gemfile` (see below)
3. For the server: detect if `Shotgun` is present and activate code reloading via `Shotgun` (which is the actual implementation)
4. Otherwise try to fallback to `entr`
5. When none of them isn't available, it should not try to activate code reloading.


// cc @jodosha 

**NOTE**: There are no link to Hanami Guides. 
