### PR TITLE
Clean up CLI descriptions

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -7,7 +7,7 @@ module Hanami
   class Cli < Thor
     # include Thor::Actions
 
-    desc 'version', 'Prints Hanami version'
+    desc 'version', 'Prints hanami version'
     long_desc <<-EOS
     `hanami version` prints the version of the bundled hanami gem.
     EOS
@@ -79,7 +79,7 @@ module Hanami
     method_option :application_base_url, desc: 'Application base url', default: Hanami::Commands::New::Abstract::DEFAULT_APPLICATION_BASE_URL
     method_option :template, desc: "Template engine (#{Hanami::Generators::TemplateEngine::SUPPORTED_ENGINES.join('/')})", default: Hanami::Generators::TemplateEngine::DEFAULT_ENGINE
     method_option :test, desc: "Project test framework (#{Hanami::Generators::TestFramework::VALID_FRAMEWORKS.join('/')})", default: Hanami::Hanamirc::DEFAULT_TEST_SUITE
-    method_option :hanami_head, desc: 'Use Hanami HEAD (true/false)', type: :boolean, default: false
+    method_option :hanami_head, desc: 'Use hanami HEAD (true/false)', type: :boolean, default: false
     method_option :help, desc: 'Displays the usage method'
     def new(application_name)
       if options[:help]

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -25,8 +25,8 @@ module Hanami
 
     $ > hanami server -p 4500
     EOS
-    method_option :port, aliases: '-p', desc: 'The port to run the server on, '
-    method_option :server, desc: 'Choose a specific Rack::Handler, e.g. webrick, thin etc'
+    method_option :port, aliases: '-p', desc: 'The port to run the server on'
+    method_option :server, desc: 'Choose a specific Rack::Handler (webrick, thin, etc)'
     method_option :rackup, desc: 'A rackup configuration file path to load (config.ru)'
     method_option :host, desc: 'The host address to bind to'
     method_option :debug, desc: 'Turn on debug output'

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -7,7 +7,7 @@ module Hanami
   class Cli < Thor
     # include Thor::Actions
 
-    desc 'version', 'prints Hanami version'
+    desc 'version', 'Prints Hanami version'
     long_desc <<-EOS
     `hanami version` prints the version of the bundled hanami gem.
     EOS
@@ -17,7 +17,7 @@ module Hanami
     end
     map %w{--version -v} => :version
 
-    desc 'server', 'starts a hanami server'
+    desc 'server', 'Starts a hanami server'
     long_desc <<-EOS
     `hanami server` starts a server for the current hanami project.
 
@@ -26,16 +26,16 @@ module Hanami
     $ > hanami server -p 4500
     EOS
     method_option :port, aliases: '-p', desc: 'The port to run the server on, '
-    method_option :server, desc: 'choose a specific Rack::Handler, e.g. webrick, thin etc'
-    method_option :rackup, desc: 'a rackup configuration file path to load (config.ru)'
-    method_option :host, desc: 'the host address to bind to'
-    method_option :debug, desc: 'turn on debug output'
-    method_option :warn, desc: 'turn on warnings'
-    method_option :daemonize, desc: 'if true, the server will daemonize itself (fork, detach, etc)'
-    method_option :pid, desc: 'path to write a pid file after daemonize'
-    method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
-    method_option :code_reloading, desc: 'code reloading', type: :boolean, default: true
-    method_option :help, desc: 'displays the usage message'
+    method_option :server, desc: 'Choose a specific Rack::Handler, e.g. webrick, thin etc'
+    method_option :rackup, desc: 'A rackup configuration file path to load (config.ru)'
+    method_option :host, desc: 'The host address to bind to'
+    method_option :debug, desc: 'Turn on debug output'
+    method_option :warn, desc: 'Turn on warnings'
+    method_option :daemonize, desc: 'If true, the server will daemonize itself (fork, detach, etc)'
+    method_option :pid, desc: 'Path to write a pid file after daemonize'
+    method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
+    method_option :code_reloading, desc: 'Code reloading', type: :boolean, default: true
+    method_option :help, desc: 'Displays the usage message'
     def server
       if options[:help]
         invoke :help, ['server']
@@ -45,15 +45,15 @@ module Hanami
       end
     end
 
-    desc 'console', 'starts a hanami console'
+    desc 'console', 'Starts a hanami console'
     long_desc <<-EOS
     `hanami console` starts the interactive hanami console.
 
     $ > hanami console --engine=pry
     EOS
-    method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
-    method_option :engine, desc: "choose a specific console engine: (#{Hanami::Commands::Console::ENGINES.keys.join('/')})"
-    method_option :help, desc: 'displays the usage method'
+    method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
+    method_option :engine, desc: "Choose a specific console engine: (#{Hanami::Commands::Console::ENGINES.keys.join('/')})"
+    method_option :help, desc: 'Displays the usage method'
     def console
       if options[:help]
         invoke :help, ['console']
@@ -62,7 +62,7 @@ module Hanami
       end
     end
 
-    desc 'new APPLICATION_NAME', 'generate a new hanami project'
+    desc 'new APPLICATION_NAME', 'Generate a new hanami project'
     long_desc <<-EOS
       `hanami new` creates a new hanami project.
       You can specify various options such as the database to be used as well as the path and architecture.
@@ -73,14 +73,14 @@ module Hanami
 
       $ > hanami new fancy_app --hanami-head=true
     EOS
-    method_option :database, aliases: ['-d', '--db'], desc: "application database (#{Hanami::Generators::DatabaseConfig::SUPPORTED_ENGINES.keys.join('/')})", default: Hanami::Generators::DatabaseConfig::DEFAULT_ENGINE
-    method_option :architecture, aliases: ['-a', '--arch'], desc: 'project architecture (container/app)', default: Hanami::Commands::New::Abstract::DEFAULT_ARCHITECTURE
-    method_option :application_name, desc: 'application name, only for container', default: Hanami::Commands::New::Container::DEFAULT_APPLICATION_NAME
-    method_option :application_base_url, desc: 'application base url', default: Hanami::Commands::New::Abstract::DEFAULT_APPLICATION_BASE_URL
-    method_option :template, desc: "template engine (#{Hanami::Generators::TemplateEngine::SUPPORTED_ENGINES.join('/')})", default: Hanami::Generators::TemplateEngine::DEFAULT_ENGINE
-    method_option :test, desc: "project test framework (#{Hanami::Generators::TestFramework::VALID_FRAMEWORKS.join('/')})", default: Hanami::Hanamirc::DEFAULT_TEST_SUITE
-    method_option :hanami_head, desc: 'use Hanami HEAD (true/false)', type: :boolean, default: false
-    method_option :help, desc: 'displays the usage method'
+    method_option :database, aliases: ['-d', '--db'], desc: "Application database (#{Hanami::Generators::DatabaseConfig::SUPPORTED_ENGINES.keys.join('/')})", default: Hanami::Generators::DatabaseConfig::DEFAULT_ENGINE
+    method_option :architecture, aliases: ['-a', '--arch'], desc: 'Project architecture (container/app)', default: Hanami::Commands::New::Abstract::DEFAULT_ARCHITECTURE
+    method_option :application_name, desc: 'Application name, only for container', default: Hanami::Commands::New::Container::DEFAULT_APPLICATION_NAME
+    method_option :application_base_url, desc: 'Application base url', default: Hanami::Commands::New::Abstract::DEFAULT_APPLICATION_BASE_URL
+    method_option :template, desc: "Template engine (#{Hanami::Generators::TemplateEngine::SUPPORTED_ENGINES.join('/')})", default: Hanami::Generators::TemplateEngine::DEFAULT_ENGINE
+    method_option :test, desc: "Project test framework (#{Hanami::Generators::TestFramework::VALID_FRAMEWORKS.join('/')})", default: Hanami::Hanamirc::DEFAULT_TEST_SUITE
+    method_option :hanami_head, desc: 'Use Hanami HEAD (true/false)', type: :boolean, default: false
+    method_option :help, desc: 'Displays the usage method'
     def new(application_name)
       if options[:help]
         invoke :help, ['new']
@@ -91,12 +91,12 @@ module Hanami
       end
     end
 
-    desc 'routes', 'prints the routes'
+    desc 'routes', 'Prints the routes'
     long_desc <<-EOS
       `hanami routes` outputs all the registered routes to the console.
     EOS
-    method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
-    method_option :help, desc: 'displays the usage method'
+    method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
+    method_option :help, desc: 'Displays the usage method'
     def routes
       if options[:help]
         invoke :help, ['routes']
@@ -107,15 +107,15 @@ module Hanami
     end
 
     require 'hanami/cli_sub_commands/db'
-    register Hanami::CliSubCommands::DB, 'db', 'db [SUBCOMMAND]', 'manage set of DB operations'
+    register Hanami::CliSubCommands::DB, 'db', 'db [SUBCOMMAND]', 'Manage set of DB operations'
 
     require 'hanami/cli_sub_commands/generate'
-    register Hanami::CliSubCommands::Generate, 'generate', 'generate [SUBCOMMAND]', 'generate hanami classes'
+    register Hanami::CliSubCommands::Generate, 'generate', 'generate [SUBCOMMAND]', 'Generate hanami classes'
 
     require 'hanami/cli_sub_commands/destroy'
-    register Hanami::CliSubCommands::Destroy, 'destroy', 'destroy [SUBCOMMAND]', 'destroy hanami classes'
+    register Hanami::CliSubCommands::Destroy, 'destroy', 'destroy [SUBCOMMAND]', 'Destroy hanami classes'
 
     require 'hanami/cli_sub_commands/assets'
-    register Hanami::CliSubCommands::Assets, 'assets', 'assets [SUBCOMMAND]', 'manage assets'
+    register Hanami::CliSubCommands::Assets, 'assets', 'assets [SUBCOMMAND]', 'Manage assets'
   end
 end

--- a/lib/hanami/cli_sub_commands/assets.rb
+++ b/lib/hanami/cli_sub_commands/assets.rb
@@ -11,7 +11,7 @@ module Hanami
     class Assets < Thor
       namespace :assets
 
-      desc 'precompile', 'precompile assets for deployment'
+      desc 'precompile', 'Precompile assets for deployment'
       def precompile
         require 'hanami/commands/assets/precompile'
         Hanami::Commands::Assets::Precompile.new(options, environment).start

--- a/lib/hanami/cli_sub_commands/db.rb
+++ b/lib/hanami/cli_sub_commands/db.rb
@@ -11,8 +11,8 @@ module Hanami
     class DB < Thor
       namespace :db
 
-      desc 'console', 'start DB console'
-      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+      desc 'console', 'Start DB console'
+      method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
       def console(name = nil)
         if options[:help]
           invoke :help, ['console']
@@ -22,8 +22,8 @@ module Hanami
         end
       end
 
-      desc 'create', 'create database for current environment'
-      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+      desc 'create', 'Create database for current environment'
+      method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
       def create
         if options[:help]
           invoke :help, ['create']
@@ -34,8 +34,8 @@ module Hanami
         end
       end
 
-      desc 'drop', 'drop database for current environment'
-      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+      desc 'drop', 'Drop database for current environment'
+      method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
       def drop
         if options[:help]
           invoke :help, ['drop']
@@ -46,8 +46,8 @@ module Hanami
         end
       end
 
-      desc 'migrate', 'migrate database for current environment'
-      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+      desc 'migrate', 'Migrate database for current environment'
+      method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
       def migrate(version = nil)
         if options[:help]
           invoke :help, ['migrate']
@@ -57,8 +57,8 @@ module Hanami
         end
       end
 
-      desc 'apply', 'migrate, dump schema, delete migrations (experimental)'
-      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+      desc 'apply', 'Migrate, dump schema, delete migrations (experimental)'
+      method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
       def apply
         if options[:help]
           invoke :help, ['apply']
@@ -69,8 +69,8 @@ module Hanami
         end
       end
 
-      desc 'prepare', 'create and migrate database'
-      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+      desc 'prepare', 'Create and migrate database'
+      method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
       def prepare
         if options[:help]
           invoke :help, ['prepare']
@@ -83,8 +83,8 @@ module Hanami
 
       # @since 0.6.0
       # @api private
-      desc 'version', 'current database version'
-      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+      desc 'version', 'Current database version'
+      method_option :environment, desc: 'Path to environment configuration (config/environment.rb)'
       def version
         if options[:help]
           invoke :help, ['version']

--- a/lib/hanami/cli_sub_commands/destroy.rb
+++ b/lib/hanami/cli_sub_commands/destroy.rb
@@ -7,7 +7,7 @@ module Hanami
       include Thor::Actions
       namespace :destroy
 
-      desc 'action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME', 'destroy a hanami action'
+      desc 'action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME', 'Destroy a hanami action'
       long_desc <<-EOS
         `hanami destroy action` will destroy an an action, view and template along with specs and a route.
 
@@ -32,7 +32,7 @@ module Hanami
         end
       end
 
-      desc 'migration NAME', 'destroy a migration'
+      desc 'migration NAME', 'Destroy a migration'
       long_desc <<-EOS
       `hanami destroy migration` will destroy a migration file.
 
@@ -48,7 +48,7 @@ module Hanami
         end
       end
 
-      desc 'model NAME', 'destroy an entity'
+      desc 'model NAME', 'Destroy an entity'
       long_desc <<-EOS
         `hanami destroy model` will destroy an entity along with repository
         and corresponding tests
@@ -65,7 +65,7 @@ module Hanami
         end
       end
 
-      desc 'application NAME', 'destroy an application'
+      desc 'application NAME', 'Destroy an application'
       long_desc <<-EOS
       `hanami destroy application` will destroy an application, along with templates and specs.
 
@@ -80,7 +80,7 @@ module Hanami
         end
       end
 
-      desc 'mailer NAME', 'destroy a mailer'
+      desc 'mailer NAME', 'Destroy a mailer'
       long_desc <<-EOS
       `hanami destroy mailer` will destroy a mailer, along with templates and specs.
 

--- a/lib/hanami/cli_sub_commands/generate.rb
+++ b/lib/hanami/cli_sub_commands/generate.rb
@@ -19,7 +19,7 @@ module Hanami
 
       # @since 0.6.0
       # @api private
-      desc 'action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME', 'generate a hanami action'
+      desc 'action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME', 'Generate a hanami action'
       long_desc <<-EOS
         `hanami generate action` generates an an action, view and template along with specs and a route.
 
@@ -50,7 +50,7 @@ module Hanami
         end
       end
 
-      desc 'migration NAME', 'generate a migration'
+      desc 'migration NAME', 'Generate a migration'
       long_desc <<-EOS
       `hanami generate migration` will generate an empty migration file.
 
@@ -65,7 +65,7 @@ module Hanami
         end
       end
 
-      desc 'model NAME', 'generate an entity'
+      desc 'model NAME', 'Generate an entity'
       long_desc <<-EOS
         `hanami generate model` will generate an entity along with repository
         and corresponding tests. The name of the model can contain slashes to
@@ -85,16 +85,16 @@ module Hanami
         end
       end
 
-      desc 'mailer NAME', 'generate a mailer'
+      desc 'mailer NAME', 'Generate a mailer'
       long_desc <<-EOS
       `hanami generate mailer` will generate an empty mailer, along with templates and specs.
 
       > $ hanami generate mailer forgot_password
       > $ hanami generate mailer forgot_password --to "'log@bookshelf.com'" --from "'support@bookshelf.com'" --subject "'New Password'"
       EOS
-      method_option :to, desc: 'sender email', default: Hanami::Commands::Generate::Mailer::DEFAULT_TO
-      method_option :from, desc: 'sendee email', default: Hanami::Commands::Generate::Mailer::DEFAULT_FROM
-      method_option :subject, desc: 'email subject', default: Hanami::Commands::Generate::Mailer::DEFAULT_SUBJECT
+      method_option :to, desc: 'Sender email', default: Hanami::Commands::Generate::Mailer::DEFAULT_TO
+      method_option :from, desc: 'Sendee email', default: Hanami::Commands::Generate::Mailer::DEFAULT_FROM
+      method_option :subject, desc: 'Email subject', default: Hanami::Commands::Generate::Mailer::DEFAULT_SUBJECT
       def mailer(name)
         if options[:help]
           invoke :help, ['mailer']
@@ -103,7 +103,7 @@ module Hanami
         end
       end
 
-      desc 'app APPLICATION_NAME', 'generate an app'
+      desc 'app APPLICATION_NAME', 'Generate an app'
       long_desc <<-EOS
         `hanami generate app` creates a new app inside the 'apps' directory.
 


### PR DESCRIPTION
This PR include several minor changes to the CLI descriptions:

1. start descriptions with capitals (this is Thor's default and it's kind of jarring to see a mix)

2. always refer to hanami as "hanami", not as a mix of that and "Hanami"

3. clean up trailing text in descriptions and unify styles on "(this, that, etc)"