### PR TITLE
Require gems in bin/hanami file

### DIFF
--- a/bin/hanami
+++ b/bin/hanami
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-
 require 'bundler'
 require 'hanami/cli'
+require 'hanami/setup'
+
 Hanami::Cli.start

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -1,11 +1,13 @@
+require 'thor'
 require 'hanami/cli_base'
 require 'hanami/commands/console'
 require 'hanami/commands/new/app'
 require 'hanami/commands/new/container'
 
 module Hanami
-  class Cli < CliBase
+  class Cli < Thor
     # include Thor::Actions
+    extend CliBase
 
     desc 'version', 'Prints hanami version'
     long_desc <<-EOS

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -1,10 +1,10 @@
-require 'thor'
+require 'hanami/cli_base'
 require 'hanami/commands/console'
 require 'hanami/commands/new/app'
 require 'hanami/commands/new/container'
 
 module Hanami
-  class Cli < Thor
+  class Cli < CliBase
     # include Thor::Actions
 
     desc 'version', 'Prints hanami version'

--- a/lib/hanami/cli_base.rb
+++ b/lib/hanami/cli_base.rb
@@ -1,0 +1,30 @@
+require 'thor'
+
+module Hanami
+  class CliBase < Thor
+    # Add new custom CLI command to special CLI class
+    #
+    # @since x.x.x
+    #
+    # @example Usage with Cli class
+    #   require 'hanami'
+    #   require 'hanami/cli'
+    #
+    #   Hanami::Cli.custom_commands do
+    #     desc 'custom', 'Generate a something'
+    #     long_desc <<-EOS
+    #       long description for your custom command
+    #     EOS
+    #     def custom
+    #       if options[:help]
+    #         invoke :help, ['auth']
+    #       else
+    #         # ...
+    #       end
+    #     end
+    #   end
+    def self.custom_commands(&blk)
+      class_eval(&blk) if block_given?
+    end
+  end
+end

--- a/lib/hanami/cli_base.rb
+++ b/lib/hanami/cli_base.rb
@@ -1,7 +1,5 @@
-require 'thor'
-
 module Hanami
-  class CliBase < Thor
+  module CliBase
     # Add new custom CLI command to special CLI class
     #
     # @since x.x.x
@@ -10,7 +8,7 @@ module Hanami
     #   require 'hanami'
     #   require 'hanami/cli'
     #
-    #   Hanami::Cli.custom_commands do
+    #   Hanami::Cli.define_commands do
     #     desc 'custom', 'Generate a something'
     #     long_desc <<-EOS
     #       long description for your custom command
@@ -23,7 +21,7 @@ module Hanami
     #       end
     #     end
     #   end
-    def self.custom_commands(&blk)
+    def define_commands(&blk)
       class_eval(&blk) if block_given?
     end
   end

--- a/lib/hanami/cli_base.rb
+++ b/lib/hanami/cli_base.rb
@@ -1,8 +1,11 @@
 module Hanami
   module CliBase
-    # Add new custom CLI command to special CLI class
+    # Add new custom CLI command to special CLI class.
+    # Please be careful. This is a private method that
+    # can be deleted soon.
     #
     # @since x.x.x
+    # @api private
     #
     # @example Usage with Cli class
     #   require 'hanami'

--- a/lib/hanami/cli_sub_commands/assets.rb
+++ b/lib/hanami/cli_sub_commands/assets.rb
@@ -8,7 +8,7 @@ module Hanami
     #
     # @since 0.6.0
     # @api private
-    class Assets < Thor
+    class Assets < CliBase
       namespace :assets
 
       desc 'precompile', 'Precompile assets for deployment'

--- a/lib/hanami/cli_sub_commands/assets.rb
+++ b/lib/hanami/cli_sub_commands/assets.rb
@@ -8,7 +8,8 @@ module Hanami
     #
     # @since 0.6.0
     # @api private
-    class Assets < CliBase
+    class Assets < Thor
+      extend CliBase
       namespace :assets
 
       desc 'precompile', 'Precompile assets for deployment'

--- a/lib/hanami/cli_sub_commands/db.rb
+++ b/lib/hanami/cli_sub_commands/db.rb
@@ -8,7 +8,7 @@ module Hanami
     #
     # @since 0.6.0
     # @api private
-    class DB < Thor
+    class DB < CliBase
       namespace :db
 
       desc 'console', 'Start DB console'

--- a/lib/hanami/cli_sub_commands/db.rb
+++ b/lib/hanami/cli_sub_commands/db.rb
@@ -8,7 +8,8 @@ module Hanami
     #
     # @since 0.6.0
     # @api private
-    class DB < CliBase
+    class DB < Thor
+      extend CliBase
       namespace :db
 
       desc 'console', 'Start DB console'

--- a/lib/hanami/cli_sub_commands/destroy.rb
+++ b/lib/hanami/cli_sub_commands/destroy.rb
@@ -3,7 +3,7 @@ require 'hanami/commands/generate/action'
 
 module Hanami
   class CliSubCommands
-    class Destroy < Thor
+    class Destroy < CliBase
       include Thor::Actions
       namespace :destroy
 

--- a/lib/hanami/cli_sub_commands/destroy.rb
+++ b/lib/hanami/cli_sub_commands/destroy.rb
@@ -3,7 +3,8 @@ require 'hanami/commands/generate/action'
 
 module Hanami
   class CliSubCommands
-    class Destroy < CliBase
+    class Destroy < Thor
+      extend CliBase
       include Thor::Actions
       namespace :destroy
 

--- a/lib/hanami/cli_sub_commands/generate.rb
+++ b/lib/hanami/cli_sub_commands/generate.rb
@@ -12,7 +12,7 @@ module Hanami
     #
     # @since 0.6.0
     # @api private
-    class Generate < Thor
+    class Generate < CliBase
       include Thor::Actions
 
       namespace :generate

--- a/lib/hanami/cli_sub_commands/generate.rb
+++ b/lib/hanami/cli_sub_commands/generate.rb
@@ -12,7 +12,8 @@ module Hanami
     #
     # @since 0.6.0
     # @api private
-    class Generate < CliBase
+    class Generate < Thor
+      extend CliBase
       include Thor::Actions
 
       namespace :generate

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -225,8 +225,8 @@ describe Hanami::Cli do
     end
   end
 
-  describe '::custom_commands' do
-    Hanami::Cli.custom_commands do
+  describe '::define_commands' do
+    Hanami::Cli.define_commands do
       desc 'custom', 'Empty command'
       def custom
         puts 'custom command'

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -225,6 +225,22 @@ describe Hanami::Cli do
     end
   end
 
+  describe '::custom_commands' do
+    Hanami::Cli.custom_commands do
+      desc 'custom', 'Empty command'
+      def custom
+        puts 'custom command'
+      end
+    end
+
+    it 'adds new custom command' do
+      assert_output("custom command\n") do
+        ARGV.replace(%w{custom})
+        Hanami::Cli.start
+      end
+    end
+  end
+
   def setup_container_app
     File.open('.hanamirc', 'w') { |file| file << "architecture=container"}
   end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -233,7 +233,21 @@ describe Hanami::Cli do
       end
     end
 
+    Hanami::CliSubCommands::Generate.define_commands do
+      desc 'custom', 'Empty command'
+      def custom
+        puts 'custom command'
+      end
+    end
+
     it 'adds new custom command' do
+      assert_output("custom command\n") do
+        ARGV.replace(%w{generate custom})
+        Hanami::Cli.start
+      end
+    end
+
+    it 'adds new custom subcommand' do
       assert_output("custom command\n") do
         ARGV.replace(%w{custom})
         Hanami::Cli.start


### PR DESCRIPTION
## Why this patch is important?
Now I working on integration the [rodauth][rodauth] gem and hanami application. And [I'm creating gem][gem] wrapper for this. On this gem I want to call custom `auth` generator like this:

```
$ bundle exec hanami generate auth
```

For this I need to require my gem to `bin/hanami` file. And with this patch I'll be have a simple way to creating custom actions or generators.

For example, if you call `hanami g` with my gem you see this output:

![screenshot 2016-05-04 04 01 07](https://cloud.githubusercontent.com/assets/1147484/15002899/44449dce-11b7-11e6-9ea0-190aa3462dfa.jpg)


/cc @hanami/contributors and @hanami/core-team 

[gem]: https://github.com/davydovanton/hanami-rodauth
[rodauth]: http://rodauth.jeremyevans.net
