### PR TITLE
Fix NilClass error when CSRF token is not passed in params

### DIFF
--- a/lib/hanami/action/csrf_protection.rb
+++ b/lib/hanami/action/csrf_protection.rb
@@ -118,7 +118,7 @@ module Hanami
       # @since 0.4.0
       # @api private
       def verify_csrf_token
-        handle_invalid_csrf_token if invalid_csrf_token?
+        handle_invalid_csrf_token if verify_csrf_token? && invalid_csrf_token?
       end
 
       # Verify if CSRF token from params, matches the one stored in session.
@@ -128,8 +128,15 @@ module Hanami
       # @since 0.4.0
       # @api private
       def invalid_csrf_token?
-        verify_csrf_token? &&
+        missing_csrf_token? ||
           ! ::Rack::Utils.secure_compare(session[CSRF_TOKEN], params[CSRF_TOKEN])
+      end
+
+      # Verify the CSRF token was passed in params.
+      #
+      # @api private
+      def missing_csrf_token?
+        Hanami::Utils::Blank.blank?(params[CSRF_TOKEN])
       end
 
       # Generates a random CSRF Token

--- a/test/controller/csrf_protection_test.rb
+++ b/test/controller/csrf_protection_test.rb
@@ -102,6 +102,12 @@ describe Hanami::Action::CSRFProtection do
           -> { @action.call(env) }.must_raise Hanami::Action::InvalidCSRFTokenError
           @action.__send__(:session).must_be :empty? # reset session
         end
+
+        it "raises error if token isn't sent (#{ verb })" do
+          env = Rack::MockRequest.env_for('/', method: verb)
+
+          -> { @action.call(env) }.must_raise Hanami::Action::InvalidCSRFTokenError
+        end
       end
     end
   end


### PR DESCRIPTION
Presently if no CSRF token is passed when making a CSRF verified request, an nil error is raised from calling `Rack::Utils.secure_compare(session['_csrf_token'], nil)`. This adds a check on the CSRF token parameter being empty, and raises the proper `InvalidCSRFTokenError`.

##### Current stack trace when CSRF token is blank: 
```
NoMethodError: undefined method `bytesize' for nil:NilClass

/usr/local/rvm/gems/ruby-2.3.1@quizard/gems/rack-1.6.4/lib/rack/utils.rb:369:in `bytesize'
/usr/local/rvm/gems/ruby-2.3.1@quizard/gems/rack-1.6.4/lib/rack/utils.rb:439:in `secure_compare'
/usr/local/rvm/gems/ruby-2.3.1@quizard/gems/hanami-0.7.2/lib/hanami/action/csrf_protection.rb:132:in `invalid_csrf_token?'
/usr/local/rvm/gems/ruby-2.3.1@quizard/gems/hanami-0.7.2/lib/hanami/action/csrf_protection.rb:121:in `verify_csrf_token'
```