### PR TITLE
Load initializers in alphabetical order on any operation system

### DIFF
--- a/lib/hanami/loader.rb
+++ b/lib/hanami/loader.rb
@@ -248,7 +248,7 @@ module Hanami
     end
 
     def load_initializers!
-      Dir["#{configuration.root}/config/initializers/**/*.rb"].each do |file|
+      Dir["#{configuration.root}/config/initializers/**/*.rb"].sort.each do |file|
         require file
       end
     end


### PR DESCRIPTION
[Documentation says](http://hanamirb.org/guides/applications/initializers/):

> Initializers are executed in alphabetical order.

But [ruby documentation](http://ruby-doc.org/core-2.2.1/Dir.html) says about `Dir.glob` (that is an alias for `Dir[...]`)

> Note that case sensitivity depends on your system (so File::FNM_CASEFOLD is ignored), as does the order in which the results are returned.

So, alphabetical order is not guaranteed, that is why we should order results manually