### PR TITLE
Fix usage of Mutex

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -122,6 +122,13 @@ module Hanami
     end
 
     class << self
+      # @since 0.8.0
+      # @api private
+      @@mutex = Mutex.new
+
+      # @since 0.2.0
+      # @api private
+      @@applications = Set.new
 
       # Registry of Hanami applications in the current Ruby process
       #
@@ -130,9 +137,7 @@ module Hanami
       # @since 0.2.0
       # @api private
       def applications
-        synchronize do
-          @@applications ||= Set.new
-        end
+        @@applications
       end
 
       # Configure the application.
@@ -238,7 +243,7 @@ module Hanami
       # @since 0.2.0
       # @api private
       def synchronize
-        Mutex.new.synchronize do
+        @@mutex.synchronize do
           yield
         end
       end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -40,6 +40,10 @@ module Hanami
       end
     end
 
+    # @since 0.8.0
+    # @api private
+    LOCK = Mutex.new
+
     # Return the routes for this application
     #
     # @return [Hanami::Router] a route set
@@ -122,10 +126,6 @@ module Hanami
     end
 
     class << self
-      # @since 0.8.0
-      # @api private
-      @@mutex = Mutex.new
-
       # @since 0.2.0
       # @api private
       @@applications = Set.new
@@ -243,7 +243,7 @@ module Hanami
       # @since 0.2.0
       # @api private
       def synchronize
-        @@mutex.synchronize do
+        LOCK.synchronize do
           yield
         end
       end

--- a/lib/hanami/container.rb
+++ b/lib/hanami/container.rb
@@ -17,19 +17,19 @@ module Hanami
       end
     end
 
-    @@mutex = Mutex.new
+    LOCK = Mutex.new
 
     attr_reader :routes
 
     def self.configure(options = {}, &blk)
-      @@mutex.synchronize do
+      LOCK.synchronize do
         @@options       = options
         @@configuration = blk
       end
     end
 
     def initialize
-      @@mutex.synchronize do
+      LOCK.synchronize do
         assert_configuration_presence!
         prepare_middleware_stack!
       end

--- a/lib/hanami/container.rb
+++ b/lib/hanami/container.rb
@@ -17,17 +17,19 @@ module Hanami
       end
     end
 
+    @@mutex = Mutex.new
+
     attr_reader :routes
 
     def self.configure(options = {}, &blk)
-      Mutex.new.synchronize do
+      @@mutex.synchronize do
         @@options       = options
         @@configuration = blk
       end
     end
 
     def initialize
-      Mutex.new.synchronize do
+      @@mutex.synchronize do
         assert_configuration_presence!
         prepare_middleware_stack!
       end

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -18,7 +18,7 @@ module Hanami
     #
     # @since 0.8.0
     # @api private
-    @@mutex = Mutex.new
+    LOCK = Mutex.new
 
     # Standard Rack ENV key
     #
@@ -198,7 +198,7 @@ module Hanami
     def initialize(options = {})
       @options = Hanami::Hanamirc.new(root).options
       @options.merge! Utils::Hash.new(options.clone).symbolize!
-      @@mutex.synchronize { set_env_vars! }
+      LOCK.synchronize { set_env_vars! }
     end
 
     # The current environment

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -14,6 +14,12 @@ module Hanami
   # @since 0.1.0
   # @api private
   class Environment
+    # Global lock (used to serialize process of environment configuration)
+    #
+    # @since 0.8.0
+    # @api private
+    @@mutex = Mutex.new
+
     # Standard Rack ENV key
     #
     # @since 0.1.0
@@ -192,8 +198,7 @@ module Hanami
     def initialize(options = {})
       @options = Hanami::Hanamirc.new(root).options
       @options.merge! Utils::Hash.new(options.clone).symbolize!
-      @mutex   = Mutex.new
-      @mutex.synchronize { set_env_vars! }
+      @@mutex.synchronize { set_env_vars! }
     end
 
     # The current environment

--- a/lib/hanami/loader.rb
+++ b/lib/hanami/loader.rb
@@ -13,6 +13,7 @@ module Hanami
   # @since 0.1.0
   # @api private
   class Loader
+    @@mutex = Mutex.new
 
     STRICT_TRANSPORT_SECURITY_HEADER = 'Strict-Transport-Security'.freeze
     STRICT_TRANSPORT_SECURITY_DEFAULT_VALUE = 'max-age=31536000'.freeze
@@ -20,12 +21,10 @@ module Hanami
     def initialize(application)
       @application   = application
       @configuration = @application.configuration
-
-      @mutex = Mutex.new
     end
 
     def load!
-      @mutex.synchronize do
+      @@mutex.synchronize do
         load_configuration!
         configure_frameworks!
         load_configuration_load_paths!

--- a/lib/hanami/loader.rb
+++ b/lib/hanami/loader.rb
@@ -13,7 +13,7 @@ module Hanami
   # @since 0.1.0
   # @api private
   class Loader
-    @@mutex = Mutex.new
+    LOCK = Mutex.new
 
     STRICT_TRANSPORT_SECURITY_HEADER = 'Strict-Transport-Security'.freeze
     STRICT_TRANSPORT_SECURITY_DEFAULT_VALUE = 'max-age=31536000'.freeze
@@ -24,7 +24,7 @@ module Hanami
     end
 
     def load!
-      @@mutex.synchronize do
+      LOCK.synchronize do
         load_configuration!
         configure_frameworks!
         load_configuration_load_paths!


### PR DESCRIPTION
Hi,

I found that Hanami uses mutexes improperly by calling `synchronize` alongside with `Mutex.new`. It is not how synchronization meant to work because you must create `Mutex` object in advance and `synchronize` your code later using the object. Otherwise there would be no synchronization at all o_O. Please take a look at my snippets:
```ruby
# Use Mutex.new every time we run #synchronize
jruby-head :001 > def synchronize
jruby-head :002?>   Mutex.new.synchronize do
jruby-head :003 >     yield
jruby-head :004?>   end
jruby-head :005?> end
 => :synchronize
jruby-head :006 >
jruby-head :007 > $gvar = 0
 => 0
jruby-head :008 >
jruby-head :009 > 5.times { Thread.new { 10_000.times { synchronize { $gvar += 1 } } } }
 => 5
jruby-head :010 > $gvar
 => 33393
```
```ruby
# Use shared Mutex value
 jruby-head :001 > $mutex = Mutex.new
 => #<Mutex:0x27ae2fd0>
jruby-head :002 >
jruby-head :003 > def synchronize
jruby-head :004?>   $mutex.synchronize do
jruby-head :005 >     yield
jruby-head :006?>   end
jruby-head :007?> end
 => :synchronize
jruby-head :008 >
jruby-head :009 > $gvar = 0
 => 0
jruby-head :010 >
jruby-head :011 > 5.times { Thread.new { 10_000.times { synchronize { $gvar += 1 } } } }
 => 5
jruby-head :012 > $gvar
 => 50000
```

I replaced all `Mutex.new` calls with class variables so everything should be fine now. I also had to assign a value to `@@applications` explicitly due to a deadlock on lazy assignment.