### PR TITLE
Welcome page: Remove trailing period, to make copy-and-pasting easier

### DIFF
--- a/lib/hanami/templates/welcome.html.erb
+++ b/lib/hanami/templates/welcome.html.erb
@@ -32,7 +32,7 @@
 
       <h3>Hanami is Open Source Software for MVC web development with Ruby.</h3>
 
-      <p>Please generate a new action with:<br><code>bundle exec hanami generate action<%= application_name %> home#index --url=/</code>.</p>
+      <p>Please generate a new action with:<br><code>bundle exec hanami generate action<%= application_name %> home#index --url=/</code></p>
 
       <hr style="margin-top: 4em;"/>
       <div id="content">


### PR DESCRIPTION
When I double click the `<code>` block to highlight the whole thing, it also includes this trailing period. It doesn't really add anything, and is a little annoying in this situation, so I think we can get rid of it.