### PR TITLE
Tiny improvement imporvement. Use tr instead gsub

### DIFF
--- a/lib/hanami/assets/asset.rb
+++ b/lib/hanami/assets/asset.rb
@@ -47,7 +47,7 @@ module Hanami
       def exist?
         return true unless original.nil?
 
-        file_path = path.gsub(URL_SEPARATOR, ::File::SEPARATOR)
+        file_path = path.tr(URL_SEPARATOR, ::File::SEPARATOR)
         destination = find_asset do |a|
           a.end_with?(file_path)
         end


### PR DESCRIPTION
```
require 'benchmark/ips'

SEP = '/'.freeze

Benchmark.ips do |x|
  x.report("gsub") do
    'awesome/string/1/2/3'.gsub(SEP, ::File::SEPARATOR)
  end

  x.report('tr') do |x|
    'awesome/string/1/2/3'.tr(SEP, ::File::SEPARATOR)
  end

  x.compare!
end

Warming up --------------------------------------
                gsub    35.312k i/100ms
                  tr   117.068k i/100ms
Calculating -------------------------------------
                gsub    440.085k (± 6.2%) i/s -      2.225M in   5.074466s
                  tr    147.561B (±20.0%) i/s -    429.881B in   3.304090s

Comparison:
                  tr: 147560714821.5 i/s
                gsub:   440085.0 i/s - 335300.52x slower
```