### PR TITLE
Allow views to render any HTTP status code.

### DIFF
--- a/lib/hanami/views/default.rb
+++ b/lib/hanami/views/default.rb
@@ -16,7 +16,7 @@ module Hanami
       template 'default'
 
       def title
-        response[2].first
+        response[2].first || Http::Status.message_for(response[0])
       end
 
       def self.render(root, template_name, context)

--- a/lib/hanami/views/null_view.rb
+++ b/lib/hanami/views/null_view.rb
@@ -5,12 +5,8 @@ module Hanami
     # @since 0.1.0
     # @api private
     class NullView
-      def initialize(body)
-        @body = body
-      end
-
       def render(_context)
-        @body
+        nil
       end
     end
   end

--- a/test/fixtures/collaboration/apps/web/app/controllers/reviews.rb
+++ b/test/fixtures/collaboration/apps/web/app/controllers/reviews.rb
@@ -1,0 +1,45 @@
+module Collaboration::Controllers::Reviews
+  class Create
+    include Collaboration::Action
+
+    def call(_params)
+      # pretend it was going to persist
+      self.status = 201
+    end
+
+    private
+
+    def verify_csrf_token?
+      false
+    end
+  end
+
+  class Show
+    include Collaboration::Action
+    expose :review
+
+    def call(_params)
+      self.status = 404
+    end
+
+    private
+
+    def verify_csrf_token?
+      false
+    end
+  end
+
+  class Update
+    include Collaboration::Action
+
+    def call(_params)
+      self.status = 422
+    end
+
+    private
+
+    def verify_csrf_token?
+      false
+    end
+  end
+end

--- a/test/fixtures/collaboration/apps/web/app/templates/418.html.erb
+++ b/test/fixtures/collaboration/apps/web/app/templates/418.html.erb
@@ -5,5 +5,6 @@
   </head>
   <body>
     <h1><%= title %> (<%= response[0] %>)</h1>
+    <h2>Additional informations</h2>
   </body>
 </html>

--- a/test/fixtures/collaboration/apps/web/app/templates/reviews/create.html.erb
+++ b/test/fixtures/collaboration/apps/web/app/templates/reviews/create.html.erb
@@ -1,0 +1,1 @@
+<h1>New Review</h1>

--- a/test/fixtures/collaboration/apps/web/app/templates/reviews/show.html.erb
+++ b/test/fixtures/collaboration/apps/web/app/templates/reviews/show.html.erb
@@ -1,0 +1,6 @@
+<% if review.nil? %>
+  <h1>Missing Review</h1>
+  <div>Hey, I can't find the review!</div>
+<% else %>
+  <h1><%= review.title %></h1>
+<% end %>

--- a/test/fixtures/collaboration/apps/web/app/templates/reviews/update.html.erb
+++ b/test/fixtures/collaboration/apps/web/app/templates/reviews/update.html.erb
@@ -1,0 +1,2 @@
+<h1>A Review</h1>
+<div>Invalid data</div>

--- a/test/fixtures/collaboration/apps/web/app/views/reviews/create.rb
+++ b/test/fixtures/collaboration/apps/web/app/views/reviews/create.rb
@@ -1,0 +1,5 @@
+module Collaboration::Views::Reviews
+  class Create
+    include Collaboration::View
+  end
+end

--- a/test/fixtures/collaboration/apps/web/app/views/reviews/show.rb
+++ b/test/fixtures/collaboration/apps/web/app/views/reviews/show.rb
@@ -1,0 +1,5 @@
+module Collaboration::Views::Reviews
+  class Show
+    include Collaboration::View
+  end
+end

--- a/test/fixtures/collaboration/apps/web/app/views/reviews/update.rb
+++ b/test/fixtures/collaboration/apps/web/app/views/reviews/update.rb
@@ -1,0 +1,5 @@
+module Collaboration::Views::Reviews
+  class Update
+    include Collaboration::View
+  end
+end

--- a/test/fixtures/collaboration/apps/web/config/routes.rb
+++ b/test/fixtures/collaboration/apps/web/config/routes.rb
@@ -12,3 +12,4 @@ redirect '/legacy',   to: '/'
 
 resources :books
 resources :authors, only: [:create, :update, :destroy]
+resources :reviews, only: [:create, :update, :show]

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -29,6 +29,32 @@ describe 'A full stack Hanami application' do
     response.body.must_match %(<h1>Welcome</h1>)
   end
 
+  it 'returns a successful response for created resource' do
+    post '/reviews', text: 'blah'
+
+    response.status.must_equal 201
+    response.body.must_match %(<title>Collaboration</title>)
+    response.body.must_match %(<h1>New Review</h1>)
+  end
+
+  it 'renders view for not found entity' do
+    get '/reviews/1'
+
+    response.status.must_equal 404
+    response.body.must_match %(<title>Collaboration</title>)
+    response.body.must_match %(<h1>Missing Review</h1>)
+    response.body.must_match %(<div>Hey, I can't find the review!</div>)
+  end
+
+  it 'renders view for unprocessable entity' do
+    patch '/reviews/1', text: 'blah'
+
+    response.status.must_equal 422
+    response.body.must_match %(<title>Collaboration</title>)
+    response.body.must_match %(<h1>A Review</h1>)
+    response.body.must_match %(<div>Invalid data</div>)
+  end
+
   it "when user provided a custom template, it renders a custom page" do
     request '/custom_error', 'HTTP_ACCEPT' => 'text/html'
 
@@ -36,6 +62,7 @@ describe 'A full stack Hanami application' do
 
     response.body.must_match %(<title>I&apos;m a teapot</title>)
     response.body.must_match %(<h1>I&apos;m a teapot (418)</h1>)
+    response.body.must_match %(<h2>Additional informations</h2>)
   end
 
   it "when html, it renders a custom page for not found resources" do
@@ -228,4 +255,3 @@ describe 'A full stack Hanami application' do
     response.headers['Location'].must_equal '/action_legacy'
   end
 end
-


### PR DESCRIPTION
## Use Cases

### I want to show a page for a book.

Be sure to have an action, a view and a template. This is the default use case.

### I want to show a generic, application wide 404 page for a not found book.

If the book is not found, from the action `halt(404)`.

### I want to show a custom, application wide 404 page for a not found book.

Create a `apps/web/templates/404.html.erb` template and from the action: `halt(404)`.

### I want to show a custom 404 page **only** for not found books.

From the action `self.status = 404`, and then manage the `nil` book from the view/template.

```erb
# apps/web/templates/books/show.html.erb
<% if book.nil? %>
  <h1>Hey, I can't find the book!</h1>
<% else %>
  <!-- ... -->
<% end %>
```

### I want exceptions to be managed by a generic, application wide 500 page.

This is already handled by Hanami.

### I want exceptions to be managed by a custom, application wide 500 page.

Create a `apps/web/templates/500.html.erb` template.

### I want exceptions to be managed by a specific page for a specific action

Make sure to handle exceptions in that action, with an exception handler. Then just assign the status.

```ruby
module Web::Controllers::Books
  class Create
    include Web::Action
    handle_exception FooError => :handle_foo_error

     def call(params)
    raise FooError.new
  end

  private

  def handle_foo_error(exception)
    self.status = 500
  end
end
```

Then handle the exception in the corresponding view/template.

```erb
# apps/web/templates/books/create.html.erb
<h1>Oh no!</h1>
```

### I want to return a 422 when validations fails

Ensure to set the status `self.status = 422`, and in the corresponding view indicate the template to render.

```ruby
module Web::Controllers::Books
  class Create
    include Web::Action

   def call(params)
      if params.valid?
      else
        self.status = 422
      end
    end
  end
end
```

```ruby
module Web::Views::Books
  class Create
    include Web::View
    template 'books/new'
  end
end
```

Please note that `params` will be used to fill form fields.

---

The bottom line is: use `#halt` to terminate the control flow and render immediately a generic page. For more control use `#status=`.

---

Closes #509 

@hanami/core-team @hanami/contributors Please review.