### PR TITLE
Introduced Hanami::Routes#recognize as testing facility for routes

### DIFF
--- a/lib/hanami/routes.rb
+++ b/lib/hanami/routes.rb
@@ -135,7 +135,73 @@ module Hanami
       Utils::Escape::SafeString.new(@routes.url(name, *args))
     end
 
+    # Recognize a route from a Rack env.
+    #
+    # This method is designed for testing purposes
+    #
+    # @param env [Hash] a Rack env
+    #
+    # @return [Hanami::Routing::RecognizedRoute] the recognized route
+    #
+    # @since x.x.x
+    #
+    # @see http://hanamirb.org/guides/routing/testing
+    #
+    # @example Path Generation
+    #   # spec/web/routes_spec.rb
+    #   RSpec.describe Web::Routes do
+    #     it 'generates "/"' do
+    #       actual = described_class.path(:root)
+    #       expect(actual).to eq '/'
+    #     end
+    #
+    #     it 'generates "/books/23"' do
+    #       actual = described_class.path(:book, id: 23)
+    #       expect(actual).to eq '/books/23'
+    #     end
+    #   end
+    #
+    # @example Route Recognition
+    #   # spec/web/routes_spec.rb
+    #   RSpec.describe Web::Routes do
+    #
+    #     # ...
+    #
+    #     it 'recognizes "GET /"' do
+    #       env   = Rack::MockRequest.env_for('/')
+    #       route = described_class.recognize(env)
+    #
+    #       expect(route).to be_routable
+    #
+    #       expect(route.path).to   eq '/'
+    #       expect(route.verb).to   eq 'GET'
+    #       expect(route.params).to eq({})
+    #     end
+    #
+    #     it 'recognizes "PATCH /books/23"' do
+    #       env   = Rack::MockRequest.env_for('/books/23', method: 'PATCH')
+    #       route = described_class.recognize(env)
+    #
+    #       expect(route).to be_routable
+    #
+    #       expect(route.path).to   eq '/books/23'
+    #       expect(route.verb).to   eq 'PATCH'
+    #       expect(route.params).to eq(id: '23')
+    #     end
+    #
+    #     it 'does not recognize unknown route' do
+    #       env   = Rack::MockRequest.env_for('/foo')
+    #       route = described_class.recognize(env)
+    #
+    #       expect(route).to_not be_routable
+    #     end
+    #   end
+    def recognize(env)
+      @routes.recognize(env)
+    end
+
     protected
+
     # @since 0.3.0
     # @api private
     def method_missing(m, *args)

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -40,6 +40,26 @@ describe Hanami::Routes do
     end
   end
 
+  describe '#recognize' do
+    it 'recognizes a route from a Rack env' do
+      env   = Rack::MockRequest.env_for('/')
+      route = @routes.recognize(env)
+
+      route.must_be :routable?
+
+      route.path.must_equal '/'
+      route.verb.must_equal 'GET'
+      route.params.must_equal({})
+    end
+
+    it 'does not recognizes a route from wrong Rack env' do
+      env   = Rack::MockRequest.env_for('/foo')
+      route = @routes.recognize(env)
+
+      route.wont_be :routable?
+    end
+  end
+
   describe 'dynamic finders' do
     describe 'for relative URLs' do
       it 'recognizes named route' do


### PR DESCRIPTION
Introduced `Hanami::Routes#recognize` to ease routes unit testing.

Here's an example:

```ruby
# spec/web/routes_spec.rb
RSpec.describe Web::Routes do
  # Path Generation unit tests (this was already possible before Hanami 0.8)
  it 'generates "/"' do
    actual = described_class.path(:root)
    expect(actual).to eq '/'
  end

  it 'generates "/books/23"' do
    actual = described_class.path(:book, id: 23)
    expect(actual).to eq '/books/23'
  end

  # Route Recognition (New Feature)
  it 'recognizes "GET /"' do
    env   = Rack::MockRequest.env_for('/')
    route = described_class.recognize(env)

    expect(route).to be_routable

    expect(route.path).to   eq '/'
    expect(route.verb).to   eq 'GET'
    expect(route.params).to eq({})
  end

  it 'recognizes "PATCH /books/23"' do
    env   = Rack::MockRequest.env_for('/books/23', method: 'PATCH')
    route = described_class.recognize(env)

    expect(route).to be_routable

    expect(route.path).to   eq '/books/23'
    expect(route.verb).to   eq 'PATCH'
    expect(route.params).to eq(id: '23')
  end

  it 'does not recognize unknown route' do
    env   = Rack::MockRequest.env_for('/foo')
    route = subject.recognize(env)

    expect(route).to_not be_routable
  end
end
```
