### PR TITLE
Prefer Shotgun as default code reloading mechanism

### DIFF
--- a/lib/hanami/commands/server.rb
+++ b/lib/hanami/commands/server.rb
@@ -44,7 +44,7 @@ module Hanami
 
       def project_paths
         applications = Hanami::Environment.new.container? ? 'apps' : 'app'
-        "#{ applications } config db lib vendor"
+        "#{ applications } config db lib"
       end
 
       def prepare_server!

--- a/lib/hanami/generators/application/app/Gemfile.tt
+++ b/lib/hanami/generators/application/app/Gemfile.tt
@@ -32,11 +32,9 @@ gem 'haml'
 <%- end -%>
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/lib/hanami/generators/application/container/Gemfile.tt
+++ b/lib/hanami/generators/application/container/Gemfile.tt
@@ -32,11 +32,9 @@ gem 'haml'
 <%- end -%>
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/cdn/cdn/Gemfile
+++ b/test/fixtures/cdn/cdn/Gemfile
@@ -14,11 +14,9 @@ gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             path: '../../../..'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/cdn/cdn_app/Gemfile
+++ b/test/fixtures/cdn/cdn_app/Gemfile
@@ -14,11 +14,9 @@ gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             path: '../../../..'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_app/Gemfile.minitest
+++ b/test/fixtures/commands/application/new_app/Gemfile.minitest
@@ -7,11 +7,9 @@ gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_app/Gemfile.rspec
+++ b/test/fixtures/commands/application/new_app/Gemfile.rspec
@@ -7,11 +7,9 @@ gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_app/Gemfile.slim
+++ b/test/fixtures/commands/application/new_app/Gemfile.slim
@@ -9,11 +9,9 @@ gem 'hanami-model', '~> 0.7'
 gem 'slim'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.filesystem
+++ b/test/fixtures/commands/application/new_container/Gemfile.filesystem
@@ -7,11 +7,9 @@ gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.head
+++ b/test/fixtures/commands/application/new_container/Gemfile.head
@@ -15,11 +15,9 @@ gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             github: 'hanami/hanami'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.jdbc:mysql2
+++ b/test/fixtures/commands/application/new_container/Gemfile.jdbc:mysql2
@@ -10,11 +10,9 @@ gem 'hanami-model', '~> 0.7'
 gem 'jdbc-mysql'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.memory
+++ b/test/fixtures/commands/application/new_container/Gemfile.memory
@@ -7,11 +7,9 @@ gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.minitest
+++ b/test/fixtures/commands/application/new_container/Gemfile.minitest
@@ -7,11 +7,9 @@ gem 'hanami',       '~> 0.8'
 gem 'hanami-model', '~> 0.7'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.mysql2
+++ b/test/fixtures/commands/application/new_container/Gemfile.mysql2
@@ -10,11 +10,9 @@ gem 'hanami-model', '~> 0.7'
 gem 'mysql2'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.postgres
+++ b/test/fixtures/commands/application/new_container/Gemfile.postgres
@@ -10,11 +10,9 @@ gem 'hanami-model', '~> 0.7'
 gem 'pg'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.rspec
+++ b/test/fixtures/commands/application/new_container/Gemfile.rspec
@@ -8,11 +8,9 @@ gem 'hanami-model', '~> 0.7'
 
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.slim
+++ b/test/fixtures/commands/application/new_container/Gemfile.slim
@@ -9,11 +9,9 @@ gem 'hanami-model', '~> 0.7'
 gem 'slim'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/commands/application/new_container/Gemfile.sqlite3
+++ b/test/fixtures/commands/application/new_container/Gemfile.sqlite3
@@ -10,11 +10,9 @@ gem 'hanami-model', '~> 0.7'
 gem 'sqlite3'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/rake/rake_tasks/Gemfile
+++ b/test/fixtures/rake/rake_tasks/Gemfile
@@ -16,11 +16,9 @@ gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             path: '../../../..'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/rake/rake_tasks_app/Gemfile
+++ b/test/fixtures/rake/rake_tasks_app/Gemfile
@@ -16,11 +16,9 @@ gem 'hanami-assets',      require: false, github: 'hanami/assets'
 gem 'hanami',                             path: '../../../..'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/static_assets/Gemfile
+++ b/test/fixtures/static_assets/Gemfile
@@ -16,11 +16,9 @@ gem 'hanami-assets',      '~> 0.1', github: 'hanami/assets',      branch: 'maste
 gem 'hanami',                       path:   '../../..'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do

--- a/test/fixtures/static_assets_app/Gemfile
+++ b/test/fixtures/static_assets_app/Gemfile
@@ -16,11 +16,9 @@ gem 'hanami-assets',      '~> 0.1', github: 'hanami/assets',      branch: 'maste
 gem 'hanami',                       path:   '../../..'
 
 group :development do
-  # Shotgun provides code reloading support for `hanami server`.
-  # If you are on a POSIX system, please use `entr`.
-  # If not possible, please use Shotgun.
-  # Read more at: [LINK TO HANAMI GUIDES]
-  # gem 'shotgun'
+  # Code reloading
+  # See: [LINK TO HANAMI GUIDES]
+  gem 'shotgun'
 end
 
 group :test, :development do


### PR DESCRIPTION
With #523 we introduced experimental code reloading via `entr(1)`.

That feature helped to remove Shotgun as a runtime dependency. That gem will be only installed where needed: on developers' machines. That won't be required anymore on servers. The reason is obvious: you won't need code reloading in production.

We discovered that the combination of `entr` and the slow startup time of Ruby/Bundler (`bundle exec`) is killing the development workflow. After I make a change, I reload the page but the app is stopped. I have to reload a second time to se the updated web page.

This PR gives priority to Shotgun as default code reloading mechanism. It served us well until now, so we want to keep that smooth development process.

Developers who want to try `entr` or can't use Shotgun, can comment the `gem 'shotgun'` entry in `Gemfile` and that won't be installed anymore.

---

/cc @aderyabin @hanami/core-team @hanami/contributors 