### PR TITLE
Adds the missing AUTOINCREMENT keyword to migrate_spec

### DIFF
--- a/spec/integration/cli/db/migrate_spec.rb
+++ b/spec/integration/cli/db/migrate_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "hanami db", type: :cli do
         db = Pathname.new("db").join("#{project}_development.sqlite")
 
         users = `sqlite3 #{db} ".schema users"`
-        expect(users).to include("CREATE TABLE `users`(`id` integer DEFAULT (NULL) NOT NULL PRIMARY KEY, `name` varchar(255) DEFAULT (NULL) NULL);")
+        expect(users).to include("CREATE TABLE `users`(`id` integer DEFAULT (NULL) NOT NULL PRIMARY KEY AUTOINCREMENT, `name` varchar(255) DEFAULT (NULL) NULL);")
 
         version = `sqlite3 #{db} "SELECT filename FROM schema_migrations ORDER BY filename DESC LIMIT 1"`
         expect(version).to include("create_users")


### PR DESCRIPTION
This PR fix the current master by adding the `AUTOINCREMENT` keyword to [this](https://github.com/hanami/hanami/blob/master/spec/integration/cli/db/migrate_spec.rb#L54) spec.

All the other tests had it, but somehow this one did not (last edit on this file was a long while ago).