### PR TITLE
Prepend routes after leading comments

### DIFF
--- a/lib/hanami/commands/generate/action.rb
+++ b/lib/hanami/commands/generate/action.rb
@@ -105,7 +105,7 @@ module Hanami
           routes_path.dirname.mkpath
           FileUtils.touch(routes_path)
 
-          generator.prepend_to_file(routes_path, "#{ http_method } '#{ route_url }', to: '#{ route_endpoint }'\n")
+          generator.prepend_after_leading_comments(routes_path, "#{ http_method } '#{ route_url }', to: '#{ route_endpoint }'\n")
         end
 
         def skip_view?

--- a/lib/hanami/generators/generator.rb
+++ b/lib/hanami/generators/generator.rb
@@ -30,6 +30,15 @@ module Hanami
           @processor.template(@template_source_path.join(src), @target_path.join(dst), options)
         end
       end
+
+      # Modelled after Thor's `inject_into_class`
+      def prepend_after_leading_comments(path, *args, &block)
+        config = args.last.is_a?(Hash) ? args.pop : {}
+        # Either prepend after the last comment line,
+        # or the first line in the file, if there are no comments
+        config.merge!(after: /\A(?:^#.*$\s)*/)
+        @processor.insert_into_file(path, *(args << config), &block)
+      end
     end
   end
 end


### PR DESCRIPTION
Going through the getting started guide, once you run `hanami generate action web books#index`, your routes file looks like this:

```
get '/books', to: 'books#index'
# Configure your routes here
# See: http://www.rubydoc.info/gems/hanami-router/#Usage
get '/', to: 'home#index'
```

When what you'd expect is it to look like:

```
# Configure your routes here
# See: http://www.rubydoc.info/gems/hanami-router/#Usage
get '/books', to: 'books#index'
get '/', to: 'home#index'
```

- The other option is to put the route at the bottom of the file, but then it might not match, which is confusing)
- In the regex, I opted for `\s` instead of `\n` because I'm not sure if `\n` matches newlines on Windows. I tried using 'multiline' mode, but that was more trouble than it was worth.
- We could just override Thor's `prepend_to_file` to have this behavior for all strings that are not comments. 