### PR TITLE
do not show warning message if code reloading is disabled

### DIFF
--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -382,8 +382,8 @@ module Hanami
     def code_reloading?
       if code_reloading = @options.fetch(:code_reloading) { !!CODE_RELOADING[environment] }
         # JRuby doesn't implement fork that's why shotgun cannot be used.
-        if Utils.jruby?
-          puts "JRuby doesn't support code reloading."
+        unless Kernel.respond_to?(:fork)
+          puts "Your platform doesn't support code reloading."
           return false
         end
       end

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -380,13 +380,15 @@ module Hanami
     # @see Hanami::Commands::Server
     # @see Hanami::Environment::CODE_RELOADING
     def code_reloading?
-      # JRuby doesn't implement fork that's why shotgun cannot be used.
-      if Utils.jruby?
-        puts "JRuby doesn't support code reloading."
-        false
-      else
-        @options.fetch(:code_reloading) { !!CODE_RELOADING[environment] }
+      if code_reloading = @options.fetch(:code_reloading) { !!CODE_RELOADING[environment] }
+        # JRuby doesn't implement fork that's why shotgun cannot be used.
+        if Utils.jruby?
+          puts "JRuby doesn't support code reloading."
+          return false
+        end
       end
+
+      code_reloading
     end
 
     # @since 0.4.0


### PR DESCRIPTION
Warning message is always displaying even in tests where code reloading is disabled. I think that is not correct.