### PR TITLE
Add Hanami::Configuration#environment for environment specific settings

### DIFF
--- a/lib/hanami/commands/new/container.rb
+++ b/lib/hanami/commands/new/container.rb
@@ -64,6 +64,7 @@ module Hanami
 
         def add_empty_directories
           add_mapping('.gitkeep', 'public/.gitkeep')
+          add_mapping('.gitkeep', 'log/.gitkeep')
           add_mapping('.gitkeep', 'config/initializers/.gitkeep')
           add_mapping('.gitkeep', "lib/#{ project_name }/entities/.gitkeep")
           add_mapping('.gitkeep', "lib/#{ project_name }/repositories/.gitkeep")

--- a/lib/hanami/commands/new/container.rb
+++ b/lib/hanami/commands/new/container.rb
@@ -64,7 +64,6 @@ module Hanami
 
         def add_empty_directories
           add_mapping('.gitkeep', 'public/.gitkeep')
-          add_mapping('.gitkeep', 'log/.gitkeep')
           add_mapping('.gitkeep', 'config/initializers/.gitkeep')
           add_mapping('.gitkeep', "lib/#{ project_name }/entities/.gitkeep")
           add_mapping('.gitkeep', "lib/#{ project_name }/repositories/.gitkeep")

--- a/lib/hanami/components/components.rb
+++ b/lib/hanami/components/components.rb
@@ -28,7 +28,7 @@ module Hanami
       end
 
       resolve do |configuration|
-        Hanami::Logger.new(Hanami.environment.project_name, configuration.logger)
+        Hanami::Logger.new(Hanami.environment.project_name, configuration.logger) unless configuration.logger.nil?
       end
     end
 

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -17,7 +17,6 @@ module Hanami
 
     def initialize(&blk)
       @settings = Concurrent::Map.new
-      # @settings[:environments] = Concurrent::Hash.new { |h, k| h[k] = [] }
       instance_eval(&blk)
     end
 
@@ -49,14 +48,13 @@ module Hanami
 
     def logger(options = nil)
       if options.nil?
-        settings.fetch(:logger)
+        settings.fetch(:logger, nil)
       else
         settings[:logger] = options
       end
     end
 
     def environment(name)
-      # settings[:environments][name.to_sym] << blk
       yield if ENV['HANAMI_ENV'] == name.to_s
     end
 

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -17,6 +17,7 @@ module Hanami
 
     def initialize(&blk)
       @settings = Concurrent::Map.new
+      # @settings[:environments] = Concurrent::Hash.new { |h, k| h[k] = [] }
       instance_eval(&blk)
     end
 
@@ -50,8 +51,13 @@ module Hanami
       if options.nil?
         settings.fetch(:logger)
       else
-        settings.put_if_absent(:logger, options)
+        settings[:logger] = options
       end
+    end
+
+    def environment(name)
+      # settings[:environments][name.to_sym] << blk
+      yield if ENV['HANAMI_ENV'] == name.to_s
     end
 
     private

--- a/lib/hanami/generators/application/container/config/environment.rb.tt
+++ b/lib/hanami/generators/application/container/config/environment.rb.tt
@@ -40,4 +40,12 @@ Hanami.configure do
       # production :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
     end
   end
+
+  environment :test do
+    logger level: :debug, stream: 'log/test.log'
+  end
+
+  environment :production do
+    logger level: :info, formatter: :json
+  end
 end

--- a/lib/hanami/generators/application/container/config/environment.rb.tt
+++ b/lib/hanami/generators/application/container/config/environment.rb.tt
@@ -5,9 +5,6 @@ require_relative '../lib/<%= config[:project_name] %>'
 
 Hanami.configure do
 
-  # See: http://hanamirb.org/guides/projects/logging
-  logger level: :debug
-
   model do
     ##
     # Database adapter
@@ -34,18 +31,19 @@ Hanami.configure do
     root 'lib/<%= config[:project_name] %>/mailers'
 
     # See http://hanamirb.org/guides/mailers/delivery
-    delivery do
-      development :test
-      test        :test
-      # production :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
-    end
+    delivery :test
   end
 
-  environment :test do
-    logger level: :debug, stream: 'log/test.log'
+  environment :development do
+    # See: http://hanamirb.org/guides/projects/logging
+    logger level: :debug
   end
 
   environment :production do
     logger level: :info, formatter: :json
+
+    mailer do
+      delivery :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
+    end
   end
 end

--- a/lib/hanami/mailer/glue.rb
+++ b/lib/hanami/mailer/glue.rb
@@ -1,55 +1,13 @@
-require 'hanami/utils/basic_object'
-
 module Hanami::Mailer
   # @since 0.5.0
   # @api private
-  class Delivery < ::Hanami::Utils::BasicObject
-    # @since 0.5.0
-    # @api private
-    def initialize(env, &blk)
-      @env = env
-      instance_eval(&blk)
-    end
-
-    # @since 0.5.0
-    # @api private
-    def to_config
-      @config
-    end
-
-    # @since 0.5.0
-    # @api private
-    def test(*args)
-      __setup_config(:test, *args)
-    end
-
-    private
-
-    # @since 0.5.0
-    # @api private
-    def method_missing(m, *args)
-      __setup_config(m, *args)
-    end
-
-    # @since 0.5.0
-    # @api private
-    def __setup_config(env, *args)
-      if env.to_s == @env
-        @config = args
-      end
-    end
-  end
-
-
-  # @since 0.5.0
-  # @api private
   module Glue
-
     # @since 0.5.0
     # @api private
-    def delivery(&blk)
-      raise ArgumentError unless block_given?
-      delivery_method(*Hanami::Mailer::Delivery.new(Hanami.env, &blk).to_config)
+    def self.included(configuration)
+      configuration.class_eval do
+        alias_method :delivery, :delivery_method
+      end
     end
   end
 

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'hanami new', type: :cli do
       create  config/environment.rb
       create  lib/#{project}.rb
       create  public/.gitkeep
+      create  log/.gitkeep
       create  config/initializers/.gitkeep
       create  lib/#{project}/entities/.gitkeep
       create  lib/#{project}/repositories/.gitkeep
@@ -199,6 +200,14 @@ Hanami.configure do
       # production :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
     end
   end
+
+  environment :test do
+    logger level: :debug, stream: 'log/test.log'
+  end
+
+  environment :production do
+    logger level: :info, formatter: :json
+  end
 end
 END
 
@@ -213,6 +222,11 @@ END
       # public/.gitkeep
       #
       expect('public/.gitkeep').to be_an_existing_file
+
+      #
+      # log/.gitkeep
+      #
+      expect('log/.gitkeep').to be_an_existing_file
 
       #
       # config/initializers/.gitkeep

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'hanami new', type: :cli do
       create  config/environment.rb
       create  lib/#{project}.rb
       create  public/.gitkeep
-      create  log/.gitkeep
       create  config/initializers/.gitkeep
       create  lib/#{project}/entities/.gitkeep
       create  lib/#{project}/repositories/.gitkeep
@@ -167,9 +166,6 @@ require_relative '../apps/web/application'
 Hanami.configure do
   mount Web::Application, at: '/'
 
-  # See: http://hanamirb.org/guides/projects/logging
-  logger level: :debug
-
   model do
     ##
     # Database adapter
@@ -194,19 +190,20 @@ Hanami.configure do
     root 'lib/#{project}/mailers'
 
     # See http://hanamirb.org/guides/mailers/delivery
-    delivery do
-      development :test
-      test        :test
-      # production :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
-    end
+    delivery :test
   end
 
-  environment :test do
-    logger level: :debug, stream: 'log/test.log'
+  environment :development do
+    # See: http://hanamirb.org/guides/projects/logging
+    logger level: :debug
   end
 
   environment :production do
     logger level: :info, formatter: :json
+
+    mailer do
+      delivery :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
+    end
   end
 end
 END
@@ -222,11 +219,6 @@ END
       # public/.gitkeep
       #
       expect('public/.gitkeep').to be_an_existing_file
-
-      #
-      # log/.gitkeep
-      #
-      expect('log/.gitkeep').to be_an_existing_file
 
       #
       # config/initializers/.gitkeep

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -433,9 +433,6 @@ Hanami.configure do
   mount #{app_name}::Application, at: '/#{app}'
   mount Web::Application, at: '/'
 
-  # See: http://hanamirb.org/guides/projects/logging
-  logger level: :debug
-
   model do
     ##
     # Database adapter
@@ -460,19 +457,20 @@ Hanami.configure do
     root 'lib/#{project}/mailers'
 
     # See http://hanamirb.org/guides/mailers/delivery
-    delivery do
-      development :test
-      test        :test
-      # production :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
-    end
+    delivery :test
   end
 
-  environment :test do
-    logger level: :debug, stream: 'log/test.log'
+  environment :development do
+    # See: http://hanamirb.org/guides/projects/logging
+    logger level: :debug
   end
 
   environment :production do
     logger level: :info, formatter: :json
+
+    mailer do
+      delivery :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
+    end
   end
 end
 END

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -466,6 +466,14 @@ Hanami.configure do
       # production :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
     end
   end
+
+  environment :test do
+    logger level: :debug, stream: 'log/test.log'
+  end
+
+  environment :production do
+    logger level: :info, formatter: :json
+  end
 end
 END
 


### PR DESCRIPTION
Add Hanami::Configuration#environment for environment specific settings. Add different logger settings according to the current env.

With this proposal, the generated `config/environment.rb` will look like this:

```ruby
require 'bundler/setup'
require 'hanami/setup'
require 'hanami/model'
require_relative '../lib/bookshelf'
require_relative '../apps/web/application'

Hanami.configure do
  mount Web::Application, at: '/'

  model do
    ##
    # Database adapter
    #
    # Available options:
    #
    #  * SQL adapter
    #    adapter :sql, 'sqlite://db/bookshelf_development.sqlite3'
    #    adapter :sql, 'postgresql://localhost/bookshelf_development'
    #    adapter :sql, 'mysql://localhost/bookshelf_development'
    #
    adapter :sql, ENV['DATABASE_URL']

    ##
    # Migrations
    #
    migrations 'db/migrations'
    schema     'db/schema.sql'
  end

  mailer do
    root 'lib/bookshelf/mailers'

    # See http://hanamirb.org/guides/mailers/delivery
    delivery :test
  end

  environment :development do
    # See: http://hanamirb.org/guides/projects/logging
    logger level: :debug
  end

  environment :production do
    logger level: :info, formatter: :json

    mailer do
      delivery :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
    end
  end
end
```

@hanami/issues @hanami/ecosystem I have one doubt about the `test` environment. Do we want to have a logger redirected to `log/test.log` or do we want to skip logging at all? Please let me know what you think. Thanks!