### PR TITLE
Help messages on cli displays subcommands names

### DIFF
--- a/lib/hanami/cli_base.rb
+++ b/lib/hanami/cli_base.rb
@@ -27,5 +27,9 @@ module Hanami
     def define_commands(&blk)
       class_eval(&blk) if block_given?
     end
+
+    def banner(command, nspace = true, subcommand = false)
+      super(command, nspace, namespace != 'hanami:cli')
+    end
   end
 end

--- a/lib/hanami/cli_base.rb
+++ b/lib/hanami/cli_base.rb
@@ -31,5 +31,16 @@ module Hanami
     def banner(command, nspace = true, subcommand = false)
       super(command, nspace, namespace != 'hanami:cli')
     end
+
+    def handle_argument_error(command, error, args, arity)
+      name = [(namespace == 'hanami:cli' ? nil : namespace), command.name].compact.join(" ")
+
+      msg = "ERROR: \"#{basename} #{name}\" was called with "
+      msg << "no arguments"               if     args.empty?
+      msg << "arguments " << args.inspect unless args.empty?
+      msg << "\nUsage: #{banner(command).inspect}"
+
+      raise Thor::InvocationError, msg
+    end
   end
 end

--- a/lib/hanami/cli_sub_commands/destroy.rb
+++ b/lib/hanami/cli_sub_commands/destroy.rb
@@ -28,7 +28,7 @@ module Hanami
       def actions(application_name = nil, controller_and_action_name)
         if Hanami::Environment.new(options).container? && application_name.nil?
           msg = "ERROR: \"hanami destroy action\" was called with arguments [\"#{controller_and_action_name}\"]\n" \
-                "Usage: \"hanami action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME\""
+                "Usage: \"hanami destroy action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME\""
           fail Error, msg
         end
 

--- a/lib/hanami/cli_sub_commands/destroy.rb
+++ b/lib/hanami/cli_sub_commands/destroy.rb
@@ -60,7 +60,7 @@ module Hanami
         `hanami destroy model` will destroy an entity along with repository
         and corresponding tests
 
-        > $ hanami generate model car
+        > $ hanami destroy model car
       EOS
 
       def model(name)

--- a/lib/hanami/cli_sub_commands/generate.rb
+++ b/lib/hanami/cli_sub_commands/generate.rb
@@ -40,7 +40,7 @@ module Hanami
       def actions(application_name = nil, controller_and_action_name)
         if Hanami::Environment.new(options).container? && application_name.nil?
           msg = "ERROR: \"hanami generate action\" was called with arguments [\"#{controller_and_action_name}\"]\n" \
-                "Usage: \"hanami action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME\""
+                "Usage: \"hanami generate action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME\""
           fail Error, msg
         end
 

--- a/spec/integration/cli/db/create_spec.rb
+++ b/spec/integration/cli/db/create_spec.rb
@@ -24,5 +24,19 @@ RSpec.describe "hanami db", type: :cli do
         expect(db).to_not be_an_existing_file
       end
     end
+
+    it 'prints help message' do
+      output = <<-OUT
+Usage:
+  hanami db create
+
+Options:
+  [--environment=ENVIRONMENT]  # Path to environment configuration (config/environment.rb)
+
+Create database for current environment
+OUT
+
+      run_command 'hanami db create --help', output
+    end
   end
 end

--- a/spec/integration/cli/destroy/action_spec.rb
+++ b/spec/integration/cli/destroy/action_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "hanami destroy", type: :cli do
       with_project do
         output = <<-OUT
 ERROR: "hanami actions" was called with no arguments
-Usage: "hanami action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
+Usage: "hanami destroy action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
 OUT
 
         run_command "hanami destroy action", output # , exit_status: 1 FIXME: Thor exit with 0

--- a/spec/integration/cli/destroy/action_spec.rb
+++ b/spec/integration/cli/destroy/action_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "hanami destroy", type: :cli do
     it "fails with missing arguments" do
       with_project do
         output = <<-OUT
-ERROR: "hanami actions" was called with no arguments
+ERROR: "hanami destroy actions" was called with no arguments
 Usage: "hanami destroy action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
 OUT
 
@@ -39,7 +39,7 @@ OUT
       with_project('bookshelf_generate_action_without_app') do
         output = <<-OUT
 ERROR: "hanami destroy action" was called with arguments ["home#index"]
-Usage: "hanami action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
+Usage: "hanami destroy action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
 OUT
 
         run_command "hanami destroy action home#index", output # , exit_status: 1 FIXME: Thor exit with 0

--- a/spec/integration/cli/destroy/app_spec.rb
+++ b/spec/integration/cli/destroy/app_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "hanami destroy", type: :cli do
       with_project do
         output = <<-OUT
 ERROR: "hanami application" was called with no arguments
-Usage: "hanami application NAME"
+Usage: "hanami destroy application NAME"
 OUT
         run_command "hanami destroy app", output
       end

--- a/spec/integration/cli/destroy/app_spec.rb
+++ b/spec/integration/cli/destroy/app_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "hanami destroy", type: :cli do
     it "fails with missing argument" do
       with_project do
         output = <<-OUT
-ERROR: "hanami application" was called with no arguments
+ERROR: "hanami destroy application" was called with no arguments
 Usage: "hanami destroy application NAME"
 OUT
         run_command "hanami destroy app", output
@@ -42,7 +42,7 @@ OUT
     xit "fails with unknown app" do
       with_project do
         output = <<-OUT
-ERROR: "hanami application" was called with no arguments
+ERROR: "hanami destroy application" was called with no arguments
 Usage: "hanami application NAME"
 OUT
         run_command "hanami destroy app unknown", output

--- a/spec/integration/cli/destroy/migration_spec.rb
+++ b/spec/integration/cli/destroy/migration_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "hanami destroy", type: :cli do
       with_project do
         output = <<-OUT
 ERROR: "hanami migration" was called with no arguments
-Usage: "hanami migration NAME"
+Usage: "hanami destroy migration NAME"
 OUT
         run_command "hanami destroy migration", output
       end

--- a/spec/integration/cli/destroy/migration_spec.rb
+++ b/spec/integration/cli/destroy/migration_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "hanami destroy", type: :cli do
     it "fails with missing argument" do
       with_project do
         output = <<-OUT
-ERROR: "hanami migration" was called with no arguments
+ERROR: "hanami destroy migration" was called with no arguments
 Usage: "hanami destroy migration NAME"
 OUT
         run_command "hanami destroy migration", output

--- a/spec/integration/cli/destroy/model_spec.rb
+++ b/spec/integration/cli/destroy/model_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "hanami destroy", type: :cli do
     it "fails with missing argument" do
       with_project do
         output = <<-OUT
-ERROR: "hanami model" was called with no arguments
+ERROR: "hanami destroy model" was called with no arguments
 Usage: "hanami destroy model NAME"
 OUT
         run_command "hanami destroy model", output

--- a/spec/integration/cli/destroy/model_spec.rb
+++ b/spec/integration/cli/destroy/model_spec.rb
@@ -29,9 +29,25 @@ RSpec.describe "hanami destroy", type: :cli do
       with_project do
         output = <<-OUT
 ERROR: "hanami model" was called with no arguments
-Usage: "hanami model NAME"
+Usage: "hanami destroy model NAME"
 OUT
         run_command "hanami destroy model", output
+      end
+    end
+
+    it 'prints help message' do
+      with_project do
+        output = <<-OUT
+Usage:
+  hanami destroy model NAME
+
+Description:
+  `hanami destroy model` will destroy an entity along with repository and \n  corresponding tests
+
+  > $ hanami destroy model car
+OUT
+
+        run_command 'hanami destroy model --help', output
       end
     end
 

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -49,7 +49,7 @@ END
       with_project('bookshelf_generate_action_without_args') do
         output = <<-OUT
 ERROR: "hanami actions" was called with no arguments
-Usage: "hanami action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
+Usage: "hanami generate action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
 OUT
 
         run_command "hanami generate action", output # , exit_status: 1 FIXME: Thor exit with 0

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -48,7 +48,7 @@ END
     it "fails with missing arguments" do
       with_project('bookshelf_generate_action_without_args') do
         output = <<-OUT
-ERROR: "hanami actions" was called with no arguments
+ERROR: "hanami generate actions" was called with no arguments
 Usage: "hanami generate action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
 OUT
 
@@ -60,7 +60,7 @@ OUT
       with_project('bookshelf_generate_action_without_app') do
         output = <<-OUT
 ERROR: "hanami generate action" was called with arguments ["home#index"]
-Usage: "hanami action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
+Usage: "hanami generate action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME"
 OUT
 
         run_command "hanami generate action home#index", output # , exit_status: 1 FIXME: Thor exit with 0

--- a/spec/integration/cli/generate/mailer_spec.rb
+++ b/spec/integration/cli/generate/mailer_spec.rb
@@ -90,7 +90,7 @@ END
     it "fails with missing arguments" do
       with_project('bookshelf_generate_mailer_without_args') do
         output = <<-OUT
-ERROR: "hanami mailer" was called with no arguments
+ERROR: "hanami generate mailer" was called with no arguments
 Usage: "hanami generate mailer NAME"
 OUT
 

--- a/spec/integration/cli/generate/mailer_spec.rb
+++ b/spec/integration/cli/generate/mailer_spec.rb
@@ -91,7 +91,7 @@ END
       with_project('bookshelf_generate_mailer_without_args') do
         output = <<-OUT
 ERROR: "hanami mailer" was called with no arguments
-Usage: "hanami mailer NAME"
+Usage: "hanami generate mailer NAME"
 OUT
 
         run_command "hanami generate mailer", output

--- a/spec/integration/cli/generate/migration_spec.rb
+++ b/spec/integration/cli/generate/migration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "hanami generate", type: :cli do
       it "fails" do
         with_project('bookshelf_generate_migration_missing_arguments') do
           output = <<-END
-ERROR: "hanami migration" was called with no arguments
+ERROR: "hanami generate migration" was called with no arguments
 Usage: "hanami generate migration NAME"
 END
           run_command "hanami generate migration", output # , exit_status: 1 FIXME: Thor exit with 0

--- a/spec/integration/cli/generate/migration_spec.rb
+++ b/spec/integration/cli/generate/migration_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "hanami generate", type: :cli do
         with_project('bookshelf_generate_migration_missing_arguments') do
           output = <<-END
 ERROR: "hanami migration" was called with no arguments
-Usage: "hanami migration NAME"
+Usage: "hanami generate migration NAME"
 END
           run_command "hanami generate migration", output # , exit_status: 1 FIXME: Thor exit with 0
         end

--- a/spec/integration/cli/generate/model_spec.rb
+++ b/spec/integration/cli/generate/model_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "hanami generate", type: :cli do
         with_project('bookshelf_generate_model_missing_arguments') do
           output = <<-END
 ERROR: "hanami model" was called with no arguments
-Usage: "hanami model NAME"
+Usage: "hanami generate model NAME"
 END
           run_command "hanami generate model", output # , exit_status: 1 FIXME: Thor exit with 0
         end

--- a/spec/integration/cli/generate/model_spec.rb
+++ b/spec/integration/cli/generate/model_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "hanami generate", type: :cli do
       it "fails" do
         with_project('bookshelf_generate_model_missing_arguments') do
           output = <<-END
-ERROR: "hanami model" was called with no arguments
+ERROR: "hanami generate model" was called with no arguments
 Usage: "hanami generate model NAME"
 END
           run_command "hanami generate model", output # , exit_status: 1 FIXME: Thor exit with 0


### PR DESCRIPTION
Fixes #623 

TODO:

- [x] Prints subcommands correct usage synopsis

- [x] Prints correct error message for commands called without arguments, e.g.: "hanami destroy model"