### PR TITLE
Allow generating an app into current folder, not under it

### DIFF
--- a/lib/hanami/commands/new/abstract.rb
+++ b/lib/hanami/commands/new/abstract.rb
@@ -35,8 +35,8 @@ module Hanami
         end
 
         def start
-          FileUtils.mkdir_p(project_name)
-          Dir.chdir(project_name) do
+          FileUtils.mkdir_p(project_directory)
+          Dir.chdir(project_directory) do
             @target_path = Pathname.pwd
 
             super
@@ -73,6 +73,10 @@ module Hanami
 
         def project_name
           ApplicationName.new(real_project_name)
+        end
+
+        def project_directory
+          @name == '.' ? '.' : project_name
         end
 
         def target

--- a/test/commands/new/container_test.rb
+++ b/test/commands/new/container_test.rb
@@ -71,7 +71,7 @@ describe Hanami::Commands::New::Container do
         with_temp_dir do |original_wd|
           command = Hanami::Commands::New::Container.new({}, '.')
           capture_io { command.start }
-          Dir.chdir('test_app') do
+          Dir.chdir('.') do
             actual_content = File.read('.env.development')
             actual_content.must_include 'DATABASE_URL="file:///db/test_app_development"'
 


### PR DESCRIPTION
Fixes #621.

There was a test for when `.` is supplied as the project name that checked that the app was put into a subfolder, so perhaps there is an argument for the current behavior? But it makes sense to me that it'd generate directly into the current folder.