### PR TITLE
Adds the right url for postgres on JRuby.

### DIFF
--- a/lib/hanami/application_configuration.rb
+++ b/lib/hanami/application_configuration.rb
@@ -1398,7 +1398,7 @@ module Hanami
     #   module Bookshelf
     #     class Application < Hanami::Application
     #       configure do
-    #         adapter       :sql, 'postgres://localhost/database'
+    #         adapter       :sql, 'postgresql://localhost/database'
     #         model.adapter :sql, 'sqlite://db/bookshelf_development'
     #       end
     #     end

--- a/lib/hanami/generators/application/app/lib/app_name.rb.tt
+++ b/lib/hanami/generators/application/app/lib/app_name.rb.tt
@@ -9,7 +9,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter :sql, 'sqlite://db/<%= config[:app_name] %>_development.sqlite3'
-  #    adapter :sql, 'postgres://localhost/<%= config[:app_name] %>_development'
+  #    adapter :sql, 'postgresql://localhost/<%= config[:app_name] %>_development'
   #    adapter :sql, 'mysql://localhost/<%= config[:app_name] %>_development'
   #
   adapter :<%= config[:database_config][:type] %>, ENV['DATABASE_URL']

--- a/lib/hanami/generators/application/container/config/environment.rb.tt
+++ b/lib/hanami/generators/application/container/config/environment.rb.tt
@@ -13,7 +13,7 @@ Hanami.configure do
     #
     #  * SQL adapter
     #    adapter :sql, 'sqlite://db/<%= config[:project_name] %>_development.sqlite3'
-    #    adapter :sql, 'postgres://localhost/<%= config[:project_name] %>_development'
+    #    adapter :sql, 'postgresql://localhost/<%= config[:project_name] %>_development'
     #    adapter :sql, 'mysql://localhost/<%= config[:project_name] %>_development'
     #
     adapter :<%= config[:database_config][:type] %>, ENV['DATABASE_URL']

--- a/lib/hanami/generators/database_config.rb
+++ b/lib/hanami/generators/database_config.rb
@@ -77,11 +77,7 @@ module Hanami
             "mysql2://localhost/#{ name }"
           end
         when 'postgresql', 'postgres'
-          if Hanami::Utils.jruby?
-            "postgresql://localhost/#{ name }"
-          else
-            "postgres://localhost/#{ name }"
-          end
+          "postgresql://localhost/#{ name }"
         when 'sqlite', 'sqlite3'
           "sqlite://db/#{ Shellwords.escape(name) }"
         end

--- a/lib/hanami/generators/database_config.rb
+++ b/lib/hanami/generators/database_config.rb
@@ -77,7 +77,11 @@ module Hanami
             "mysql2://localhost/#{ name }"
           end
         when 'postgresql', 'postgres'
-          "postgres://localhost/#{ name }"
+          if Hanami::Utils.jruby?
+            "postgresql://localhost/#{ name }"
+          else
+            "postgres://localhost/#{ name }"
+          end
         when 'sqlite', 'sqlite3'
           "sqlite://db/#{ Shellwords.escape(name) }"
         end

--- a/spec/integration/cli/new/database_spec.rb
+++ b/spec/integration/cli/new/database_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "hanami new", type: :cli do
           # .env.development
           #
           development_url = Platform.match do
-            engine(:ruby)  { "postgres://localhost/#{project}_development" }
-            engine(:jruby) { "jdbc:postgres://localhost/#{project}_development" }
+            engine(:ruby)  { "postgresql://localhost/#{project}_development" }
+            engine(:jruby) { "jdbc:postgresql://localhost/#{project}_development" }
           end
 
           expect('.env.development').to have_file_content(%r{DATABASE_URL="#{development_url}"})

--- a/spec/integration/cli/new/database_spec.rb
+++ b/spec/integration/cli/new/database_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "hanami new", type: :cli do
           # .env.test
           #
           test_url = Platform.match do
-            engine(:ruby)  { "postgres://localhost/#{project}_test" }
-            engine(:jruby) { "jdbc:postgres://localhost/#{project}_test" }
+            engine(:ruby)  { "postgresql://localhost/#{project}_test" }
+            engine(:jruby) { "jdbc:postgresql://localhost/#{project}_test" }
           end
 
           expect('.env.test').to have_file_content(%r{DATABASE_URL="#{test_url}"})

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -165,7 +165,7 @@ Hanami.configure do
     #
     #  * SQL adapter
     #    adapter :sql, 'sqlite://db/#{project}_development.sqlite3'
-    #    adapter :sql, 'postgres://localhost/#{project}_development'
+    #    adapter :sql, 'postgresql://localhost/#{project}_development'
     #    adapter :sql, 'mysql://localhost/#{project}_development'
     #
     adapter :sql, ENV['DATABASE_URL']

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -471,7 +471,7 @@ Hanami.configure do
     #
     #  * SQL adapter
     #    adapter :sql, 'sqlite://db/#{project}_development.sqlite3'
-    #    adapter :sql, 'postgres://localhost/#{project}_development'
+    #    adapter :sql, 'postgresql://localhost/#{project}_development'
     #    adapter :sql, 'mysql://localhost/#{project}_development'
     #
     adapter :sql, ENV['DATABASE_URL']

--- a/test/commands/new/container_test.rb
+++ b/test/commands/new/container_test.rb
@@ -155,10 +155,10 @@ describe Hanami::Commands::New::Container do
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_development\"")
+            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgresql://localhost/new_container_development\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_test\"")
+            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgresql://localhost/new_container_test\"")
 
             assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }postgres"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.postgres.rb'), 'lib/new_container.rb')
@@ -196,10 +196,10 @@ describe Hanami::Commands::New::Container do
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_development\"")
+            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgresql://localhost/new_container_development\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_test\"")
+            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgresql://localhost/new_container_test\"")
 
             assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }postgres"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.postgres.rb'), 'lib/new_container.rb')

--- a/test/fixtures/commands/application/new_app/lib/new_app.rb
+++ b/test/fixtures/commands/application/new_app/lib/new_app.rb
@@ -15,7 +15,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/new_app_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/new_app_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/new_app_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_app_development'
   #
   adapter type: :file_system, uri: ENV['DATABASE_URL']

--- a/test/fixtures/commands/application/new_container/lib/new_container.filesystem.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.filesystem.rb
@@ -16,7 +16,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/new_container_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
   adapter type: :file_system, uri: ENV['DATABASE_URL']

--- a/test/fixtures/commands/application/new_container/lib/new_container.memory.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.memory.rb
@@ -16,7 +16,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/new_container_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
   adapter type: :memory, uri: ENV['DATABASE_URL']

--- a/test/fixtures/commands/application/new_container/lib/new_container.mysql2.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.mysql2.rb
@@ -16,7 +16,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/new_container_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
   adapter type: :sql, uri: ENV['DATABASE_URL']

--- a/test/fixtures/commands/application/new_container/lib/new_container.postgres.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.postgres.rb
@@ -16,7 +16,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/new_container_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
   adapter type: :sql, uri: ENV['DATABASE_URL']

--- a/test/fixtures/commands/application/new_container/lib/new_container.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.rb
@@ -16,7 +16,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/new_container_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
   adapter type: :file_system, uri: ENV['DATABASE_URL']

--- a/test/fixtures/commands/application/new_container/lib/new_container.sqlite3.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.sqlite3.rb
@@ -16,7 +16,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/new_container_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
   adapter type: :sql, uri: ENV['DATABASE_URL']

--- a/test/fixtures/rake/rake_tasks/lib/rake_tasks.rb
+++ b/test/fixtures/rake/rake_tasks/lib/rake_tasks.rb
@@ -22,7 +22,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/rake_tasks_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/rake_tasks_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/rake_tasks_development'
   #    adapter type: :sql, uri: 'mysql://localhost/rake_tasks_development'
   #
   adapter type: :sql, uri: "#{ADAPTER_TYPE}://#{Dir.pwd}/db/rake_tasks_test.sqlite"

--- a/test/fixtures/rake/rake_tasks_app/lib/rake_tasks_app.rb
+++ b/test/fixtures/rake/rake_tasks_app/lib/rake_tasks_app.rb
@@ -22,7 +22,7 @@ Hanami::Model.configure do
   #
   #  * SQL adapter
   #    adapter type: :sql, uri: 'sqlite://db/rake_tasks_app_development.sqlite3'
-  #    adapter type: :sql, uri: 'postgres://localhost/rake_tasks_app_development'
+  #    adapter type: :sql, uri: 'postgresql://localhost/rake_tasks_app_development'
   #    adapter type: :sql, uri: 'mysql://localhost/rake_tasks_app_development'
   #
   adapter type: :sql, uri: "#{ADAPTER_TYPE}://#{Dir.pwd}/db/rake_tasks_app_test.sqlite"

--- a/test/generators/database_config_test.rb
+++ b/test/generators/database_config_test.rb
@@ -58,6 +58,7 @@ describe Hanami::Generators::DatabaseConfig do
 
   describe '#to_hash' do
     let(:adapter_prefix) { :'jdbc:' if Hanami::Utils.jruby? }
+    let(:adapter_postfix) { :'ql' if Hanami::Utils.jruby? }
 
     describe 'SQL databases' do
       let(:engine) { 'postgres' }
@@ -67,8 +68,8 @@ describe Hanami::Generators::DatabaseConfig do
           gem: (Hanami::Utils.jruby? ? 'jdbc-postgres' : 'pg'),
           type: :sql,
           uri: {
-            development: "#{ adapter_prefix }postgres://localhost/basecamp_development",
-            test: "#{ adapter_prefix }postgres://localhost/basecamp_test"
+            development: "#{ adapter_prefix }postgres#{ adapter_postfix }://localhost/basecamp_development",
+            test: "#{ adapter_prefix }postgres#{ adapter_postfix }://localhost/basecamp_test"
           }
         )
       end

--- a/test/generators/database_config_test.rb
+++ b/test/generators/database_config_test.rb
@@ -58,7 +58,6 @@ describe Hanami::Generators::DatabaseConfig do
 
   describe '#to_hash' do
     let(:adapter_prefix) { :'jdbc:' if Hanami::Utils.jruby? }
-    let(:adapter_postfix) { :'ql' if Hanami::Utils.jruby? }
 
     describe 'SQL databases' do
       let(:engine) { 'postgres' }
@@ -68,8 +67,8 @@ describe Hanami::Generators::DatabaseConfig do
           gem: (Hanami::Utils.jruby? ? 'jdbc-postgres' : 'pg'),
           type: :sql,
           uri: {
-            development: "#{ adapter_prefix }postgres#{ adapter_postfix }://localhost/basecamp_development",
-            test: "#{ adapter_prefix }postgres#{ adapter_postfix }://localhost/basecamp_test"
+            development: "#{ adapter_prefix }postgresql://localhost/basecamp_development",
+            test: "#{ adapter_prefix }postgresql://localhost/basecamp_test"
           }
         )
       end


### PR DESCRIPTION
Currently when generating a new app with `hanami new bookshelf --database=postgres` the default database url is `DATABASE_URL="jdbc:postgres://localhost/bookshelf_development"` when it should be `DATABASE_URL="jdbc:postgresql://localhost/bookshelf_development"`. 

The reason is that Sequel requires the `jdbc:postgresql` database adapter instead of `jdbc:postgres`.