### PR TITLE
[WIP] Add logger for all requests

### DIFF
--- a/lib/hanami/common_logger.rb
+++ b/lib/hanami/common_logger.rb
@@ -1,0 +1,47 @@
+module Hanami
+  class CommonLogger < ::Rack::CommonLogger
+    def call(env)
+      began_at = Time.now
+      status, header, body = @app.call(env)
+      log(env, status, header, began_at)
+      [status, header, body]
+    end
+
+  private
+
+    def log(env, status, header, began_at)
+      now = Time.now
+      length = extract_content_length(header)
+
+      msg = {
+        addr: env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_ADDR'],
+        user: env["REMOTE_USER"],
+        now_time: now.strftime("%d/%b/%Y:%H:%M:%S %z"),
+        request_method: env['REQUEST_METHOD'],
+        path: env['PATH_INFO'],
+        query_string: env['QUERY_STRING'].empty? ? nil : "?#{env['QUERY_STRING']}",
+        http_version: env['HTTP_VERSION'],
+        status: status.to_s[0..3],
+        length: length,
+        time: now - began_at
+      }
+
+      # Standard library logger doesn't support write but it supports << which actually
+      # calls to write on the log device without formatting
+      @logger.log(@logger.level, msg)
+    end
+
+    def extract_content_length(headers)
+      value = headers['Content-Length'] or return
+      value.to_s == '0' ? nil : value
+    end
+  end
+end
+
+module Rack
+  class CommonLogger
+    def call(env)
+      @app.call(env)
+    end
+  end
+end

--- a/lib/hanami/common_logger.rb
+++ b/lib/hanami/common_logger.rb
@@ -21,7 +21,7 @@ module Hanami
         request_method: env['REQUEST_METHOD'],
         path: env['PATH_INFO'] + query_string(env),
         http_version: env['HTTP_VERSION'],
-        length: extract_content_length(headers),
+        length: extract_content_length(header),
         status: status.to_s[0..3],
         time: now - began_at
       }
@@ -35,8 +35,8 @@ module Hanami
       env['QUERY_STRING'].empty? ? EMPTY_STRING : "?#{env['QUERY_STRING']}"
     end
 
-    def extract_content_length(headers)
-      value = headers['Content-Length'] or return
+    def extract_content_length(header)
+      value = header['Content-Length'] or return
       value.to_s == '0' ? nil : value
     end
   end

--- a/lib/hanami/common_logger.rb
+++ b/lib/hanami/common_logger.rb
@@ -1,6 +1,7 @@
 module Hanami
   class CommonLogger < ::Rack::CommonLogger
     EMPTY_STRING = ''.freeze
+    ROOT_PATH = '/'.freeze
 
     def call(env)
       began_at = Time.now
@@ -13,31 +14,39 @@ module Hanami
   private
 
     def log(env, status, header, began_at)
-      now = Time.now
-
-      msg = {
-        addr: env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_ADDR'],
-        now_time: now.strftime("'%d/%b/%Y %H:%M:%S %z'"),
-        request_method: env['REQUEST_METHOD'],
-        path: env['PATH_INFO'] + query_string(env),
-        http_version: env['HTTP_VERSION'],
-        length: extract_content_length(header),
-        status: status.to_s[0..3],
-        time: now - began_at
-      }
+      msg = generate_message(env, status, began_at)
+      length = extract_content_length(header)
+      msg[:length] = length if length
 
       # Standard library logger doesn't support write but it supports << which actually
       # calls to write on the log device without formatting
       @logger.log(@logger.level, msg)
     end
 
-    def query_string(env)
-      env['QUERY_STRING'].empty? ? EMPTY_STRING : "?#{env['QUERY_STRING']}"
+    def full_path(env)
+      path = env['PATH_INFO'].empty? ? ROOT_PATH : env['PATH_INFO']
+      query = env['QUERY_STRING'].empty? ? EMPTY_STRING : "?#{env['QUERY_STRING']}"
+
+      path + query
     end
 
     def extract_content_length(header)
-      value = header['Content-Length'] or return
+      value = header['Content-Length'] || return
       value.to_s == '0' ? nil : value
+    end
+
+    def generate_message(env, status, began_at)
+      now = Time.now
+
+      {
+        addr: env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_ADDR'],
+        now_time: now.strftime("'%d/%b/%Y %H:%M:%S %z'"),
+        request_method: env['REQUEST_METHOD'],
+        path: full_path(env).inspect,
+        http_version: env['HTTP_VERSION'],
+        status: status.to_s[0..3],
+        time: now - began_at
+      }
     end
   end
 end

--- a/lib/hanami/middleware.rb
+++ b/lib/hanami/middleware.rb
@@ -1,3 +1,5 @@
+require 'hanami/common_logger'
+
 module Hanami
   # Rack middleware stack for an application
   #
@@ -101,6 +103,7 @@ module Hanami
         _load_session_middleware
         _load_default_welcome_page_for(application)
         _load_method_override_middleware
+        _load_common_logger(application)
 
         true
       end
@@ -149,6 +152,20 @@ module Hanami
       if !env.container?
         use Rack::MethodOverride
       end
+    end
+
+    # Use CommonLogger middleware
+    #
+    # @api private
+    # @since x.x.x
+    def _load_common_logger(application)
+      # application_module ||= Utils::Class.load!(
+      #   Utils::String.new(application.name).namespace
+      # )
+      #
+      # use Hanami::CommonLogger, application_module.const_get('Logger')
+
+      use Hanami::CommonLogger, @configuration.logger.build
     end
   end
 end


### PR DESCRIPTION
This work in progress PR provide simple way for log requests. I created custom `CommonLogger` middleware and use it in hanami middleware stack. On my local machine it looks like this:

```
[2016-05-31 02:02:50] INFO  WEBrick 1.3.1
[2016-05-31 02:02:50] INFO  ruby 2.3.0 (2015-12-25) [x86_64-darwin15]
[2016-05-31 02:02:50] INFO  WEBrick::HTTPServer#start: pid=66815 port=2300
app=Web severity=DEBUG time=0.009833 addr=::1  now_time=31/May/2016:02:02:51 +0300 request_method=GET path=  http_version=HTTP/1.1 status=200
app=Web severity=DEBUG time=0.004552 addr=::1  now_time=31/May/2016:02:03:14 +0300 request_method=GET path=  http_version=HTTP/1.1 status=200
[2016-05-31 02:06:30] INFO  going to shutdown ...
[2016-05-31 02:06:30] INFO  WEBrick::HTTPServer#start done.
```

As you can see all looks good but I found that each web server have a special start logger format. If we want to change this we need redefine logger in each server.

Any ideas for server logger?

/cc @jodosha, @joneslee85 and @hanami/contributors 
