### PR TITLE
Use poltergeist for all platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,11 +41,7 @@ if RUBY_DESCRIPTION =~ /linux/
   gem 'therubyrhino', require: false, platforms: :jruby
 end
 
-if RUBY_DESCRIPTION =~ /linux|jruby/
-  gem 'poltergeist', require: false
-else
-  gem 'capybara-webkit', require: false
-end
+gem 'poltergeist', require: false
 
 # `hanami assets` integration tests
 gem 'sass',          require: false

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ bundle
 
   * Ruby 2.3+ / JRuby 9.1.5.0+
   * Bundler
-  * Qt (MacOS)
+  * [PhantomJS](http://phantomjs.org/download.html)
   * Node.js (MacOS)
 
 ### Testing

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -10,20 +10,6 @@ end
 Capybara.configure do |config|
   config.run_server = false
 
-  Platform.match do
-    os(:linux) do
-      require 'capybara/poltergeist'
-      config.default_driver = :poltergeist
-    end
-
-    engine(:jruby) do
-      require 'capybara/poltergeist'
-      config.default_driver = :poltergeist
-    end
-
-    os(:macos) do
-      require 'capybara/webkit'
-      config.default_driver = :webkit
-    end
-  end
+  require 'capybara/poltergeist'
+  config.default_driver = :poltergeist
 end


### PR DESCRIPTION
Linux and JRuby: `poltergeist` depends on `phantomjs`, which is 16+ MB.

Everything else: `capybara-webkit` depends on `QT`, which is 700+ MB.

Using two different libraries based on platform could cause problems down the road if the drivers behave differently.

Can we just use poltergeist for all platforms?

@jodosha What do we need these for? Do we have feature tests that need JS? I'd prefer using `Rack::Test` (no dependencies) if possible!