### PR TITLE
Delimited %w literal in cli.rb

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -17,7 +17,7 @@ module Hanami
       require 'hanami/version'
       puts "v#{ Hanami::VERSION }"
     end
-    map (%w{--version -v}) => :version
+    map %w({--version -v}) => :version
 
     desc 'server', 'Starts a hanami server'
     long_desc <<-EOS

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -17,7 +17,7 @@ module Hanami
       require 'hanami/version'
       puts "v#{ Hanami::VERSION }"
     end
-    map %w{--version -v} => :version
+    map (%w{--version -v}) => :version
 
     desc 'server', 'Starts a hanami server'
     long_desc <<-EOS


### PR DESCRIPTION
Hi. 

Looks like there was ```%w``` literal which was not delimited in lib/hanami/cli.rb. 

This should remove a minor bug risk.

Thank you. 