### PR TITLE
capture_io for code reloading message

### DIFF
--- a/lib/hanami/commands/server.rb
+++ b/lib/hanami/commands/server.rb
@@ -83,7 +83,7 @@ module Hanami
             if fork_supported?
               @strategy = :shotgun
             else
-              puts WARNING_MESSAGE
+              warn WARNING_MESSAGE
             end
           elsif entr_enabled?
             @strategy = :entr

--- a/test/commands/server_test.rb
+++ b/test/commands/server_test.rb
@@ -311,12 +311,14 @@ describe Hanami::Commands::Server do
             end
           end
 
-          @server = @server_klass.new(opts).server
+          @stdout, _ = capture_io { @server = @server_klass.new(opts).server }
         end
 
         let(:opts) { Hash[code_reloading: true] }
 
         it "doesn't use Shotgun" do
+          @stdout.must_equal "Your platform doesn't support code reloading.\n"
+          @server.must_be_kind_of(Hanami::Server)
           @server.instance_variable_get(:@app).must_be_nil
         end
       end

--- a/test/commands/server_test.rb
+++ b/test/commands/server_test.rb
@@ -311,13 +311,13 @@ describe Hanami::Commands::Server do
             end
           end
 
-          @stdout, _ = capture_io { @server = @server_klass.new(opts).server }
+          _, @stderr = capture_io { @server = @server_klass.new(opts).server }
         end
 
         let(:opts) { Hash[code_reloading: true] }
 
         it "doesn't use Shotgun" do
-          @stdout.must_equal "Your platform doesn't support code reloading.\n"
+          @stderr.must_equal "Your platform doesn't support code reloading.\n"
           @server.must_be_kind_of(Hanami::Server)
           @server.instance_variable_get(:@app).must_be_nil
         end


### PR DESCRIPTION
Also add assertion to make sure that message is correct

Before:

```bash
$ ruby -Ilib:test test/commands/server_test.rb
Run options: --seed 48365

# Running:

................................Your platform doesn't support code reloading.
....

Finished in 0.104439s, 344.6980 runs/s, 402.1477 assertions/s.

36 runs, 42 assertions, 0 failures, 0 errors, 0 skips
```

After:
```bash
$ ruby -Ilib:test test/commands/server_test.rb
Run options: --seed 20962

# Running:

....................................

Finished in 0.048766s, 738.2183 runs/s, 902.2668 assertions/s.

36 runs, 44 assertions, 0 failures, 0 errors, 0 skips
```

I also added `@server.must_be_kind_of(Hanami::Server)` because  `@server.instance_variable_get(:@app).must_be_nil` doesn't really check anything on its own... you can set `@server = nil` and that `@server`'s `@app` is nil.