### PR TITLE
Namespace container

### DIFF
--- a/lib/hanami/commands/generate/app.rb
+++ b/lib/hanami/commands/generate/app.rb
@@ -65,8 +65,8 @@ module Hanami
         end
 
         def add_mount_app
-          generator.inject_into_file base_path.join('config/environment.rb'), after: /Hanami::Container.configure do/ do |match|
-            "\n  mount #{ classified_app_name }::Application, at: '#{ application_base_url }'"
+          generator.inject_into_file base_path.join('config/environment.rb'), after: /configure do/ do |match|
+            "\n      mount #{ classified_app_name }::Application, at: '#{ application_base_url }'"
           end
         end
 

--- a/lib/hanami/commands/new/container.rb
+++ b/lib/hanami/commands/new/container.rb
@@ -18,14 +18,15 @@ module Hanami
 
         def template_options
           {
-            app_name:             app_name,
-            hanami_head:          hanami_head?,
-            test:                 test_framework.framework,
-            database:             database_config.type,
-            database_config:      database_config.to_hash,
-            hanami_model_version: hanami_model_version,
-            hanami_version:       hanami_version,
-            template:             template_engine.name
+            app_name:                   app_name,
+            classified_container_name:  classified_container_name,
+            hanami_head:                hanami_head?,
+            test:                       test_framework.framework,
+            database:                   database_config.type,
+            database_config:            database_config.to_hash,
+            hanami_model_version:       hanami_model_version,
+            hanami_version:             hanami_version,
+            template:                   template_engine.name
           }
         end
 
@@ -91,6 +92,10 @@ module Hanami
 
         def app_slice_name
           options.fetch(:application_name, DEFAULT_APPLICATION_NAME)
+        end
+
+        def classified_container_name
+          Utils::String.new(app_name).classify.tr('::', '')
         end
 
         def template_source_path

--- a/lib/hanami/container.rb
+++ b/lib/hanami/container.rb
@@ -21,8 +21,8 @@ module Hanami
 
     def self.configure(options = {}, &blk)
       Mutex.new.synchronize do
-        @@options       = options
-        @@configuration = blk
+        @options       = options
+        @configuration = blk
       end
     end
 
@@ -38,15 +38,16 @@ module Hanami
     end
 
     private
+
     def assert_configuration_presence!
-      unless self.class.class_variable_defined?(:@@configuration)
+      unless self.class.instance_variable_defined?(:@configuration)
         raise ArgumentError.new("#{ self.class } doesn't have any application mounted.")
       end
     end
 
     def prepare_middleware_stack!
       @builder = ::Rack::Builder.new
-      @routes  = Router.new(&@@configuration)
+      @routes  = Router.new(&self.class.instance_variable_get(:@configuration))
 
       if Hanami.environment.serve_static_assets?
         require 'hanami/static'

--- a/lib/hanami/container.rb
+++ b/lib/hanami/container.rb
@@ -21,7 +21,6 @@ module Hanami
 
     def self.configure(options = {}, &blk)
       Mutex.new.synchronize do
-        @options       = options
         @configuration = blk
       end
     end

--- a/lib/hanami/generators/application/container/config.ru.tt
+++ b/lib/hanami/generators/application/container/config.ru.tt
@@ -1,3 +1,3 @@
 require './config/environment'
 
-run Hanami::Container.new
+run <%= config[:classified_container_name] %>::Container.new

--- a/lib/hanami/generators/application/container/config/environment.rb.tt
+++ b/lib/hanami/generators/application/container/config/environment.rb.tt
@@ -3,5 +3,9 @@ require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/<%= config[:app_name] %>'
 
-Hanami::Container.configure do
+module <%= config[:classified_container_name] %>
+  class Container < Hanami::Container
+    configure do
+    end
+  end
 end

--- a/test/commands/console_test.rb
+++ b/test/commands/console_test.rb
@@ -180,12 +180,12 @@ describe Hanami::Commands::Console do
       before do
         @old_pwd = Dir.pwd
         Dir.chdir 'test/fixtures/microservices'
-        Hanami::Container.class_variable_set(:@@configuration, Proc.new{})
+        Hanami::Container.instance_variable_set(:@configuration, Proc.new{})
       end
 
       after do
         Dir.chdir @old_pwd
-        Hanami::Container.remove_class_variable(:@@configuration)
+        Hanami::Container.remove_instance_variable(:@configuration)
       end
 
       it 'requires that file and starts a console session' do
@@ -216,11 +216,11 @@ describe Hanami::Commands::Console do
       }
 
       before do
-        Hanami::Container.class_variable_set(:@@configuration, Proc.new{})
+        Hanami::Container.instance_variable_set(:@configuration, Proc.new{})
       end
 
       after do
-        Hanami::Container.remove_class_variable(:@@configuration)
+        Hanami::Container.remove_instance_variable(:@configuration)
       end
 
       it 'requires that file and starts a console session' do
@@ -251,12 +251,12 @@ describe Hanami::Commands::Console do
 
       @engine = Minitest::Mock.new
       @engine.expect(:start, nil)
-      Hanami::Container.class_variable_set(:@@configuration, Proc.new{})
+      Hanami::Container.instance_variable_set(:@configuration, Proc.new{})
     end
 
     after do
       Hanami::Utils::IO.silence_warnings { TOPLEVEL_BINDING = @old_main }
-      Hanami::Container.remove_class_variable(:@@configuration)
+      Hanami::Container.remove_instance_variable(:@configuration)
     end
 
     it 'mixes convenience methods into the TOPLEVEL_BINDING' do

--- a/test/commands/routes_test.rb
+++ b/test/commands/routes_test.rb
@@ -16,10 +16,14 @@ describe Hanami::Commands::Routes do
     let(:architecture) { 'container' }
 
     before do
-      Hanami::Container.configure do
-        mount Backend::App, at: '/backend'
-        mount RackApp,      at: '/rackapp'
-        mount TinyApp,      at: '/'
+      module Dummy
+        class Container < Hanami::Container
+          configure do
+            mount Backend::App, at: '/backend'
+            mount RackApp,      at: '/rackapp'
+            mount TinyApp,      at: '/'
+          end
+        end
       end
     end
 
@@ -31,7 +35,7 @@ describe Hanami::Commands::Routes do
           %(GET, HEAD  /                              TinyApp::Controllers::Home::Index)
         ]
 
-        actual = Hanami::Container.new.routes.inspector.to_s
+        actual = Dummy::Container.new.routes.inspector.to_s
         expectations.each do |expectation|
           actual.must_include(expectation)
         end

--- a/test/container_test.rb
+++ b/test/container_test.rb
@@ -9,14 +9,14 @@ describe Hanami::Container do
     end
 
     it 'allows to define mounted applications with a block' do
-      assert Hanami::Container.class_variable_get(:@@configuration) == @blk, "Expected Hanami::Container configuration to equal @blk"
+      assert Hanami::Container.instance_variable_get(:@configuration) == @blk, "Expected Hanami::Container configuration to equal @blk"
     end
 
     it 'allows to redefine the configuration' do
       blk = -> { mount RackApp, at: '/rack2' }
       Hanami::Container.configure(&blk)
 
-      assert Hanami::Container.class_variable_get(:@@configuration) == blk, "Expected Hanami::Container configuration to equal blk"
+      assert Hanami::Container.instance_variable_get(:@configuration) == blk, "Expected Hanami::Container configuration to equal blk"
     end
   end
 
@@ -36,7 +36,7 @@ describe Hanami::Container do
 
     describe 'without configuration' do
       before do
-        Hanami::Container.remove_class_variable(:@@configuration) rescue nil
+        Hanami::Container.remove_instance_variable(:@configuration) rescue nil
       end
 
       it 'raises error when initialized' do

--- a/test/fixtures/cdn/cdn/config.ru
+++ b/test/fixtures/cdn/cdn/config.ru
@@ -1,3 +1,3 @@
 require './config/environment'
 
-run Hanami::Container.new
+run Cdn::Container.new

--- a/test/fixtures/cdn/cdn/config/environment.rb
+++ b/test/fixtures/cdn/cdn/config/environment.rb
@@ -4,6 +4,10 @@ require 'hanami/setup'
 require_relative '../lib/cdn'
 require_relative '../apps/web/application'
 
-Hanami::Container.configure do
-  mount Web::Application, at: '/'
+module Cdn
+  class Container < Hanami::Container
+    configure do
+      mount Web::Application, at: '/'
+    end
+  end
 end

--- a/test/fixtures/commands/application/new_container/config.ru
+++ b/test/fixtures/commands/application/new_container/config.ru
@@ -1,3 +1,3 @@
 require './config/environment'
 
-run Hanami::Container.new
+run NewContainer::Container.new

--- a/test/fixtures/commands/application/new_container/config/environment.rb
+++ b/test/fixtures/commands/application/new_container/config/environment.rb
@@ -4,6 +4,10 @@ require 'hanami/setup'
 require_relative '../lib/new_container'
 require_relative '../apps/web/application'
 
-Hanami::Container.configure do
-  mount Web::Application, at: '/'
+module NewContainer
+  class Container < Hanami::Container
+    configure do
+      mount Web::Application, at: '/'
+    end
+  end
 end

--- a/test/fixtures/commands/application/new_container/config/environment_mypath.rb
+++ b/test/fixtures/commands/application/new_container/config/environment_mypath.rb
@@ -4,6 +4,10 @@ require 'hanami/setup'
 require_relative '../lib/new_container'
 require_relative '../apps/web/application'
 
-Hanami::Container.configure do
-  mount Web::Application, at: '/mypath'
+module NewContainer
+  class Container < Hanami::Container
+    configure do
+      mount Web::Application, at: '/mypath'
+    end
+  end
 end

--- a/test/fixtures/commands/generate/app/environment.rb
+++ b/test/fixtures/commands/generate/app/environment.rb
@@ -4,6 +4,10 @@ require 'hanami/setup'
 require_relative '../lib/container-app'
 require_relative '../apps/web/application'
 
-Hanami::Container.configure do
-  mount Web::Application, at: '/'
+module Haiku
+  class Container < Hanami::Container
+    configure do
+      mount Web::Application, at: '/'
+    end
+  end
 end

--- a/test/fixtures/commands/generate/app/environment_with_app_added.rb
+++ b/test/fixtures/commands/generate/app/environment_with_app_added.rb
@@ -5,7 +5,11 @@ require_relative '../lib/container-app'
 require_relative '../apps/admin/application'
 require_relative '../apps/web/application'
 
-Hanami::Container.configure do
-  mount Admin::Application, at: '/admin'
-  mount Web::Application, at: '/'
+module Haiku
+  class Container < Hanami::Container
+    configure do
+      mount Admin::Application, at: '/admin'
+      mount Web::Application, at: '/'
+    end
+  end
 end

--- a/test/fixtures/commands/generate/app/environment_with_app_added_url.rb
+++ b/test/fixtures/commands/generate/app/environment_with_app_added_url.rb
@@ -5,7 +5,11 @@ require_relative '../lib/container-app'
 require_relative '../apps/admin/application'
 require_relative '../apps/web/application'
 
-Hanami::Container.configure do
-  mount Admin::Application, at: '/backend'
-  mount Web::Application, at: '/'
+module Haiku
+  class Container < Hanami::Container
+    configure do
+      mount Admin::Application, at: '/backend'
+      mount Web::Application, at: '/'
+    end
+  end
 end


### PR DESCRIPTION
## What is this about?
To namespace container project.

## Why are we doing this?
There is a needs for a placeholder to contain global project config/logic codes. It makes sense to place them in container level, that is `Hanami::Container`.

By having a class that extends `Hanami::Container`, we could allow user to customise this layer without monkey-patching this class.

before:

```
Hanami::Container.configure do; end;
```

after:

```
module YourApp
  class Container < Hanami::Container
    configure do
    end

    #extra logic
  end
end
```

## Notes
The Release Notes should document about this change to avoid confusion for users.

cc @hanami/core-team 