### PR TITLE
Ensure `:environment` Rake task to load the entire project

### DIFF
--- a/lib/hanami/rake_helper.rb
+++ b/lib/hanami/rake_helper.rb
@@ -21,8 +21,10 @@ module Hanami
     # rubocop:disable Metrics/MethodLength
     def install
       desc "Load the full project"
-      task environment: :preload do
-        Components.resolve('apps')
+      task :environment do
+        require 'hanami/environment'
+        Hanami::Environment.new.require_project_environment
+        Components.resolve('all')
       end
 
       # Ruby ecosystem compatibility

--- a/spec/isolation/rake/environment_spec.rb
+++ b/spec/isolation/rake/environment_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe "Rake: environment", type: :cli do
+  it "loads the project" do
+    with_project do
+      generate_migrations
+      generate_model "user"
+      hanami "db prepare"
+
+      append "Rakefile", <<-EOF
+task database_counts: :environment do
+puts "users: \#{UserRepository.new.all.count}"
+end
+EOF
+
+      bundle_exec "rake database_counts"
+
+      expect(out).to eq("users: 0")
+    end
+  end
+end

--- a/spec/support/files.rb
+++ b/spec/support/files.rb
@@ -33,6 +33,13 @@ module RSpec
         rewrite(path, content)
       end
 
+      def append(path, contents)
+        content = ::File.readlines(path)
+        content << "#{contents}\n"
+
+        rewrite(path, content)
+      end
+
       def open(path, mode, *content)
         ::File.open(path, mode) do |file|
           file.write(Array(content).flatten.join)


### PR DESCRIPTION
It also eliminates the dependency with the `:preload` Rake task which was removed from v0.9.0.

---

Closes #677

/cc @mereghost @hanami/core-team @hanami/contributors for review. Thanks