### PR TITLE
Don't duplicate middlewares in the stack

### DIFF
--- a/lib/hanami/middleware.rb
+++ b/lib/hanami/middleware.rb
@@ -15,7 +15,7 @@ module Hanami
     #
     # @see Hanami::Configuration
     def initialize(configuration)
-      @stack = []
+      @stack = Set.new
       @configuration = configuration
     end
 
@@ -64,7 +64,7 @@ module Hanami
     #
     # @see Hanami::Middleware#prepend
     def use(middleware, *args, &blk)
-      @stack.push [middleware, args, blk]
+      @stack.add [middleware, args, blk]
     end
 
     # Prepend a middleware to the stack.
@@ -79,7 +79,7 @@ module Hanami
     #
     # @see Hanami::Middleware#use
     def prepend(middleware, *args, &blk)
-      @stack.unshift [middleware, args, blk]
+      @stack = Set[[middleware, args, blk]] | @stack
     end
 
     # @api private

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -32,7 +32,7 @@ describe Hanami::Middleware do
 
   it 'appends new added middleware' do
     middleware.use MockMiddleware
-    middleware.stack.last.must_equal [MockMiddleware, [], nil]
+    middleware.stack.to_a.last.must_equal [MockMiddleware, [], nil]
   end
 
   describe "with container architecture" do
@@ -110,8 +110,9 @@ describe Hanami::Middleware do
       end
 
       it 'prepends sessions' do
-        sessions_position   = middleware.stack.index(["Rack::Session::Cookie", [{:domain=>nil, :secure=>false}], nil]).to_i
-        middleware_position = middleware.stack.index([MockMiddlewareClass, [], nil])
+        middleware_stack    = middleware.stack.to_a
+        sessions_position   = middleware_stack.index(["Rack::Session::Cookie", [{:domain=>nil, :secure=>false}], nil]).to_i
+        middleware_position = middleware_stack.index([MockMiddlewareClass, [], nil])
 
         assert sessions_position < middleware_position,
           "Expected sessions middleware to be prepended"


### PR DESCRIPTION
Closes #638.

Middleware stack was changed to `Set` from `Array`. This guarantees uniqueness for free. That avoids to have duplicated middlewares and their other values in the stack.