### PR TITLE
Fix typo on every delivery code example

### DIFF
--- a/lib/hanami/generators/application/app/lib/app_name.rb.tt
+++ b/lib/hanami/generators/application/app/lib/app_name.rb.tt
@@ -51,6 +51,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/lib/hanami/generators/application/container/lib/app_name.rb.tt
+++ b/lib/hanami/generators/application/container/lib/app_name.rb.tt
@@ -52,6 +52,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/commands/application/new_app/lib/new_app.rb
+++ b/test/fixtures/commands/application/new_app/lib/new_app.rb
@@ -43,6 +43,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/commands/application/new_container/lib/new_container.filesystem.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.filesystem.rb
@@ -44,6 +44,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/commands/application/new_container/lib/new_container.memory.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.memory.rb
@@ -44,6 +44,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/commands/application/new_container/lib/new_container.mysql2.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.mysql2.rb
@@ -50,6 +50,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/commands/application/new_container/lib/new_container.postgres.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.postgres.rb
@@ -50,6 +50,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/commands/application/new_container/lib/new_container.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.rb
@@ -44,6 +44,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/commands/application/new_container/lib/new_container.sqlite3.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.sqlite3.rb
@@ -50,6 +50,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/rake/rake_tasks/lib/rake_tasks.rb
+++ b/test/fixtures/rake/rake_tasks/lib/rake_tasks.rb
@@ -47,6 +47,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!

--- a/test/fixtures/rake/rake_tasks_app/lib/rake_tasks_app.rb
+++ b/test/fixtures/rake/rake_tasks_app/lib/rake_tasks_app.rb
@@ -46,6 +46,6 @@ Hanami::Mailer.configure do
   delivery do
     development :test
     test        :test
-    # production :stmp, address: ENV['SMTP_PORT'], port: 1025
+    # production :smtp, address: ENV['SMTP_PORT'], port: 1025
   end
 end.load!


### PR DESCRIPTION
This is a small PR to fix the typo on `delivery` examples. 
Will change every `stmp` typo to `smtp`.

🍻 