### PR TITLE
Add notice to about SERVE_STATIC_ASSETS

### DIFF
--- a/lib/hanami/rake_helper.rb
+++ b/lib/hanami/rake_helper.rb
@@ -60,6 +60,11 @@ module Hanami
 
       namespace :assets do
         task :precompile do
+          puts "=============================================================="
+          puts "NOTE: In order to serve static assets on Heroku (and others), "
+          puts "the environment variable SERVE_STATIC_ASSETS must equal 'true'"
+          puts "To do this, run `heroku config:set SERVE_STATIC_ASSETS=true`  "
+          puts "=============================================================="
           system("bundle exec hanami assets precompile") || exit($?.exitstatus)
         end
       end

--- a/test/integration/rake/test_application.rb
+++ b/test/integration/rake/test_application.rb
@@ -114,10 +114,24 @@ describe 'Rake tasks (Application)' do
     end
 
     it "precompile assets" do
-      success = system "bundle exec rake assets:precompile"
-      success.must_equal true
+      capture_subprocess_io {
+        success = system "bundle exec rake assets:precompile"
+        success.must_equal true
+      }
 
       root.join('public', 'assets.json').must_be :exist?
+    end
+
+    it "outputs note about setting SERVE_STATIC_ASSETS to true" do
+      output, _ = capture_subprocess_io { system "bundle exec rake assets:precompile" }
+      assert_equal(
+        output,
+          "==============================================================\n"\
+          "NOTE: In order to serve static assets on Heroku (and others), \n"\
+          "the environment variable SERVE_STATIC_ASSETS must equal 'true'\n"\
+          "To do this, run `heroku config:set SERVE_STATIC_ASSETS=true`  \n"\
+          "==============================================================\n"
+      )
     end
   end
 end

--- a/test/integration/rake/test_container.rb
+++ b/test/integration/rake/test_container.rb
@@ -114,10 +114,25 @@ describe 'Rake tasks (Container)' do
     end
 
     it "precompile assets" do
-      success = system "bundle exec rake assets:precompile"
-      success.must_equal true
+      capture_subprocess_io {
+        success = system "bundle exec rake assets:precompile"
+        success.must_equal true
+      }
+
 
       root.join('public', 'assets.json').must_be :exist?
+    end
+
+    it "outputs note about setting SERVE_STATIC_ASSETS to true" do
+      output, _ = capture_subprocess_io { system "bundle exec rake assets:precompile" }
+      assert_equal(
+        output,
+          "==============================================================\n"\
+          "NOTE: In order to serve static assets on Heroku (and others), \n"\
+          "the environment variable SERVE_STATIC_ASSETS must equal 'true'\n"\
+          "To do this, run `heroku config:set SERVE_STATIC_ASSETS=true`  \n"\
+          "==============================================================\n"
+      )
     end
   end
 end

--- a/test/rake_helper_test.rb
+++ b/test/rake_helper_test.rb
@@ -40,7 +40,9 @@ describe Hanami::RakeHelper do
   describe 'when "assets:precompile" task failed' do
     it 'exits with failed status code' do
       task = rake_task "assets:precompile"
-      -> { task.invoke }.must_raise SystemExit
+      capture_io do
+        -> { task.invoke }.must_raise SystemExit
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #562.

Since Heroku is the only one who should be running `rake assets:precompile` (other should use `hanami assets precompile`, this is a good place to tell users about `SERVE_STATIC_ASSETS=true`.

I happily welcome suggestions for improvements to the message :)