### PR TITLE
Revert "Require gems in bin/hanami file"

### DIFF
--- a/bin/hanami
+++ b/bin/hanami
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
+
 require 'bundler'
 require 'hanami/cli'
-require 'hanami/setup'
-
 Hanami::Cli.start


### PR DESCRIPTION
This reverts commit 9a8db0445fec53046c2b65e96987569a2bf1c005.

We use `hanami` bin both inside and outside Hanami projects. Inside, with the presence of a `Gemfile`, requiring `hanami/setup` just works fine. But outside, without a `Gemfile`, `hanami` crashes.

```bash
 ➜ hanami version
/Users/luca/.gem/ruby/2.3.1/gems/bundler-1.12.5/lib/bundler.rb:170:in `rescue in root': Could not locate Gemfile or .bundle/ directory (Bundler::GemfileNotFound)
	from /Users/luca/.gem/ruby/2.3.1/gems/bundler-1.12.5/lib/bundler.rb:166:in `root'
	from /Users/luca/.gem/ruby/2.3.1/gems/bundler-1.12.5/lib/bundler.rb:74:in `bundle_path'
	from /Users/luca/.gem/ruby/2.3.1/gems/bundler-1.12.5/lib/bundler.rb:414:in `configure_gem_home_and_path'
	from /Users/luca/.gem/ruby/2.3.1/gems/bundler-1.12.5/lib/bundler.rb:60:in `configure'
	from /Users/luca/.gem/ruby/2.3.1/gems/bundler-1.12.5/lib/bundler.rb:121:in `definition'
	from /Users/luca/.gem/ruby/2.3.1/gems/bundler-1.12.5/lib/bundler.rb:91:in `setup'
	from /Users/luca/.gem/ruby/2.3.1/gems/bundler-1.12.5/lib/bundler.rb:102:in `require'
	from /Users/luca/.gem/ruby/2.3.1/gems/hanami-0.8.0/lib/hanami/setup.rb:3:in `<top (required)>'
	from /Users/luca/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /Users/luca/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /Users/luca/.gem/ruby/2.3.1/gems/hanami-0.8.0/bin/hanami:4:in `<top (required)>'
	from /Users/luca/.gem/ruby/2.3.1/bin/hanami:22:in `load'
	from /Users/luca/.gem/ruby/2.3.1/bin/hanami:22:in `<main>'
```

This problem affects `hanami version` and `hanami new`, which are the only two commands that are run outside of a Hanami project.

---

Ref #566
FYI @davydovanton 