### PR TITLE
Optimize route helpers by defining actual methods after being called once

### DIFF
--- a/lib/hanami/routes.rb
+++ b/lib/hanami/routes.rb
@@ -139,10 +139,18 @@ module Hanami
     # @since 0.3.0
     # @api private
     def method_missing(m, *args)
-      named_route, type = m.to_s.split(/\_(path|url)\z/)
+      name, type = m.to_s.split(/\_(path|url)\z/)
 
-      if type
-        public_send(type, named_route.to_sym, *args)
+      if %w(path url).include? type
+        result = public_send(type.to_sym, name.to_sym, *args)
+
+        instance_eval <<-CODE
+          def #{m}(*args)
+            #{type}(:#{name.inspect}, *args)
+          end
+        CODE
+
+        result
       else
         super
       end


### PR DESCRIPTION
I'd like to get feedback if this is a worthy optimization.

This update _caches_ route helper methods by defining an actual method whenever a dynamic route helper is called. This way, multiple successive calls to `method_missing` to call a particular route helper is unnecessary when running on the same process.

Example:

```ruby
routes.books_path #=> First call is slow. Evaluated via #method_missing
routes.books_path #=> Second call is fast. Calls actual #books_path method
```