### PR TITLE
Fix for issue 494 - Move Rack::MethodOverride middleware from application to container

### DIFF
--- a/lib/hanami/container.rb
+++ b/lib/hanami/container.rb
@@ -52,6 +52,7 @@ module Hanami
         require 'hanami/static'
         @builder.use Hanami::Static
       end
+      @builder.use Rack::MethodOverride
 
       @builder.run @routes
     end

--- a/lib/hanami/middleware.rb
+++ b/lib/hanami/middleware.rb
@@ -100,7 +100,7 @@ module Hanami
         _load_assets_middleware
         _load_session_middleware
         _load_default_welcome_page_for(application)
-        use Rack::MethodOverride
+        _load_method_override_middleware
 
         true
       end
@@ -137,6 +137,18 @@ module Hanami
       if !env.container? && env.serve_static_assets?
         require 'hanami/static'
         use Hanami::Static
+      end
+    end
+
+    # Use MethodOverride middleware
+    #
+    # @api private
+    # @since x.x.x
+    def _load_method_override_middleware
+      env = Hanami.environment
+
+      if !env.container?
+        use Rack::MethodOverride
       end
     end
   end

--- a/test/fixtures/middleware_stack/application.rb
+++ b/test/fixtures/middleware_stack/application.rb
@@ -12,6 +12,7 @@ module MiddlewareStack
 
       routes do
         get '/', to: 'home#index'
+        patch '/', to: 'home#update'
       end
     end
 
@@ -53,6 +54,14 @@ module MiddlewareStack
 
       def call(params)
         self.body = 'Hello'
+      end
+    end
+
+    class Update
+      include MiddlewareStack::Action
+
+      def call(params)
+        self.body = 'Update successful'
       end
     end
   end

--- a/test/fixtures/one_file/.hanamirc
+++ b/test/fixtures/one_file/.hanamirc
@@ -1,3 +1,3 @@
-architecture=container
+architecture=app
 test=minitest
 template=erb

--- a/test/integration/container_middleware_test.rb
+++ b/test/integration/container_middleware_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+require 'rack/test'
+require 'fixtures/middleware_stack/application'
+
+describe Hanami::Container do
+  include Rack::Test::Methods
+
+  before do
+    Hanami::Container.configure do
+      mount MiddlewareStack::Application, at: '/middleware'
+    end
+
+    @container = Hanami::Container.new
+    MiddlewareStack::Application.load!
+  end
+
+  def app
+    @container
+  end
+
+  def response
+    last_response
+  end
+
+  it 'applies the MethodOverride middleware to map POST to PATCH given correct header' do
+    post '/middleware/', {}, { 'HTTP_X_HTTP_METHOD_OVERRIDE' => 'PATCH' }
+
+    response.status.must_equal 200
+    response.body.must_equal %(Update successful)
+  end
+end

--- a/test/integration/middleware_stack_test.rb
+++ b/test/integration/middleware_stack_test.rb
@@ -40,4 +40,11 @@ describe 'Middleware stack' do
 
     response.status.must_equal 404
   end
+
+  it 'applies the MethodOverride middleware to map POST to PATCH given correct header' do
+    post '/', {}, { 'X-HTTP-Method-Override' => 'PATCH' }
+
+    response.status.must_equal 200
+    response.body.must_equal %(Update successful)
+  end
 end

--- a/test/integration/middleware_stack_test.rb
+++ b/test/integration/middleware_stack_test.rb
@@ -40,11 +40,4 @@ describe 'Middleware stack' do
 
     response.status.must_equal 404
   end
-
-  it 'applies the MethodOverride middleware to map POST to PATCH given correct header' do
-    post '/', {}, { 'X-HTTP-Method-Override' => 'PATCH' }
-
-    response.status.must_equal 200
-    response.body.must_equal %(Update successful)
-  end
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -35,29 +35,32 @@ describe Hanami::Middleware do
     middleware.stack.last.must_equal [MockMiddleware, [], nil]
   end
 
-  it 'does not contain Rack::MethodOverride by default' do
-    middleware.stack.wont_include [Rack::MethodOverride, [], nil]
+  describe "with container architecture" do
+    before do
+      setup_container_app
+    end
+
+    it 'does not contain Rack::MethodOverride by default' do
+      middleware.stack.wont_include [Rack::MethodOverride, [], nil]
+    end
   end
 
-  describe "with a non-container application" do
+  describe "with app architecture" do
     before do
-      @old_pwd = Dir.pwd
-      Dir.chdir('test/fixtures/one_file')
-    end
-
-    after do
-      Dir.chdir @old_pwd
-    end
-
-    let(:config_blk) do
-      proc do
-        root '.'
-      end
+      setup_app_app
     end
 
     it 'contains Rack::MethodOverride for non-container applications' do
       middleware.stack.must_include [Rack::MethodOverride, [], nil]
     end
+  end
+
+  def setup_container_app
+    File.open('.hanamirc', 'w') { |file| file << "architecture=container"}
+  end
+
+  def setup_app_app
+    File.open('.hanamirc', 'w') { |file| file << "architecture=app"}
   end
 
   describe "when it's configured with sessions" do

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -35,8 +35,29 @@ describe Hanami::Middleware do
     middleware.stack.last.must_equal [MockMiddleware, [], nil]
   end
 
-  it 'contains Rack::MethodOverride by default' do
-    middleware.stack.must_include [Rack::MethodOverride, [], nil]
+  it 'does not contain Rack::MethodOverride by default' do
+    middleware.stack.wont_include [Rack::MethodOverride, [], nil]
+  end
+
+  describe "with a non-container application" do
+    before do
+      @old_pwd = Dir.pwd
+      Dir.chdir('test/fixtures/one_file')
+    end
+
+    after do
+      Dir.chdir @old_pwd
+    end
+
+    let(:config_blk) do
+      proc do
+        root '.'
+      end
+    end
+
+    it 'contains Rack::MethodOverride for non-container applications' do
+      middleware.stack.must_include [Rack::MethodOverride, [], nil]
+    end
   end
 
   describe "when it's configured with sessions" do


### PR DESCRIPTION
This is an attempt to fix https://github.com/hanami/hanami/issues/494

I've moved `Rack::MethodOverride` from the application middleware stack to the container, but only when using the container architecture.

If the application is running the application architecture then there is no container middleware stack so I think we need to keep `Rack::MethodOverride` in the per application stack. To detect this I'm checking `Hanami.environment.container?` - is this the correct way to determine the architecture?

There was no obvious way to test the contents of the container middleware stack directly after making the change, I may be missing something here? I've added an integration test that sets up a container app and checks that `Rack::MethodOverride` is present by invoking a PATCH action (it fails without the change). 