### PR TITLE
Fix generate new mailer when app dir name and app name differ

### DIFF
--- a/lib/hanami/commands/generate/abstract.rb
+++ b/lib/hanami/commands/generate/abstract.rb
@@ -53,6 +53,11 @@ module Hanami
           end
         end
 
+        # @since 0.8.0
+        # @api private
+        def project_name
+          Utils::String.new(Hanami::Environment.new.project_name).underscore
+        end
       end
     end
   end

--- a/lib/hanami/commands/generate/mailer.rb
+++ b/lib/hanami/commands/generate/mailer.rb
@@ -110,7 +110,7 @@ module Hanami
         end
 
         def core_root
-          Pathname.new("lib").join(::File.basename(Dir.getwd))
+          Pathname.new("lib").join(project_name)
         end
       end
     end

--- a/lib/hanami/commands/generate/model.rb
+++ b/lib/hanami/commands/generate/model.rb
@@ -113,12 +113,6 @@ module Hanami
         def model_name_underscored
           input
         end
-
-        # @since 0.8.0
-        # @api private
-        def project_name
-          Utils::String.new(Hanami::Environment.new.project_name).underscore
-        end
       end
     end
   end

--- a/spec/integration/cli/generate/mailer_spec.rb
+++ b/spec/integration/cli/generate/mailer_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe "hanami generate", type: :cli do
+  describe 'mailer' do
+    it 'generates new mailer' do
+      with_project('bookshelf_generate_mailer') do
+        output = [
+          "create  spec/bookshelf_generate_mailer/mailers/welcome_spec.rb",
+          "create  lib/bookshelf_generate_mailer/mailers/welcome.rb",
+          "create  lib/bookshelf_generate_mailer/mailers/templates/welcome.txt.erb",
+          "create  lib/bookshelf_generate_mailer/mailers/templates/welcome.html.erb"
+        ]
+
+        run_command "hanami generate mailer welcome", output
+
+        #
+        # spec/bookshelf_generate_mailer/mailers/welcome_spec.rb
+        #
+        expect('spec/bookshelf_generate_mailer/mailers/welcome_spec.rb').to have_file_content <<-END
+require 'spec_helper'
+
+describe Mailers::Welcome do
+  it 'delivers email' do
+    mail = Mailers::Welcome.deliver
+  end
+end
+END
+
+        #
+        # lib/bookshelf_generate_mailer/mailers/welcome.rb
+        #
+        expect('lib/bookshelf_generate_mailer/mailers/welcome.rb').to have_file_content <<-END
+class Mailers::Welcome
+  include Hanami::Mailer
+
+  from    '<from>'
+  to      '<to>'
+  subject 'Hello'
+end
+END
+
+        expect('lib/bookshelf_generate_mailer/mailers/templates/welcome.txt.erb').to have_file_content ''
+        expect('lib/bookshelf_generate_mailer/mailers/templates/welcome.html.erb').to have_file_content ''
+      end
+    end
+
+
+    it "fails with missing arguments" do
+      with_project('bookshelf_generate_mailer_without_args') do
+        output = <<-OUT
+ERROR: "hanami mailer" was called with no arguments
+Usage: "hanami mailer NAME"
+OUT
+
+        run_command "hanami generate mailer", output
+      end
+    end
+
+    it 'generates mailer with options from, to, subject' do
+      with_project('bookshelf_generate_mailer_with_options') do
+        output = [
+          "create  spec/bookshelf_generate_mailer_with_options/mailers/welcome_spec.rb",
+          "create  lib/bookshelf_generate_mailer_with_options/mailers/welcome.rb",
+          "create  lib/bookshelf_generate_mailer_with_options/mailers/templates/welcome.txt.erb",
+          "create  lib/bookshelf_generate_mailer_with_options/mailers/templates/welcome.html.erb"
+        ]
+
+        run_command "hanami generate mailer welcome --from=\"'mail@example.com'\" --to=\"'user@example.com'\" --subject=\"'Welcome'\"", output
+
+        expect('lib/bookshelf_generate_mailer_with_options/mailers/welcome.rb').to have_file_content <<-END
+class Mailers::Welcome
+  include Hanami::Mailer
+
+  from    'mail@example.com'
+  to      'user@example.com'
+  subject 'Welcome'
+end
+END
+      end
+    end
+  end
+end


### PR DESCRIPTION
For example if application live in `docker` in `/app` dir
command `hanami generate mailer welcome` copy templates to wrong dir
`lib/app/mailers/welcome.rb`

```
create  spec./mailers/welcome_spec.rb
create  lib./mailers/welcome.rb
create  lib./mailers/templates/welcome.txt.erb
create
lib./mailers/templates/welcome.html.erb
```