### PR TITLE
Destroy generated route, regardless of url param

### DIFF
--- a/lib/hanami/commands/generate/action.rb
+++ b/lib/hanami/commands/generate/action.rb
@@ -64,9 +64,9 @@ module Hanami
             application_name = File.basename(Dir.pwd)
           end
 
-          controller_and_action_name = Utils::String.new(controller_and_action_name).underscore.gsub(QUOTED_NAME, '')
+          @controller_and_action_name = Utils::String.new(controller_and_action_name).underscore.gsub(QUOTED_NAME, '')
 
-          *controller_name, @action_name = controller_and_action_name.split(ACTION_SEPARATOR_MATCHER)
+          *controller_name, @action_name = @controller_and_action_name.split(ACTION_SEPARATOR_MATCHER)
 
           @application_name = Utils::String.new(application_name).classify
 
@@ -112,6 +112,11 @@ module Hanami
             relative_view_path:   relative_view_path,
             template_path:        template_path,
           }
+        end
+
+        def destroy
+          generator.gsub_file(routes_path, /^.*#{@controller_and_action_name}.*\n/, '')
+          super
         end
 
         private

--- a/lib/hanami/commands/generate/action.rb
+++ b/lib/hanami/commands/generate/action.rb
@@ -115,7 +115,7 @@ module Hanami
         end
 
         def destroy
-          generator.gsub_file(routes_path, /^.*#{@controller_and_action_name}.*\n/, '')
+          generator.gsub_file(routes_path, /^.*#{@controller_and_action_name}.*\n/, '', verbose: false)
           super
         end
 

--- a/lib/hanami/generators/generator.rb
+++ b/lib/hanami/generators/generator.rb
@@ -7,7 +7,7 @@ module Hanami
 
       extend Forwardable
 
-      def_delegators :@processor, :run, :behavior=, :inject_into_file, :append_to_file, :prepend_to_file
+      def_delegators :@processor, :run, :behavior=, :inject_into_file, :append_to_file, :prepend_to_file, :gsub_file
 
       class Processor < Thor
         include Thor::Actions

--- a/test/commands/generate/action_test.rb
+++ b/test/commands/generate/action_test.rb
@@ -405,8 +405,8 @@ describe Hanami::Commands::Generate::Action do
       end
     end
 
-    describe 'with --url' do
-      it 'erases route configuration' do
+    describe 'generated with --url' do
+      it 'erases route configuration with --url' do
         with_temp_dir do |original_wd|
           setup_container_app
 
@@ -414,6 +414,20 @@ describe Hanami::Commands::Generate::Action do
             Hanami::Commands::Generate::Action.new({url: '/mybooks'}, 'web', 'books#index').start
 
             Hanami::Commands::Generate::Action.new({url: '/mybooks'}, 'web', 'books#index').destroy.start
+          }
+
+          refute_file_includes('apps/web/config/routes.rb', "get '/mybooks', to: 'books#index'")
+        end
+      end
+
+      it 'erases route configuration without --url' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+
+          capture_io {
+            Hanami::Commands::Generate::Action.new({url: '/mybooks'}, 'web', 'books#index').start
+
+            Hanami::Commands::Generate::Action.new({}, 'web', 'books#index').destroy.start
           }
 
           refute_file_includes('apps/web/config/routes.rb', "get '/mybooks', to: 'books#index'")


### PR DESCRIPTION
Closes #451 .

The code that normally removes the route basically runs the generate command backwards (a.k.a. [`revoke`](https://github.com/erikhuda/thor/blob/f0c2166534e122636f5ce04d61885736ef605617/lib/thor/actions/inject_into_file.rb#L62)). In this case, we want to be more permissive, removing the route regardless of the URL.

Rather than monkey patching Thor, we let it do its thing, then we run a `gsub_file` to remove the offending line. 

I'm not sure we want to add the `@controller_and_action_name` instance variable, but it seems weird to split it to get `@controller_name` and `@action_name`, then join them back together.
Maybe we want to only have`@controller_and_action_name`, and convert `controller_name` and `action_name` into methods. Happy to do that work, if it's the direction we want to go.