### PR TITLE
Add spec helper for each generated spec file

### DIFF
--- a/lib/hanami/generators/action/action_spec.rspec.tt
+++ b/lib/hanami/generators/action/action_spec.rspec.tt
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require_relative '<%= config[:relative_action_path] %>'
 
 RSpec.describe <%= config[:app] %>::Controllers::<%= config[:controller] %>::<%= config[:action] %> do

--- a/lib/hanami/generators/action/view_spec.rspec.tt
+++ b/lib/hanami/generators/action/view_spec.rspec.tt
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require_relative '<%= config[:relative_view_path] %>'
 
 RSpec.describe <%= config[:app] %>::Views::<%= config[:controller] %>::<%= config[:action] %> do

--- a/lib/hanami/generators/model/entity_spec.rspec.tt
+++ b/lib/hanami/generators/model/entity_spec.rspec.tt
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe <%= config[:model_name] %> do
   # place your tests here
 end

--- a/lib/hanami/generators/model/repository_spec.rspec.tt
+++ b/lib/hanami/generators/model/repository_spec.rspec.tt
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe <%= config[:model_name] %>Repository do
   # place your tests here
 end

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -293,6 +293,7 @@ END
           # spec/web/controllers/books/index_spec.rb
           #
           expect('spec/web/controllers/books/index_spec.rb').to have_file_content <<-END
+require 'spec_helper'
 require_relative '../../../../apps/web/controllers/books/index'
 
 RSpec.describe Web::Controllers::Books::Index do
@@ -310,6 +311,7 @@ END
           # spec/web/views/books/index_spec.rb
           #
           expect('spec/web/views/books/index_spec.rb').to have_file_content <<-END
+require 'spec_helper'
 require_relative '../../../../apps/web/views/books/index'
 
 RSpec.describe Web::Views::Books::Index do

--- a/spec/integration/cli/generate/model_spec.rb
+++ b/spec/integration/cli/generate/model_spec.rb
@@ -95,6 +95,8 @@ END
           # spec/<project>/entities/<model>_spec.rb
           #
           expect("spec/#{project}/entities/#{model}_spec.rb").to have_file_content <<-END
+require 'spec_helper'
+
 RSpec.describe #{class_name} do
   # place your tests here
 end
@@ -104,6 +106,8 @@ END
           # spec/<project>/repositories/<model>_repository_spec.rb
           #
           expect("spec/#{project}/repositories/#{model}_repository_spec.rb").to have_file_content <<-END
+require 'spec_helper'
+
 RSpec.describe BookRepository do
   # place your tests here
 end


### PR DESCRIPTION
I found that `generation` doesn't add `spec_helper` that's why I have some troubles with rspec-hanami and that's why I need to put `require 'spec_helper'` to each file.

/cc @hanami/core 