### PR TITLE
Update commentary for example with file system adapter

### DIFF
--- a/lib/hanami/generators/application/app/lib/app_name.rb.tt
+++ b/lib/hanami/generators/application/app/lib/app_name.rb.tt
@@ -8,7 +8,7 @@ Hanami::Model.configure do
   # Available options:
   #
   #  * File System adapter
-  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #    adapter type: :file_system, uri: 'file:///db/<%= config[:app_name] %>_development'
   #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/<%= config[:app_name] %>_development'

--- a/test/fixtures/commands/application/new_app/lib/new_app.rb
+++ b/test/fixtures/commands/application/new_app/lib/new_app.rb
@@ -8,7 +8,7 @@ Hanami::Model.configure do
   # Available options:
   #
   #  * File System adapter
-  #    adapter type: :file_system, uri: 'file:///db/bookshelf_development'
+  #    adapter type: :file_system, uri: 'file:///db/new_app_development'
   #
   #  * Memory adapter
   #    adapter type: :memory, uri: 'memory://localhost/new_app_development'


### PR DESCRIPTION
Use app name in example, instead of default `bookshelf_development`