### PR TITLE
Do not overwrite shell declared ENV vars

### DIFF
--- a/lib/hanami/env.rb
+++ b/lib/hanami/env.rb
@@ -59,6 +59,8 @@ module Hanami
       parsed   = Dotenv::Parser.call(contents)
 
       parsed.each do |k, v|
+        next if @env.has_key?(k)
+
         @env[k] = v
       end
       nil

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -193,6 +193,10 @@ module Hanami
     #   # is "development". The settings defined in this last file override
     #   # the one defined in the parent (eg `FOO` is overwritten). All the
     #   # other settings (eg `XYZ`) will be left untouched.
+    #   # Variables declared on `.env` and `.env.development` will not override
+    #   # any variable declared on the shell when calling a `hanami` command.
+    #   # Eg. In `FOO="not ok" bundle exec hanami c` `FOO` will not be overwritten
+    #   # to `"ok"`.
     def initialize(options = {})
       opts     = options.to_h.dup
       @env     = Hanami::Env.new(env: opts.delete(:env) || ENV)

--- a/spec/unit/env_spec.rb
+++ b/spec/unit/env_spec.rb
@@ -26,5 +26,15 @@ RSpec.describe Hanami::Env do
       subject.load!('spec/support/fixtures/dotenv/.env.development')
       expect(subject['BAZ']).to eq('yes')
     end
+
+    it "does not overwrite existing env vars" do
+      env = { "BAZ" => "no" }
+      subject = described_class.new(env: env)
+
+      subject.load!('spec/support/fixtures/dotenv/.env.development')
+      expect(subject['BAZ']).to eq('no')
+      expect(subject['HANAMI_PORT']).to eq('42')
+      expect(subject['WAT']).to eq('true')
+    end
   end
 end

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Hanami::Environment do
           expect(subject.port).to eq(42)
         end
       end
+
+      context 'with same ENV variable set in ENV and .env.development' do
+        let(:env) { {'WAT' => 'false'} }
+
+        it 'sets manual set ENV vars over .env.development set' do
+          with_directory('spec/support/fixtures/dotenv') do
+            described_class.new(env: env)
+
+            expect(env['HANAMI_PORT']).to eq('42')
+
+            expect(env['BAZ']).to eq('yes')
+            expect(env['WAT']).to eq('false')
+          end
+        end
+      end
     end
 
     context "missing per environment .env" do


### PR DESCRIPTION
As mentioned on #712, if an `ENV` var, with the same name as one declared on `.env.*` is declared on the shell when calling a hanami command, we will end up with the value declared on `.env.*, which is not the desired outcome.

This PR changes the initialization of `Hanami::Environment` to ensure that the `ENV` vars declared by the user on the shell are not overwritten when `.env.*` is loaded.

While my solutions works, there are some I would like to discuss if it is the best solution or not. 

My other solution was to change `Hanami::Env#load!` to only load the variables that yet not loaded on the instance. Now that I am writing this PR and thinking better, this is actually a better solution then the actual, but I wait for some feedback before I act on it.

Closes #712