### PR TITLE
Remove default HTTP method from thor's method_option

### DIFF
--- a/lib/hanami/cli_sub_commands/generate.rb
+++ b/lib/hanami/cli_sub_commands/generate.rb
@@ -31,7 +31,7 @@ module Hanami
 
         > $ hanami generate action web cars#create --method=post
       EOS
-      method_option :method, desc: "The HTTP method to be used for the generated route. Must be one of (#{Hanami::Routing::Route::VALID_HTTP_VERBS.join('/')})", default: Hanami::Commands::Generate::Action::DEFAULT_HTTP_METHOD
+      method_option :method, desc: "The HTTP method to be used for the generated route. Default is #{Hanami::Commands::Generate::Action::DEFAULT_HTTP_METHOD}. Must be one of (#{Hanami::Routing::Route::VALID_HTTP_VERBS.join('/')})"
       method_option :url, desc: 'Relative URL for action, will be used for the route', default: nil
       method_option :test, desc: 'Defines the testing Framework to be used. Default is defined through your .hanamirc file.'
       method_option :skip_view, desc: 'Skip the generation of the view. Also skips template generation.', default: false, type: :boolean

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -78,7 +78,7 @@ describe Hanami::Cli do
 
   describe 'generate' do
     describe 'action' do
-      let(:default_options) { {'method' => 'GET', 'skip_view' => false} }
+      let(:default_options) { {'skip_view' => false} }
 
       it 'calls the generator with application and controller/action name' do
         ARGV.replace(%w{generate action app controller#action})


### PR DESCRIPTION
Closes #539 

The 'default' isn't always 'GET' anymore, since it changes for resourceful routes.