### PR TITLE
Load assets configuration in development code reloading mode

### DIFF
--- a/lib/hanami/assets/static.rb
+++ b/lib/hanami/assets/static.rb
@@ -101,6 +101,7 @@ module Hanami
       # @since 0.8.0
       # @api private
       def _assets_configuration(application)
+        Hanami::Loader.new(application).load_assets!
         application.configuration.namespace::Assets.configuration
       end
     end

--- a/lib/hanami/loader.rb
+++ b/lib/hanami/loader.rb
@@ -34,6 +34,13 @@ module Hanami
       end
     end
 
+    def load_assets!
+      LOCK.synchronize do
+        load_configuration!
+        _configure_assets_framework!
+      end
+    end
+
     private
     attr_reader :application, :configuration
 


### PR DESCRIPTION
Recently I came up with problem with assets in code reloading mode. I described it in my demo app: https://github.com/ksenia-zalesnaya/hanami-assets-sample
As far as I know there are no tests on how framework works under code reloading mode, so I couldn't add any new, just did some plain old manual testing on several different macs - mine and colleagues'. We all had different problems with assets which I described in demo (some had more problems, some had less), but my fix fixed everything.
So I wonder how close I am to real solving the problem.