### PR TITLE
Add .sort to glob, to fix OS X / Linux discrepancy

### DIFF
--- a/lib/hanami/config/load_paths.rb
+++ b/lib/hanami/config/load_paths.rb
@@ -13,7 +13,7 @@ module Hanami
         @root = root
 
         each do |path|
-          Dir.glob(path.join(PATTERN)).each { |file| require file }
+          Dir.glob(path.join(PATTERN)).sort.each { |file| require file }
         end
       end
 


### PR DESCRIPTION
Closes #646. @kkolotyuk confirmed it fixes the problem for them

We should look through all examples of `Dir.glob` (and its alias `Dir[]`) and see if adding `.sort` would be helpful. Looks like we do that 7 other times in `hanami/hanami`. Happy to do that for this PR if it's deemed necessary. Or we could make it a separate issue that would be great for a first time contribution :) 