### PR TITLE
Skip preloading when code reloading is enabled

### DIFF
--- a/lib/hanami/commands/server.rb
+++ b/lib/hanami/commands/server.rb
@@ -78,7 +78,7 @@ module Hanami
       # @see Hanami::Environment::CODE_RELOADING
       def detect_strategy!
         @strategy = :rackup
-        if Hanami::Environment.new(@options).code_reloading?
+        if code_reloading?
           if shotgun_enabled?
             if fork_supported?
               @strategy = :shotgun
@@ -95,7 +95,17 @@ module Hanami
 
       def preload_applications!
         Hanami::Environment.new(@options).require_application_environment
-        Hanami::Application.preload!
+        Hanami::Application.preload! unless code_reloading?
+      end
+
+      # Check if code reloading is enabled
+      #
+      # @return [Boolean]
+      #
+      # @since 0.?.?
+      # @api private
+      def code_reloading?
+        Hanami::Environment.new(@options).code_reloading?
       end
 
       # Check if entr(1) is installed


### PR DESCRIPTION
This issue was originally reported by @opan in chat, but I was able to confirm it using an [example app](https://github.com/bruz/bookshelf-delivery-example), with code changes in either the controller or view not reflecting on refresh when running in development mode.

The problem appears to have started as of https://github.com/hanami/hanami/commit/027cd29f58845933e65ac4dfab0d18ed0a384cb9, due to running `Hanami::Application#preload!`. I'm not sure if this proposed fix is the best one possible or if code reloading should be fixed at the per-framework level. Also, is there any way to test that code reloading is happening?