### PR TITLE
Lazily load the project when `hanami server` isn't used

### DIFF
--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -77,7 +77,15 @@ module Hanami
     end
   end
 
-  # Boot Hanami project
+  # Boot your Hanami project
+  #
+  # NOTE: In case this is invoked many times, it guarantees that the boot
+  #   process happens only once.
+  #
+  # NOTE: There is no reason to cache the result with `@_booted`, because it
+  #   already caches it internally.
+  #
+  # NOTE: This MUST NOT be wrapped by a Mutex, because it would cause a deadlock.
   #
   # @since 0.9.0
   # @api private
@@ -92,11 +100,20 @@ module Hanami
   #   * `config.ru` (`run Hanami.app`)
   #   * Feature tests (`Capybara.app = Hanami.app`)
   #
+  #
+  #
+  # It lazily loads your Hanami project, in case it wasn't booted on before.
+  # This is the case when `hanami server` isn't invoked, but we use different
+  # ways to run the project (eg. `rackup`).
+  #
   # @return [Hanami::App] the app
   #
   # @since 0.9.0
   # @api private
+  #
+  # @see Hanami.boot
   def self.app
+    boot
     App.new(configuration, environment)
   end
 

--- a/spec/integration/cli/console_spec.rb
+++ b/spec/integration/cli/console_spec.rb
@@ -22,22 +22,4 @@ RSpec.describe "hanami console", type: :cli do
 
   # TODO: test with pry
   # TODO: test with ripl
-
-  private
-
-  def setup_model # rubocop:disable Metrics/MethodLength
-    generate_model     "book"
-    generate_migration "create_books", <<-EOF
-Hanami::Model.migration do
-  change do
-    create_table :books do
-      primary_key :id
-      column :title, String
-    end
-  end
-end
-EOF
-
-    migrate
-  end
 end

--- a/spec/integration/cli/server_spec.rb
+++ b/spec/integration/cli/server_spec.rb
@@ -298,22 +298,4 @@ EOF
       end
     end
   end
-
-  private
-
-  def setup_model # rubocop:disable Metrics/MethodLength
-    generate_model     "book"
-    generate_migration "create_books", <<-EOF
-Hanami::Model.migration do
-  change do
-    create_table :books do
-      primary_key :id
-      column :title, String
-    end
-  end
-end
-EOF
-
-    migrate
-  end
 end

--- a/spec/integration/rackup_spec.rb
+++ b/spec/integration/rackup_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe 'rackup', type: :cli do
+  it "serves contents from database" do
+    with_project do
+      setup_model
+      console do |input, _, _|
+        input.puts("BookRepository.new.create(title: 'Learn Hanami')")
+        input.puts("exit")
+      end
+
+      generate "action web books#show --url=/books/:id"
+      rewrite  "apps/web/controllers/books/show.rb", <<-EOF
+module Web::Controllers::Books
+  class Show
+    include Web::Action
+    expose :book
+
+    def call(params)
+      @book = BookRepository.new.find(params[:id]) or halt(404)
+    end
+  end
+end
+      EOF
+      rewrite "apps/web/templates/books/show.html.erb", <<-EOF
+<h1><%= book.title %></h1>
+      EOF
+
+      rackup do
+        visit "/books/1"
+        expect(page).to have_content("Learn Hanami")
+      end
+    end
+  end
+end

--- a/spec/integration/rake/with_minitest_spec.rb
+++ b/spec/integration/rake/with_minitest_spec.rb
@@ -33,20 +33,6 @@ EOF
 
   private
 
-  def setup_model
-    generate_model     "book"
-    generate_migration "create_books", <<-EOF
-Hanami::Model.migration do
-  change do
-    create_table :books do
-      primary_key :id
-      column :title, String
-    end
-  end
-end
-EOF
-  end
-
   def prepare_development_database
     prepare_database
   end

--- a/spec/integration/rake/with_rspec_spec.rb
+++ b/spec/integration/rake/with_rspec_spec.rb
@@ -31,20 +31,6 @@ EOF
 
   private
 
-  def setup_model
-    generate_model     "book"
-    generate_migration "create_books", <<-EOF
-Hanami::Model.migration do
-  change do
-    create_table :books do
-      primary_key :id
-      column :title, String
-    end
-  end
-end
-EOF
-  end
-
   def prepare_development_database
     prepare_database
   end


### PR DESCRIPTION
Our CLI commands guarantee to load only certain parts of a project.

For instance `hanami routes` loads only the routes of the project, **without** loading other useless parts like repositories or actions.

In the case of `hanami server`, it loads the entire project (routes, actions, models, etc..). But when the project is loaded without this command (eg. `rackup` or `puma`), the boot process doesn't happen (as reported by #675).

---

Personally, I use this configuration for Puma:

```ruby
# config/puma.rb
workers Integer(ENV['WEB_CONCURRENCY'] || 2)
threads_count = Integer(ENV['MAX_THREADS'] || 5)
threads threads_count, threads_count

preload_app!

rackup      DefaultRackup
port        ENV['PORT']     || 2300
environment ENV['RACK_ENV'] || ENV['HANAMI_ENV'] || 'development'

on_worker_boot do
  Hanami.boot
end
```

Which is used like this:

```shell
bundle exec puma -C config/puma.rb
```

That `on_worker_boot` hook is used to (re)boot the project.

---

While the configuration above solves the problem, the lack of lazy boot can be: confusing (see #675) or inelegant (`bundle exec rackup --eval "require './config/environment'; Hanami.boot"` would solve the problem)

**This PR aims to solves these frictions by introducting lazy boot support.**

---

Closes #675 

/cc @mereghost @tadejm @hanami/core-team @hanami/contributors for review