### PR TITLE
Generate command for secret token in production

### DIFF
--- a/lib/hanami/cli_sub_commands/generate.rb
+++ b/lib/hanami/cli_sub_commands/generate.rb
@@ -123,6 +123,22 @@ module Hanami
           Hanami::Commands::Generate::App.new(options, application_name).start
         end
       end
+
+      desc 'secret APPLICATION_NAME', 'Print a fresh secret token for production'
+      long_desc <<-EOS
+        `hanami generate secret` prints a new secret for a given app
+
+        > $ hanami generate secret admin
+
+      EOS
+      def secret(application_name = nil)
+        if options[:help]
+          invoke :help, ['secret']
+        else
+          require 'hanami/commands/generate/secret_token'
+          Hanami::Commands::Generate::SecretToken.new(application_name).start
+        end
+      end
     end
   end
 end

--- a/lib/hanami/commands/generate/secret_token.rb
+++ b/lib/hanami/commands/generate/secret_token.rb
@@ -1,0 +1,31 @@
+require 'hanami/commands/generate/abstract'
+require 'hanami/application_name'
+require 'securerandom'
+
+module Hanami
+  module Commands
+    class Generate
+      class SecretToken
+
+        def initialize(application_name)
+          @application_name = application_name
+        end
+
+        def start
+          if Hanami::Utils::Blank.blank?(@application_name)
+            puts SecureRandom.hex(32)
+          else
+            puts "Set the following environment variable to provide the secret token:"
+            puts %(#{ upcase_app_name }_SESSIONS_SECRET="#{ SecureRandom.hex(32) }")
+          end
+        end
+
+        private
+        def upcase_app_name
+          @application_name.upcase
+        end
+
+      end
+    end
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -4,6 +4,7 @@ require 'hanami/commands/generate/migration'
 require 'hanami/commands/generate/model'
 require 'hanami/commands/generate/action'
 require 'hanami/commands/generate/app'
+require 'hanami/commands/generate/secret_token'
 require 'hanami/commands/new/container'
 require 'hanami/commands/new/app'
 
@@ -250,6 +251,18 @@ describe Hanami::Cli do
         options = {'application_base_url' => '/backend'}
 
         assert_cli_calls_command(Hanami::Commands::Generate::App, options, 'admin')
+      end
+    end
+
+    describe 'secret' do
+      it 'calls the generator with app name' do
+        ARGV.replace(%w(generate secret admin))
+        assert_cli_calls_command(Hanami::Commands::Generate::SecretToken, 'admin')
+      end
+
+      it 'calls the generator with nothing' do
+        ARGV.replace(%w(generate secret))
+        assert_cli_calls_command(Hanami::Commands::Generate::SecretToken, nil)
       end
     end
   end

--- a/test/commands/generate/secret_token_test.rb
+++ b/test/commands/generate/secret_token_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'hanami/commands/generate/secret_token'
+
+describe Hanami::Commands::Generate::SecretToken do
+  describe 'with no argument' do
+    it 'prints a generated secret token' do
+      command = Hanami::Commands::Generate::SecretToken.new(nil)
+      out, err = capture_io { command.start }
+      assert (out =~ /[a-f, 0-9]{64}/), "Expected '#{out}' to contain a generated secret token."
+    end
+  end
+
+  describe 'with an application name' do
+    it 'prints a ENV var with instructions' do
+      command = Hanami::Commands::Generate::SecretToken.new('admin')
+      out, err = capture_io { command.start }
+      assert (out =~ /Set the following environment variable to provide the secret token:/ ), "Expected '#{out}' to provide instruction to set the secret token."
+      assert (out =~ /ADMIN_SESSIONS_SECRET=\"[a-f, 0-9]{64}\"/), "Expected '#{out}' to contain a session secret property."
+    end
+  end
+end


### PR DESCRIPTION
As I wanted something simple to contribute for a first time, I decided to implement a generate subcommand for the issue #625. It appends a secret token to the `.env` file for a given app.

As #625 was not already acknowledged as something the hanami team would like, I understand that contribution could be rejected. At least, it helped me to dig more into the hanami code :).

Considering it's something you'd like, what do you think of the changes? Have I missed anything?

I have a side question: is it right that the documentation/guide is to submit to https://github.com/hanami/hanami.github.io/?

