### PR TITLE
Remove require 'rubygems'

### DIFF
--- a/lib/hanami/generators/application/app/config/environment.rb.tt
+++ b/lib/hanami/generators/application/app/config/environment.rb.tt
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/<%= config[:app_name] %>'

--- a/lib/hanami/generators/application/container/config/environment.rb.tt
+++ b/lib/hanami/generators/application/container/config/environment.rb.tt
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/<%= config[:app_name] %>'

--- a/test/fixtures/cdn/cdn/config/environment.rb
+++ b/test/fixtures/cdn/cdn/config/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/cdn'

--- a/test/fixtures/cdn/cdn_app/config/environment.rb
+++ b/test/fixtures/cdn/cdn_app/config/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/cdn_app'

--- a/test/fixtures/commands/application/new_app/config/environment.rb
+++ b/test/fixtures/commands/application/new_app/config/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/new_app'

--- a/test/fixtures/commands/application/new_container/config/environment.rb
+++ b/test/fixtures/commands/application/new_container/config/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/new_container'

--- a/test/fixtures/commands/application/new_container/config/environment_mypath.rb
+++ b/test/fixtures/commands/application/new_container/config/environment_mypath.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/new_container'

--- a/test/fixtures/commands/generate/app/environment.rb
+++ b/test/fixtures/commands/generate/app/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/container-app'

--- a/test/fixtures/commands/generate/app/environment_with_app_added.rb
+++ b/test/fixtures/commands/generate/app/environment_with_app_added.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/container-app'

--- a/test/fixtures/commands/generate/app/environment_with_app_added_url.rb
+++ b/test/fixtures/commands/generate/app/environment_with_app_added_url.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/container-app'

--- a/test/fixtures/rake/rake_tasks/config/environment.rb
+++ b/test/fixtures/rake/rake_tasks/config/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/rake_tasks'

--- a/test/fixtures/rake/rake_tasks_app/config/environment.rb
+++ b/test/fixtures/rake/rake_tasks_app/config/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require_relative '../lib/rake_tasks_app'

--- a/test/fixtures/static_assets/config/environment.rb
+++ b/test/fixtures/static_assets/config/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require 'tilt/sass'

--- a/test/fixtures/static_assets_app/config/environment.rb
+++ b/test/fixtures/static_assets_app/config/environment.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'hanami/setup'
 require 'tilt/sass'

--- a/test/support/helper.rb
+++ b/test/support/helper.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler/setup'
 
 # Autoloading 'tilt/erb' in a non thread-safe way


### PR DESCRIPTION
Hanami supports MRI 2+ and the gem system is built-in since 1.9.
Do we still need loading it explicitly?

All tests are passing without the lines (except `S`s)