### PR TITLE
Allow to specify a target path while generating new app

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -94,6 +94,7 @@ module Hanami
 
       $ > hanami new fancy_app --hanami-head=true
     EOS
+    method_option :path, desc: 'Target path'
     method_option :database, aliases: ['-d', '--db'], desc: "Application database (#{Hanami::Generators::DatabaseConfig::SUPPORTED_ENGINES.keys.join('/')})", default: Hanami::Generators::DatabaseConfig::DEFAULT_ENGINE
     method_option :architecture, aliases: ['-a', '--arch'], desc: 'Project architecture (container/app)', default: Hanami::Commands::New::Abstract::DEFAULT_ARCHITECTURE
     method_option :application_name, desc: 'Application name, only for container', default: Hanami::Commands::New::Container::DEFAULT_APPLICATION_NAME

--- a/lib/hanami/commands/new/abstract.rb
+++ b/lib/hanami/commands/new/abstract.rb
@@ -40,7 +40,7 @@ module Hanami
           FileUtils.mkdir_p(application_name)
           Dir.chdir(application_name) do
             @target_path = Pathname.pwd
-            
+
             super
           end
         end

--- a/lib/hanami/commands/new/abstract.rb
+++ b/lib/hanami/commands/new/abstract.rb
@@ -36,11 +36,11 @@ module Hanami
 
         def start
           path = options[:path] || '.'
-          application_name = "#{path}/#{app_name}"
+          application_name = File.join(path, app_name)
           FileUtils.mkdir_p(application_name)
           Dir.chdir(application_name) do
             @target_path = Pathname.pwd
-
+            
             super
           end
         end

--- a/lib/hanami/commands/new/abstract.rb
+++ b/lib/hanami/commands/new/abstract.rb
@@ -35,8 +35,10 @@ module Hanami
         end
 
         def start
-          FileUtils.mkdir_p(app_name)
-          Dir.chdir(app_name) do
+          path = options[:path] || '.'
+          application_name = "#{path}/#{app_name}"
+          FileUtils.mkdir_p(application_name)
+          Dir.chdir(application_name) do
             @target_path = Pathname.pwd
 
             super


### PR DESCRIPTION
With this I can be at `/Users/psantos/Desktop` location, and run the following:

> $ hanami new bookshelf --path=/Users/psantos/Workspace/learning/learning_ruby_and_hanami

And my application will be generated at this location: `/Users/psantos/Workspace/learning/learning_ruby_and_hanami`