### PR TITLE
Proof of concept: allow users to disable models/assets tasks

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -131,8 +131,10 @@ module Hanami
       end
     end
 
-    require 'hanami/cli_sub_commands/db'
-    register Hanami::CliSubCommands::DB, 'db', 'db [SUBCOMMAND]', 'Manage set of DB operations'
+    if defined?(Hanami::Model)
+      require 'hanami/cli_sub_commands/db'
+      register Hanami::CliSubCommands::DB, 'db', 'db [SUBCOMMAND]', 'Manage set of DB operations'
+    end
 
     require 'hanami/cli_sub_commands/generate'
     register Hanami::CliSubCommands::Generate, 'generate', 'generate [SUBCOMMAND]', 'Generate hanami classes'
@@ -140,7 +142,9 @@ module Hanami
     require 'hanami/cli_sub_commands/destroy'
     register Hanami::CliSubCommands::Destroy, 'destroy', 'destroy [SUBCOMMAND]', 'Destroy hanami classes'
 
-    require 'hanami/cli_sub_commands/assets'
-    register Hanami::CliSubCommands::Assets, 'assets', 'assets [SUBCOMMAND]', 'Manage assets'
+    if Hanami::Environment.disable_assets_piplene?
+      require 'hanami/cli_sub_commands/assets'
+      register Hanami::CliSubCommands::Assets, 'assets', 'assets [SUBCOMMAND]', 'Manage assets'
+    end
   end
 end

--- a/lib/hanami/rake_helper.rb
+++ b/lib/hanami/rake_helper.rb
@@ -52,15 +52,20 @@ module Hanami
       #
       # This is the preferred way to run Hanami command line tasks.
       # Please use them when you're in control of your deployment environment.
-      namespace :db do
-        task :migrate do
-          system("bundle exec hanami db migrate") || exit($?.exitstatus)
+
+      if defined?(Hanami::Model)
+        namespace :db do
+          task :migrate do
+            system("bundle exec hanami db migrate") || exit($?.exitstatus)
+          end
         end
       end
 
-      namespace :assets do
-        task :precompile do
-          system("bundle exec hanami assets precompile") || exit($?.exitstatus)
+      if Hanami::Environment.disable_assets_piplene?
+        namespace :assets do
+          task :precompile do
+            system("bundle exec hanami assets precompile") || exit($?.exitstatus)
+          end
         end
       end
     end


### PR DESCRIPTION
Hi guys! Just want to ask about possible ability to disable assets- / model- related tasks.

### Some background

I am trying to use rom-rb with Hanami without Hanami::Model. I don't want to use `rake db:migrate` from Hanami or `hanami db migrate`. Instead, I want to use `rake db:migrate` from rom-sql. So there is collision with rake tasks. 

### What to do

Seems like there are a few ways to manage this issue:

0) Do not touch Hanami, create workaround in your own code. I think it's a bad idea, because http://hanamirb.org/guides/models/use-your-own-orm/ suggests me the way to use my own ORM, but after removing Hamani::Model there are still some parts of inside the main gem. 

1) Check if there is such module/lib loaded to activate/deactivate rake tasks. Something like `if defined?(Hanami::Model)...`. It seems ok for Hanami::Model, but it's not ok for other libs packed in hanami gem itself.

2) Use a flag in ENV/application.rb to disable these features. 


**My questions are:**

— Do you want to see a real PR with such functions like disabling model or(and) assets?
— If answer is "yes", which way do you prefer: 1), or 2), or something else?



