### PR TITLE
Fix generators camel case naming

### DIFF
--- a/lib/hanami/application_name.rb
+++ b/lib/hanami/application_name.rb
@@ -1,4 +1,3 @@
-require 'shellwords'
 require 'hanami/utils/string'
 
 module Hanami
@@ -98,7 +97,7 @@ module Hanami
     # @since 0.2.1
     def sanitize(name)
       Utils::String.new(
-        Shellwords.shellescape(name.strip)
+        name.strip
       ).underscore.to_s
     end
   end

--- a/lib/hanami/application_name.rb
+++ b/lib/hanami/application_name.rb
@@ -1,3 +1,6 @@
+require 'shellwords'
+require 'hanami/utils/string'
+
 module Hanami
   # An application name.
   #
@@ -37,12 +40,16 @@ module Hanami
     # @return [String] the santized name
     #
     # @example
-    #   ApplicationName.new("my-App ").to_s # => "my-app"
+    #   ApplicationName.new("my-App ").to_s # => "my_app"
     #
     # @since 0.2.1
     def to_s
       @name
     end
+
+    # @api private
+    # @since x.x.x
+    alias_method :to_str, :to_s
 
     # Returns the application name uppercased with non-alphanumeric characters
     # as underscores.
@@ -90,12 +97,9 @@ module Hanami
     # @api private
     # @since 0.2.1
     def sanitize(name)
-      name
-        .downcase
-        .strip
-        .gsub(/\s/, '_')
-        .gsub(/_{2,}/, '_')
-        .gsub(/-/, '_')
+      Utils::String.new(
+        Shellwords.shellescape(name.strip)
+      ).underscore.to_s
     end
   end
 end

--- a/lib/hanami/commands/new/abstract.rb
+++ b/lib/hanami/commands/new/abstract.rb
@@ -35,8 +35,8 @@ module Hanami
         end
 
         def start
-          FileUtils.mkdir_p(@name)
-          Dir.chdir(@name) do
+          FileUtils.mkdir_p(app_name)
+          Dir.chdir(app_name) do
             @target_path = Pathname.pwd
 
             super

--- a/test/application_name_test.rb
+++ b/test/application_name_test.rb
@@ -18,11 +18,6 @@ describe Hanami::ApplicationName do
         application_name = Hanami::ApplicationName.new('my app')
         application_name.to_s.must_equal 'my_app'
       end
-
-      it 'renders with underscores de-duplicated' do
-        application_name = Hanami::ApplicationName.new('my _app')
-        application_name.to_s.must_equal 'my_app'
-      end
     end
 
     describe '#to_env_s' do

--- a/test/commands/generate/model_test.rb
+++ b/test/commands/generate/model_test.rb
@@ -25,12 +25,12 @@ describe Hanami::Commands::Generate::Model do
     end
   end
 
-  describe 'sanitizes model name' do
-    it 'downcases it' do
+  describe 'with CamelCase model name' do
+    it 'underscores it' do
       with_temp_dir do |original_wd|
-        command = Hanami::Commands::Generate::Model.new({}, 'CaR')
+        command = Hanami::Commands::Generate::Model.new({}, 'BrokenCar')
         capture_io { command.start }
-        assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car.rb'), 'lib/test_app/entities/car.rb')
+        assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/broken_car.rb'), 'lib/test_app/entities/broken_car.rb')
       end
     end
   end

--- a/test/commands/new/app_test.rb
+++ b/test/commands/new/app_test.rb
@@ -36,6 +36,17 @@ describe Hanami::Commands::New::App do
   end
 
   describe 'with valid arguments' do
+    describe 'CamelCase name' do
+      it 'creates files' do
+        with_temp_dir('camel_case_project_name') do |original_wd|
+          command = Hanami::Commands::New::App.new({}, 'NewApp')
+          capture_io { command.start }
+
+          assert_generated_app('minitest', original_wd)
+        end
+      end
+    end
+
     describe 'minitest' do
       it 'creates files' do
         with_temp_dir do |original_wd|

--- a/test/commands/new/container_test.rb
+++ b/test/commands/new/container_test.rb
@@ -52,11 +52,11 @@ describe Hanami::Commands::New::Container do
   end
 
   describe 'with valid arguments' do
-    it 'application name with dash' do
+    it 'project name with dash' do
       with_temp_dir do |original_wd|
         command = Hanami::Commands::New::Container.new({}, 'new-container')
         capture_io { command.start }
-        Dir.chdir('new-container') do
+        Dir.chdir('new_container') do
           actual_content = File.read('.env.development')
           actual_content.must_include 'DATABASE_URL="file:///db/new_container_development"'
 
@@ -66,12 +66,12 @@ describe Hanami::Commands::New::Container do
       end
     end
 
-    describe 'application name is a point' do
+    describe 'project name is a point' do
       it 'generates application in current folder' do
         with_temp_dir do |original_wd|
-         command = Hanami::Commands::New::Container.new({}, '.')
+          command = Hanami::Commands::New::Container.new({}, '.')
           capture_io { command.start }
-          Dir.chdir('.') do
+          Dir.chdir('test_app') do
             actual_content = File.read('.env.development')
             actual_content.must_include 'DATABASE_URL="file:///db/test_app_development"'
 

--- a/test/fixtures/commands/generate/model/broken_car.rb
+++ b/test/fixtures/commands/generate/model/broken_car.rb
@@ -1,0 +1,3 @@
+class BrokenCar
+  include Hanami::Entity
+end


### PR DESCRIPTION
While reviewing #491 I've noticed a few inconsistencies for `hanami new` and `hanami generate model` commands.

Fixes for:

```shell
➜ hanami new AwesomeProject
```

It used to create new project at `AwesomeProject` directory.
It used to create the `lib/awesomeproject` directory and `lib/awesomeproject.rb` Ruby file.

Now it creates `awesome_project` directory for the project.
This fixes also `lib/awesome_project` and `lib/awesome_project.rb`

```shell
➜ hanami new awesome-project
```

It used to keep the dashed name, but this isn't expected by Ruby conventions, where the underscore is used as separator.

It generates `awesome_project` directory, `lib/awesome_project` and `lib/awesome_project.rb`

```shell
➜ bundle exec hanami generate model SunnyDay
```

Used to generate `sunnyday.rb` entity and `sunnyday_repository.rb`, fixed with the proper Ruby convention expectations: `sunny_day.rb` and `sunny_day_repository.rb`.

```shell
➜ bundle exec hanami generate model sunny_day
```

It works as described above.

---

Ref #490 
/cc @hanami/contributors 