### PR TITLE
Add Shotgun::Static when code_reloading is enabled.

### DIFF
--- a/lib/hanami/commands/server.rb
+++ b/lib/hanami/commands/server.rb
@@ -41,6 +41,7 @@ module Hanami
         mw = Hash.new { |e, m| e[m] = [] }
         mw["deployment"].concat([::Rack::ContentLength, ::Rack::CommonLogger])
         mw["development"].concat(mw["deployment"] + [::Rack::ShowExceptions, ::Rack::Lint])
+        mw["development"].push(::Shotgun::Static) if code_reloading?
         mw
       end
 

--- a/test/commands/server_test.rb
+++ b/test/commands/server_test.rb
@@ -19,10 +19,34 @@ describe Hanami::Commands::Server do
       expected = {
         'deployment'  => [::Rack::ContentLength, ::Rack::CommonLogger],
         'development' => [::Rack::ContentLength, ::Rack::CommonLogger,
-                          ::Rack::ShowExceptions, Rack::Lint]
+                          ::Rack::ShowExceptions, Rack::Lint, Shotgun::Static]
       }
 
       @server.middleware.must_equal(expected)
+    end
+  end
+
+  describe 'Shotgun::Static' do
+    it 'is added when code_reloading is enabled' do
+      server = Hanami::Commands::Server.new(code_reloading: true)
+      expected = {
+        'deployment'  => [::Rack::ContentLength, ::Rack::CommonLogger],
+        'development' => [::Rack::ContentLength, ::Rack::CommonLogger,
+                          ::Rack::ShowExceptions, Rack::Lint, Shotgun::Static]
+      }
+
+      server.middleware.must_equal(expected)
+    end
+
+    it 'is not added when code_reloading is disabled' do
+      server = Hanami::Commands::Server.new(code_reloading: false)
+      expected = {
+        'deployment'  => [::Rack::ContentLength, ::Rack::CommonLogger],
+        'development' => [::Rack::ContentLength, ::Rack::CommonLogger,
+                          ::Rack::ShowExceptions, Rack::Lint]
+      }
+
+      server.middleware.must_equal(expected)
     end
   end
 


### PR DESCRIPTION
Backport of the Shotgun::Static fix for slow static assets.

(Similar fix already applied in https://github.com/hanami/hanami/pull/573 for master).

Before:
<img width="1533" alt="bildschirmfoto 2016-05-20 um 16 18 01" src="https://cloud.githubusercontent.com/assets/16653/15430776/18544d84-1ea7-11e6-877f-24666684a85b.png">

After:

<img width="1532" alt="bildschirmfoto 2016-05-20 um 16 17 45" src="https://cloud.githubusercontent.com/assets/16653/15430781/1f9b070e-1ea7-11e6-8c26-e1c160079feb.png">

