### PR TITLE
Remove bundler dependency

### DIFF
--- a/lib/hanami/generators/application/app/Gemfile.tt
+++ b/lib/hanami/generators/application/app/Gemfile.tt
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 <%- if config[:hanami_head] -%>
 

--- a/lib/hanami/generators/application/container/Gemfile.tt
+++ b/lib/hanami/generators/application/container/Gemfile.tt
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 <%- if config[:hanami_head] -%>
 

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -83,7 +83,6 @@ END
         expect('Gemfile').to have_file_content <<-END
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 gem 'hanami',       '#{Hanami::Version.gem_requirement}'
 gem 'hanami-model', '~> 1.0.0.beta1'
@@ -115,7 +114,6 @@ END
         expect('Gemfile').to have_file_content <<-END
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 gem 'hanami',       '#{Hanami::Version.gem_requirement}'
 gem 'hanami-model', '~> 1.0.0.beta1'

--- a/test/fixtures/cdn/cdn/Gemfile
+++ b/test/fixtures/cdn/cdn/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 gem 'hanami-utils',       require: false, github: 'hanami/utils'
 gem 'hanami-router',      require: false, github: 'hanami/router'

--- a/test/fixtures/cdn/cdn_app/Gemfile
+++ b/test/fixtures/cdn/cdn_app/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 gem 'hanami-utils',       require: false, github: 'hanami/utils'
 gem 'hanami-router',      require: false, github: 'hanami/router'

--- a/test/fixtures/commands/application/new_app/Gemfile.jruby:minitest
+++ b/test/fixtures/commands/application/new_app/Gemfile.jruby:minitest
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_app/Gemfile.jruby:rspec
+++ b/test/fixtures/commands/application/new_app/Gemfile.jruby:rspec
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_app/Gemfile.jruby:slim
+++ b/test/fixtures/commands/application/new_app/Gemfile.jruby:slim
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_app/Gemfile.minitest
+++ b/test/fixtures/commands/application/new_app/Gemfile.minitest
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_app/Gemfile.rspec
+++ b/test/fixtures/commands/application/new_app/Gemfile.rspec
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_app/Gemfile.slim
+++ b/test/fixtures/commands/application/new_app/Gemfile.slim
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.filesystem
+++ b/test/fixtures/commands/application/new_container/Gemfile.filesystem
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.head
+++ b/test/fixtures/commands/application/new_container/Gemfile.head
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami-utils',       require: false, github: 'hanami/utils'

--- a/test/fixtures/commands/application/new_container/Gemfile.jdbc:mysql2
+++ b/test/fixtures/commands/application/new_container/Gemfile.jdbc:mysql2
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.jdbc:postgres
+++ b/test/fixtures/commands/application/new_container/Gemfile.jdbc:postgres
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.jdbc:sqlite3
+++ b/test/fixtures/commands/application/new_container/Gemfile.jdbc:sqlite3
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.jruby:filesystem
+++ b/test/fixtures/commands/application/new_container/Gemfile.jruby:filesystem
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.jruby:head
+++ b/test/fixtures/commands/application/new_container/Gemfile.jruby:head
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami-utils',       require: false, github: 'hanami/utils'

--- a/test/fixtures/commands/application/new_container/Gemfile.jruby:memory
+++ b/test/fixtures/commands/application/new_container/Gemfile.jruby:memory
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.jruby:minitest
+++ b/test/fixtures/commands/application/new_container/Gemfile.jruby:minitest
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.jruby:rspec
+++ b/test/fixtures/commands/application/new_container/Gemfile.jruby:rspec
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.jruby:slim
+++ b/test/fixtures/commands/application/new_container/Gemfile.jruby:slim
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.memory
+++ b/test/fixtures/commands/application/new_container/Gemfile.memory
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.minitest
+++ b/test/fixtures/commands/application/new_container/Gemfile.minitest
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.mysql2
+++ b/test/fixtures/commands/application/new_container/Gemfile.mysql2
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.postgres
+++ b/test/fixtures/commands/application/new_container/Gemfile.postgres
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.rspec
+++ b/test/fixtures/commands/application/new_container/Gemfile.rspec
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.slim
+++ b/test/fixtures/commands/application/new_container/Gemfile.slim
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/commands/application/new_container/Gemfile.sqlite3
+++ b/test/fixtures/commands/application/new_container/Gemfile.sqlite3
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 
 gem 'hanami',       '~> 0.8'

--- a/test/fixtures/rake/rake_tasks/Gemfile
+++ b/test/fixtures/rake/rake_tasks/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 gem 'sqlite3',      platforms: :ruby
 gem 'jdbc-sqlite3', platforms: :jruby

--- a/test/fixtures/rake/rake_tasks_app/Gemfile
+++ b/test/fixtures/rake/rake_tasks_app/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 gem 'sqlite3',      platforms: :ruby
 gem 'jdbc-sqlite3', platforms: :jruby

--- a/test/fixtures/static_assets/Gemfile
+++ b/test/fixtures/static_assets/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 gem 'sass'
 

--- a/test/fixtures/static_assets_app/Gemfile
+++ b/test/fixtures/static_assets_app/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundler'
 gem 'rake'
 gem 'sass'
 


### PR DESCRIPTION
In a Gemfile generate by `hanami new` contains a line

```ruby
gem 'bundler'
```

I think it is redundant.

Since Gemfiles are intended to be interpreted by bundler itself, when it can tell you the project depends on bundler, you already have it.

Consider removing this line from generated apps.