### PR TITLE
Serve static assets via Shotgun::Static

### DIFF
--- a/lib/hanami/server.rb
+++ b/lib/hanami/server.rb
@@ -49,10 +49,34 @@ module Hanami
       mw = Hash.new { |e, m| e[m] = [] }
       mw["deployment"].concat([::Rack::ContentLength, ::Rack::CommonLogger])
       mw["development"].concat(mw["deployment"] + [::Rack::ShowExceptions, ::Rack::Lint])
+      mw["development"].push(::Shotgun::Static) if enable_shotgun_static?
       mw
     end
 
     private
+
+    # @since x.x.x
+    # @api private
+    def enable_shotgun_static?
+      code_reloading? && shotgun_available?
+    end
+
+    # @since x.x.x
+    # @api private
+    def shotgun_available?
+      begin
+        require 'shotgun'
+        true
+      rescue LoadError
+        false
+      end
+    end
+
+    # @since x.x.x
+    # @api private
+    def code_reloading?
+      @_env.code_reloading?
+    end
 
     # @since 0.8.0
     # @api private

--- a/lib/hanami/server.rb
+++ b/lib/hanami/server.rb
@@ -64,12 +64,10 @@ module Hanami
     # @since x.x.x
     # @api private
     def shotgun_available?
-      begin
-        require 'shotgun'
-        true
-      rescue LoadError
-        false
-      end
+      require 'shotgun'
+      true
+    rescue LoadError
+      false
     end
 
     # @since x.x.x

--- a/test/commands/server_test.rb
+++ b/test/commands/server_test.rb
@@ -26,7 +26,7 @@ describe Hanami::Commands::Server do
       expected = {
         'deployment'  => [::Rack::ContentLength, ::Rack::CommonLogger],
         'development' => [::Rack::ContentLength, ::Rack::CommonLogger,
-                          ::Rack::ShowExceptions, Rack::Lint]
+                          ::Rack::ShowExceptions, Rack::Lint, Shotgun::Static]
       }
 
       @server.middleware.must_equal(expected)

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1,0 +1,17 @@
+require_relative 'test_helper'
+require 'hanami/server'
+
+describe 'Server' do
+
+  it 'adds Shotgun::Static when code reloading is enabled' do
+    middlewares = Hanami::Server.new(code_reloading: true).middleware['development'].map(&:name)
+    middlewares.must_include('Shotgun::Static')
+  end
+
+  it 'does not add Shotgun::Static when code reloading is disabled' do
+    middlewares = Hanami::Server.new(code_reloading: false).middleware['development'].map(&:name)
+    middlewares.wont_include('Shotgun::Static')
+  end
+
+
+end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1,8 +1,7 @@
-require_relative 'test_helper'
+require 'test_helper'
 require 'hanami/server'
 
 describe 'Server' do
-
   it 'adds Shotgun::Static when code reloading is enabled' do
     middlewares = Hanami::Server.new(code_reloading: true).middleware['development'].map(&:name)
     middlewares.must_include('Shotgun::Static')
@@ -12,6 +11,4 @@ describe 'Server' do
     middlewares = Hanami::Server.new(code_reloading: false).middleware['development'].map(&:name)
     middlewares.wont_include('Shotgun::Static')
   end
-
-
 end


### PR DESCRIPTION
This fixes https://github.com/hanami/hanami/issues/572 as discussed on gitter.

Before:

<img width="1892" alt="bildschirmfoto 2016-05-19 um 19 48 02" src="https://cloud.githubusercontent.com/assets/16653/15403993/d500d166-1dfb-11e6-806e-19aca6f38a17.png">

After:
<img width="1920" alt="bildschirmfoto 2016-05-19 um 19 59 40" src="https://cloud.githubusercontent.com/assets/16653/15404097/4355f952-1dfc-11e6-9dda-3d1bc843d0f6.png">


(Tested with https://github.com/apotonick/gemgem-hanami)