### PR TITLE
Propose an alternate default CSP policy

### DIFF
--- a/lib/hanami/generators/app/application.rb.tt
+++ b/lib/hanami/generators/app/application.rb.tt
@@ -214,7 +214,7 @@ module <%= config[:classified_app_name] %>
         img-src 'self' https: data:;
         style-src 'self' 'unsafe-inline' https:;
         font-src 'self';
-        object-src 'none'; 
+        object-src 'none';
         plugin-types application/pdf;
         child-src 'self';
         frame-src 'self';

--- a/lib/hanami/generators/app/application.rb.tt
+++ b/lib/hanami/generators/app/application.rb.tt
@@ -206,17 +206,15 @@ module <%= config[:classified_app_name] %>
       #
       security.content_security_policy %{
         form-action 'self';
-        referrer origin-when-cross-origin;
-        reflected-xss block;
         frame-ancestors 'self';
         base-uri 'self';
         default-src 'none';
         script-src 'self';
         connect-src 'self';
-        img-src 'self';
-        style-src 'self';
+        img-src 'self' https: data:;
+        style-src 'self' 'unsafe-inline' https:;
         font-src 'self';
-        object-src 'self';
+        object-src 'none'; 
         plugin-types application/pdf;
         child-src 'self';
         frame-src 'self';

--- a/test/fixtures/commands/generate/app/application.rb
+++ b/test/fixtures/commands/generate/app/application.rb
@@ -206,17 +206,15 @@ module Admin
       #
       security.content_security_policy %{
         form-action 'self';
-        referrer origin-when-cross-origin;
-        reflected-xss block;
         frame-ancestors 'self';
         base-uri 'self';
         default-src 'none';
         script-src 'self';
         connect-src 'self';
-        img-src 'self';
-        style-src 'self';
+        img-src 'self https: data:';
+        style-src 'self 'unsafe-inline' https:;
         font-src 'self';
-        object-src 'self';
+        object-src 'none';
         plugin-types application/pdf;
         child-src 'self';
         frame-src 'self';

--- a/test/fixtures/commands/generate/app/application.rb
+++ b/test/fixtures/commands/generate/app/application.rb
@@ -211,8 +211,8 @@ module Admin
         default-src 'none';
         script-src 'self';
         connect-src 'self';
-        img-src 'self https: data:';
-        style-src 'self 'unsafe-inline' https:;
+        img-src 'self' https: data:;
+        style-src 'self' 'unsafe-inline' https:;
         font-src 'self';
         object-src 'none';
         plugin-types application/pdf;


### PR DESCRIPTION
First off, I want to congratulate y'all on applying a default CSP. The concept of CSP as a default has amazing returns. I've seen orgs gradually grasp content security policy while applying it over time simply because it was a default and opting out required thought (and approval).

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/hanamirb">@hanamirb</a> respectfully I think an unrealistic policy will cause people to disable csp. I&#39;ll submit a pr for discussion.</p>&mdash; neil matatall (@ndm) <a href="https://twitter.com/ndm/status/748798325931913217">July 1, 2016</a></blockquote>

This is a follow up to https://twitter.com/ndm/status/748798325931913217 and is related to https://github.com/rails/rails/pull/24961 where I proposed a default CSP, but the idea was rejected due to lack of a CSP management API. The proposed policies are not the same and there is some room for debate. A lot of the reasoning comes from [GitHub's CSP Journey](http://githubengineering.com/githubs-csp-journey/).

With the exception of `object-src` becoming `'none'`, this policy should be a non-breaking change for applications. Considering it's in a generator, there's less risk of breaking things.

Reasonings:
- Changing `object-src` to `'none'` - `object-src` is very dangerous. Using a value of `'self'` opens up a lot of cross-origin bypasses mostly via flash or pdf bugs.
- `img-src` gets `https data:` added - while sourcing 3rd party images can lead to defacement if the underlying tags reference undesirable content, the goal here is to eliminated mixed content. `data:` is safe as a default.
- `style-src` gets `'unsafe-inline' https:'` - while "scriptless" attacks exist, restricting inline style is not a realistic goal. So much so that a 3rd `'unsafe'` value had been discussed but it was too complex and nobody cared enough to make it happen. Inline styles are safe enough. Similarly, almost any style is safe from a security point of view so let's just prevent mixed content here too.
- Removing `referrer` and `reflected-xss` - these are non-standard at this point. I don't think these are well supported either. Glad to add these back.

More proposed changes:
- (breaking change) default `script-src` to be `https:` - using `'self'` opens you up to jsonp attacks. In a lot of cases, people bundle assets on a CDN. Using `'self'` is mostly for convenience when developing locally. While closing the jsonp loophole is nice, maybe allowing any `https` worse. Using Subresource integrity with CSP alleviates the risk of using the broad `https:` value.
- Adding `https: data;` to font-src - this is _mostly_ safe.