### PR TITLE
Replaced hash merge in generator.rb

### DIFF
--- a/lib/hanami/generators/generator.rb
+++ b/lib/hanami/generators/generator.rb
@@ -36,7 +36,7 @@ module Hanami
         config = args.last.is_a?(Hash) ? args.pop : {}
         # Either prepend after the last comment line,
         # or the first line in the file, if there are no comments
-        config.merge!(after: /\A(?:^#.*$\s)*/)
+        config[:after] = /\A(?:^#.*$\s)*/
         @processor.insert_into_file(path, *(args << config), &block)
       end
     end


### PR DESCRIPTION
Hi.

Looks like there was a hash merge in lib/hanami/generators/generator.rb. I replaced this merge with faster version. I am aware that destructive method (such as ```merge!```) does not duplicate the hash but this should make the operation even faster.

Thank you.