### PR TITLE
X-Content-Type-Options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ if !ENV['TRAVIS']
 end
 
 gem 'sass'
+gem 'i18n'
 gem 'hanami-utils',       '~> 0.8', require: false, github: 'hanami/utils',       branch: '0.8.x'
 gem 'hanami-validations', '~> 0.6', require: false, github: 'hanami/validations', branch: '0.6.x'
 gem 'hanami-router',      '~> 0.7', require: false, github: 'hanami/router',      branch: '0.7.x'

--- a/lib/hanami/config/security.rb
+++ b/lib/hanami/config/security.rb
@@ -10,6 +10,12 @@ module Hanami
       # @see Hanami::Loader#_configure_controller_framework!
       X_FRAME_OPTIONS_HEADER = 'X-Frame-Options'.freeze
 
+      # @since x.x.x
+      # @api private
+      #
+      # @see Hanami::Loader#_configure_controller_framework!
+      X_CONTENT_TYPE_OPTIONS_HEADER = 'X-Content-Type-Options'.freeze
+
       # @since 0.3.0
       # @api private
       #
@@ -40,6 +46,25 @@ module Hanami
           @x_frame_options
         else
           @x_frame_options = value
+        end
+      end
+
+      # X-Content-Type-Options headers' value
+      #
+      # @overload x_content_type_options(value)
+      #   Sets the given value
+      #   @param value [String] for X-Content-Type-Options header.
+      #
+      # @overload x_content_type_options
+      #   Gets the value
+      #   @return [String] X-Content-Type-Options header's value
+      #
+      # @since x.x.x
+      def x_content_type_options(value = nil)
+        if value.nil?
+          @x_content_type_options
+        else
+          @x_content_type_options = value
         end
       end
 

--- a/lib/hanami/generators/app/application.rb.tt
+++ b/lib/hanami/generators/app/application.rb.tt
@@ -169,6 +169,17 @@ module <%= config[:classified_app_name] %>
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/lib/hanami/generators/application/app/config/application.rb.tt
+++ b/lib/hanami/generators/application/app/config/application.rb.tt
@@ -166,6 +166,17 @@ module <%= config[:classified_app_name] %>
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/lib/hanami/loader.rb
+++ b/lib/hanami/loader.rb
@@ -58,6 +58,7 @@ module Hanami
           default_response_format config.default_response_format
           default_headers({
             Hanami::Config::Security::X_FRAME_OPTIONS_HEADER         => config.security.x_frame_options,
+            Hanami::Config::Security::X_CONTENT_TYPE_OPTIONS_HEADER  => config.security.x_content_type_options,
             Hanami::Config::Security::CONTENT_SECURITY_POLICY_HEADER => config.security.content_security_policy,
           })
           default_headers.merge!(STRICT_TRANSPORT_SECURITY_HEADER => STRICT_TRANSPORT_SECURITY_DEFAULT_VALUE) if config.force_ssl

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -41,6 +41,7 @@ module CoffeeShop
       default_response_format :html
 
       security.x_frame_options "DENY"
+      security.x_content_type_options "nosniff"
       security.content_security_policy %{
         form-action 'self';
         referrer origin-when-cross-origin;

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,3 +1,4 @@
+require 'hanami/validations'
 require 'hanami/model'
 require 'hanami/mailer'
 

--- a/test/fixtures/cdn/cdn/apps/web/application.rb
+++ b/test/fixtures/cdn/cdn/apps/web/application.rb
@@ -146,6 +146,17 @@ module Web
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/fixtures/cdn/cdn_app/config/application.rb
+++ b/test/fixtures/cdn/cdn_app/config/application.rb
@@ -143,6 +143,17 @@ module CdnApp
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/fixtures/commands/application/new_app/config/application.rb
+++ b/test/fixtures/commands/application/new_app/config/application.rb
@@ -166,6 +166,17 @@ module NewApp
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/fixtures/commands/generate/app/application.rb
+++ b/test/fixtures/commands/generate/app/application.rb
@@ -169,6 +169,17 @@ module Admin
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/fixtures/rake/rake_tasks/apps/web/application.rb
+++ b/test/fixtures/rake/rake_tasks/apps/web/application.rb
@@ -169,6 +169,17 @@ module Web
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/fixtures/rake/rake_tasks_app/config/application.rb
+++ b/test/fixtures/rake/rake_tasks_app/config/application.rb
@@ -166,6 +166,17 @@ module RakeTasksApp
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/fixtures/security_headers/apps/web/application.rb
+++ b/test/fixtures/security_headers/apps/web/application.rb
@@ -31,6 +31,7 @@ module SecurityHeaders
       routes  'config/routes'
 
       security.x_frame_options 'ALLOW ALL'
+      security.x_content_type_options ''
       security.content_security_policy "script-src 'self' https://apis.google.com"
 
       adapter type: :sql, uri: SECURITY_HEADERS_SQLITE_CONNECTION_STRING

--- a/test/fixtures/static_assets/apps/admin/application.rb
+++ b/test/fixtures/static_assets/apps/admin/application.rb
@@ -145,6 +145,17 @@ module Admin
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/fixtures/static_assets/apps/web/application.rb
+++ b/test/fixtures/static_assets/apps/web/application.rb
@@ -146,6 +146,17 @@ module Web
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/fixtures/static_assets_app/config/application.rb
+++ b/test/fixtures/static_assets_app/config/application.rb
@@ -142,6 +142,17 @@ module StaticAssetsApp
       #
       security.x_frame_options 'DENY'
 
+      # X-Content-Type-Options prevents browsers from interpreting files as
+      # something else than declared by the content type in the HTTP headers.
+      #
+      # Read more at:
+      #
+      #   * https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-Content-Type-Options
+      #   * https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+      #   * https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update
+      #
+      security.x_content_type_options 'nosniff'
+
       # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
       # It determines trusted sources of execution for dynamic contents
       # (JavaScript) or other web related assets: stylesheets, images, fonts,

--- a/test/integration/headers_test.rb
+++ b/test/integration/headers_test.rb
@@ -30,6 +30,7 @@ describe 'A full stack Hanami application' do
       get '/'
 
       response.headers.key?('X-Frame-Options').must_equal         false
+      response.headers.key?('X-Content-Type-Options').must_equal  false
       response.headers.key?('Content-Security-Policy').must_equal false
     end
   end
@@ -60,6 +61,7 @@ describe 'A full stack Hanami application' do
       get '/'
 
       response.headers['X-Frame-Options'].must_equal 'ALLOW ALL'
+      response.headers['X-Content-Type-Options'].must_equal ''
       response.headers['Content-Security-Policy'].must_equal "script-src 'self' https://apis.google.com"
     end
   end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -49,6 +49,7 @@ describe Hanami::Loader do
         CoffeeShop::Controller.configuration.default_headers.
           must_equal({
             "X-Frame-Options" => "DENY",
+            "X-Content-Type-Options" => "nosniff",
             "Content-Security-Policy" => "form-action 'self'; referrer origin-when-cross-origin; reflected-xss block; frame-ancestors 'self'; base-uri 'self'; default-src 'none'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'; plugin-types application/pdf; child-src 'self'; frame-src 'self'; media-src 'self'",
           })
       end


### PR DESCRIPTION
Include `X-Content-Type-Options: nosniff` in default response headers.

Ref #604