### PR TITLE
fix whitespace in generated Gemfiles

### DIFF
--- a/lib/hanami/generators/application/app/Gemfile.tt
+++ b/lib/hanami/generators/application/app/Gemfile.tt
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gem 'bundler'
 gem 'rake'
-
 <%- if config[:hanami_head] -%>
+
 gem 'hanami-utils',       require: false, github: 'hanami/utils'
 gem 'hanami-router',      require: false, github: 'hanami/router'
 gem 'hanami-validations', require: false, github: 'hanami/validations'
@@ -18,15 +18,16 @@ gem 'hanami',                             github: 'hanami/hanami'
 gem 'hanami',       '<%= config[:hanami_version] %>'
 gem 'hanami-model', '<%= config[:hanami_model_version] %>'
 <%- end -%>
-
 <%- if config[:database_config][:gem] -%>
+
 gem '<%= config[:database_config][:gem] %>'
 <%- end -%>
-
 <%- case config[:template] -%>
 <%- when 'slim' -%>
+
 gem 'slim'
 <%- when 'haml' -%>
+
 gem 'haml'
 <%- end -%>
 

--- a/lib/hanami/generators/application/container/Gemfile.tt
+++ b/lib/hanami/generators/application/container/Gemfile.tt
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gem 'bundler'
 gem 'rake'
-
 <%- if config[:hanami_head] -%>
+
 gem 'hanami-utils',       require: false, github: 'hanami/utils'
 gem 'hanami-router',      require: false, github: 'hanami/router'
 gem 'hanami-validations', require: false, github: 'hanami/validations'
@@ -18,15 +18,16 @@ gem 'hanami',                             github: 'hanami/hanami'
 gem 'hanami',       '<%= config[:hanami_version] %>'
 gem 'hanami-model', '<%= config[:hanami_model_version] %>'
 <%- end -%>
+<%- if config[:database_config][:gem] -%>
 
-<%- if config[:database_config][:gem] %>
 gem '<%= config[:database_config][:gem] %>'
 <%- end -%>
-
 <%- case config[:template] -%>
 <%- when 'slim' -%>
+
 gem 'slim'
 <%- when 'haml' -%>
+
 gem 'haml'
 <%- end -%>
 


### PR DESCRIPTION
The generated Gemfiles was leaving extra new lines when conditions don't apply. One of the tags was also missing a closing `-%>`. The generated Gemfiles should now properly add whitespace only when the conditions apply