### PR TITLE
Setup Hanami::Mailer as a component

### DIFF
--- a/lib/hanami/components/components.rb
+++ b/lib/hanami/components/components.rb
@@ -13,7 +13,7 @@ module Hanami
     # @since 0.9.0
     # @api private
     register 'all' do
-      requires 'model', 'apps', 'finalizers'
+      requires 'mailer', 'model', 'apps', 'finalizers'
 
       resolve { true }
     end
@@ -132,6 +132,45 @@ module Hanami
 
       resolve do
         true if defined?(Hanami::Model)
+      end
+    end
+
+    # Tries to evaluate hanami-mailer configuration
+    #
+    # @since 1.0.0.beta1
+    # @api private
+    #
+    # @example With hanami-mailer
+    #   Hanami::Components.resolve('mailer.configuration')
+    #   Hanami::Components['mailer.configuration'].class # => Hanami::Mailer::Configuration
+    register 'mailer.configuration' do
+      prepare do
+        require 'hanami/mailer'
+        require 'hanami/mailer/glue'
+      end
+
+      resolve do |configuration|
+        Hanami::Mailer.configure(&configuration.mailer)
+        Hanami::Mailer.configuration
+      end
+    end
+
+    # Tries to load hanami-mailer
+    #
+    # @since 1.0.0.beta1
+    # @api private
+    #
+    # @example
+    #   Hanami::Components.resolve('mailer')
+    #   Hanami::Components['mailer'] # => true
+    register 'mailer' do
+      requires 'mailer.configuration'
+
+      resolve do
+        if Components['mailer.configuration']
+          Hanami::Mailer.load!
+          true
+        end
       end
     end
 

--- a/spec/isolation/components/all/component_spec.rb
+++ b/spec/isolation/components/all/component_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe "Components: all", type: :cli do
       expect(Hanami::Components['model.configuration']).to_not be(nil)
       expect(Hanami::Components['model']).to_not               be(nil)
 
+      expect(Hanami::Components['mailer.configuration']).to_not be(nil)
+      expect(Hanami::Components['mailer']).to_not               be(nil)
+
+
       expect(Hanami::Components['web']).to_not   be(nil)
       expect(Hanami::Components['admin']).to_not be(nil)
 

--- a/spec/isolation/components/all/ensure_once_spec.rb
+++ b/spec/isolation/components/all/ensure_once_spec.rb
@@ -6,22 +6,26 @@ RSpec.describe "Components: all", type: :cli do
       require Pathname.new(Dir.pwd).join("config", "environment")
       Hanami::Components.resolve('all')
 
-      model_configuration = Hanami::Components['model.configuration']
-      model               = Hanami::Components['model']
-      web_configuration   = Hanami::Components['web.configuration']
-      web_app_config      = Web::Application.configuration
-      admin_configuration = Hanami::Components['admin.configuration']
-      admin_app_config    = Admin::Application.configuration
+      model_configuration  = Hanami::Components['model.configuration']
+      model                = Hanami::Components['model']
+      mailer               = Hanami::Components['mailer']
+      web_configuration    = Hanami::Components['web.configuration']
+      web_app_config       = Web::Application.configuration
+      admin_configuration  = Hanami::Components['admin.configuration']
+      admin_app_config     = Admin::Application.configuration
+      mailer_configuration = Hanami::Mailer.configuration
 
       # Simulate accidental double trigger
       Hanami::Components.resolve('all')
 
-      expect(Hanami::Components['model.configuration']).to be(model_configuration)
-      expect(Hanami::Components['model']).to               be(model)
-      expect(Hanami::Components['web.configuration']).to   be(web_configuration)
-      expect(Web::Application.configuration).to            be(web_app_config)
-      expect(Hanami::Components['admin.configuration']).to be(admin_configuration)
-      expect(Admin::Application.configuration).to          be(admin_app_config)
+      expect(Hanami::Components['model.configuration']).to  be(model_configuration)
+      expect(Hanami::Components['model']).to                be(model)
+      expect(Hanami::Components['mailer.configuration']).to be(mailer_configuration)
+      expect(Hanami::Components['mailer']).to               be(mailer)
+      expect(Hanami::Components['web.configuration']).to    be(web_configuration)
+      expect(Web::Application.configuration).to             be(web_app_config)
+      expect(Hanami::Components['admin.configuration']).to  be(admin_configuration)
+      expect(Admin::Application.configuration).to           be(admin_app_config)
     end
   end
 end

--- a/spec/isolation/components/mailer/with_hanami_mailer_spec.rb
+++ b/spec/isolation/components/mailer/with_hanami_mailer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Components: mailer", type: :cli do
-  context "with hanami-model" do
+  context "with hanami-mailer" do
     it "resolves mailer" do
       with_project do
         require Pathname.new(Dir.pwd).join("config", "environment")

--- a/spec/isolation/components/mailer/with_hanami_mailer_spec.rb
+++ b/spec/isolation/components/mailer/with_hanami_mailer_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Components: mailer", type: :cli do
+  context "with hanami-model" do
+    it "resolves mailer" do
+      with_project do
+        require Pathname.new(Dir.pwd).join("config", "environment")
+        Hanami::Components.resolve('mailer')
+
+        expect(Hanami::Components['mailer']).to               be(true)
+        expect(Hanami::Components['mailer.configuration']).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/isolation/components/mailer_configuration/with_hanami_mailer_spec.rb
+++ b/spec/isolation/components/mailer_configuration/with_hanami_mailer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Components: mailer.configuration", type: :cli do
   context "with hanami-mailer" do
-    it "resolves model configuration" do
+    it "resolves mailer configuration" do
       with_project do
         require Pathname.new(Dir.pwd).join("config", "environment")
         Hanami::Components.resolve('mailer.configuration')

--- a/spec/isolation/components/mailer_configuration/with_hanami_mailer_spec.rb
+++ b/spec/isolation/components/mailer_configuration/with_hanami_mailer_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe "Components: mailer.configuration", type: :cli do
+  context "with hanami-mailer" do
+    it "resolves model configuration" do
+      with_project do
+        require Pathname.new(Dir.pwd).join("config", "environment")
+        Hanami::Components.resolve('mailer.configuration')
+
+        expect(Hanami::Components['mailer.configuration']).to be_kind_of(Hanami::Mailer::Configuration)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`hanami-mailer` was only called by the `Glue` module and it would not load the configurations (no calls to `.load!`) passed to the `Hanami::Application`. A side effect created by this was that the mailer root was setup, so all calls to `.deliver` would fail.

This PR fixes #703 by setting `hanami-mailer` as a component and loading it. There's still a weird behaviour that the global config is not reflected on the mailers, but that's a separate issue with `hanami-mailer` (working on a fix).