### PR TITLE
Ensure force SSL to redirect to the right port

### DIFF
--- a/lib/hanami/application_configuration.rb
+++ b/lib/hanami/application_configuration.rb
@@ -21,6 +21,10 @@ module Hanami
     # @see Hanami::Configuration#ssl?
     SSL_SCHEME = 'https'.freeze
 
+    # @since x.x.x
+    # @api private
+    DEFAULT_SSL_PORT = 443
+
     # @since 0.1.0
     # @api private
     attr_reader :namespace
@@ -37,11 +41,11 @@ module Hanami
     #
     # @since 0.1.0
     # @api private
-    def initialize(namespace, configurations, path_prefix)
+    def initialize(namespace, configurations, path_prefix, env: Environment.new)
       @namespace      = namespace
       @configurations = configurations
       @path_prefix    = path_prefix
-      @env            = Environment.new
+      @env            = env
 
       evaluate_configurations!
     end
@@ -1012,7 +1016,10 @@ module Hanami
       if value
         @port = Integer(value)
       else
-        @port || @env.port
+        return @port if defined?(@port)
+        return @env.port unless @env.default_port?
+        return DEFAULT_SSL_PORT if force_ssl
+        @env.port
       end
     end
 

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -329,6 +329,16 @@ module Hanami
       end.to_i
     end
 
+    # Check if the current port is the default one
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Hanami::ApplicationConfiguration#port
+    def default_port?
+      port == DEFAULT_PORT
+    end
+
     # Path to the Rack configuration file
     #
     # In order to decide the value, it looks up the following sources:

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -6,3 +6,11 @@ module UnitTesting
   class Application < Hanami::Application
   end
 end
+
+# Please use this app only for:
+#
+#   * spec/unit/application_configuration_spec.rb
+module ApplicationConfigurationTesting
+  class Application < Hanami::Application
+  end
+end

--- a/spec/unit/application_configuration_spec.rb
+++ b/spec/unit/application_configuration_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe Hanami::ApplicationConfiguration do
             expect(subject.port).to eq(8200)
           end
         end
+
+        context "and forced by env var" do
+          let(:hanami_port) { 4321 }
+
+          xit "returns the one from the env var" do
+            expect(subject.port).to eq(4321)
+          end
+        end
       end
 
       context "only in the current environment configuration" do

--- a/spec/unit/application_configuration_spec.rb
+++ b/spec/unit/application_configuration_spec.rb
@@ -1,0 +1,109 @@
+RSpec.describe Hanami::ApplicationConfiguration do
+  before do
+    env['HANAMI_ENV']  = hanami_env
+    env['HANAMI_PORT'] = hanami_port unless hanami_port.nil?
+  end
+
+  subject { described_class.new(namespace, configurations, path_prefix, env: environment) }
+
+  let(:namespace)      { ApplicationConfigurationTesting }
+  let(:configurations) { Hanami::EnvironmentApplicationConfigurations.new }
+  let(:path_prefix)    { '/' }
+
+  let(:environment)    { Hanami::Environment.new(env: env) }
+  let(:env)            { Hash[] }
+
+  let(:hanami_env)  { 'development' }
+  let(:hanami_port) { nil }
+
+  describe "#port" do
+    context "when not configured" do
+      it "returns the default value" do
+        expect(subject.port).to eq(2300)
+      end
+
+      context "and force_ssl is active" do
+        before do
+          configurations.add(nil) do
+            force_ssl true
+          end
+        end
+
+        it "returns the default SSL port" do
+          expect(subject.port).to eq(443)
+        end
+      end
+
+      context "and HANAMI_PORT env var is set" do
+        let(:hanami_port) { "8080" }
+
+        it "returns the value from the env var" do
+          expect(subject.port).to eq(8080)
+        end
+
+        context "and force_ssl is active" do
+          before do
+            configurations.add(nil) do
+              force_ssl true
+            end
+          end
+
+          it "returns the value from the env var" do
+            expect(subject.port).to eq(8080)
+          end
+        end
+      end
+    end
+
+    context "when already configured" do
+      context "in the general configuration" do
+        before do
+          configurations.add(nil) do
+            port 4600
+          end
+        end
+
+        it "returns the configured value" do
+          expect(subject.port).to eq(4600)
+        end
+
+        context "and overwritten by current environment configuration" do
+          before do
+            configurations.add(hanami_env) do
+              port 8200
+            end
+          end
+
+          it "returns the current environment value" do
+            expect(subject.port).to eq(8200)
+          end
+        end
+      end
+
+      context "only in the current environment configuration" do
+        before do
+          configurations.add(nil) do
+            port 7200
+          end
+        end
+
+        it "returns the configured value" do
+          expect(subject.port).to eq(7200)
+        end
+      end
+
+      context "and force_ssl is active" do
+        before do
+          configurations.add(nil) do
+            port      4433
+            force_ssl true
+          end
+        end
+
+        it "returns the default SSL port" do
+          expect(subject.port).to eq(4433)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When force SSL option is active and the port is not set, the application configuration returns a wrong port value.

```ruby
module Web
  class Application < Hanami::Application
    # ...
    configure :production do
      force_ssl true
      scheme 'https'
      host 'example.org'
      # port 443
    end
  end
end
```

In this case the returned port is `2300`, but it should be the default SSL port `443`.

---

This PR fixes this problem, by implementing the following rules:

  * When nothing is set, return `2300`
  * When port is set via `HANAMI_PORT` env var, use it
  * When port is set via `port` setting, use it
  * When nothing is set, but `force_ssl` is, use `443`
  * When `force_ssl` is set but one of `HANAMI_PORT` or `port` are used, give them the priority

---

Closes #666 

/cc @createdbypete @hanami/core-team @hanami/contributors for review. Thanks. 😄 