### PR TITLE
Remove architecture flag from CLI and .hanamirc

### DIFF
--- a/lib/hanami/application_configuration.rb
+++ b/lib/hanami/application_configuration.rb
@@ -1024,10 +1024,6 @@ module Hanami
 
     # Defines a relative pattern to find controllers.
     #
-    # Hanami supports multiple architectures (aka application structures), this
-    # setting helps to understand the namespace where to find applications'
-    # controllers and actions.
-    #
     # By default this equals to <tt>"Controllers::%{controller}::%{action}"</tt>
     # That means controllers must be structured like this:
     # <tt>Bookshelf::Controllers::Dashboard::Index</tt>, where <tt>Bookshelf</tt>
@@ -1153,11 +1149,7 @@ module Hanami
       end
     end
 
-    # Defines a relative pattern to find views:.
-    #
-    # Hanami supports multiple architectures (aka application structures), this
-    # setting helps to understand the namespace where to find applications'
-    # views:.
+    # Defines a relative pattern to find views.
     #
     # By default this equals to <tt>"Views::%{controller}::%{action}"</tt>
     # That means views must be structured like this:

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -88,16 +88,15 @@ module Hanami
     desc 'new PROJECT_NAME', 'Generate a new hanami project'
     long_desc <<-EOS
 `hanami new` creates a new hanami project.
-You can specify various options such as the database to be used as well as the path and architecture.
+You can specify various options, like which database type, testing framework or templating engine the project will use.
 
 $ > hanami new fancy_app --application_name=admin
 
-$ > hanami new fancy_app --arch=app
+$ > hanami new fancy_app --database=postgresql
 
 $ > hanami new fancy_app --hanami-head=true
     EOS
     method_option :database, aliases: ['-d', '--db'], desc: "Application database (#{Hanami::Generators::DatabaseConfig::SUPPORTED_ENGINES.keys.join('/')})", default: Hanami::Generators::DatabaseConfig::DEFAULT_ENGINE
-    method_option :architecture, aliases: ['-a', '--arch'], desc: 'Project architecture (container/app)', default: Hanami::Commands::New::Abstract::DEFAULT_ARCHITECTURE
     method_option :application_name, desc: 'Application name, only for container', default: Hanami::Commands::New::Container::DEFAULT_APPLICATION_NAME
     method_option :application_base_url, desc: 'Application base url', default: Hanami::Commands::New::Abstract::DEFAULT_APPLICATION_BASE_URL
     method_option :template, desc: "Template engine (#{Hanami::Generators::TemplateEngine::SUPPORTED_ENGINES.join('/')})", default: Hanami::Generators::TemplateEngine::DEFAULT_ENGINE
@@ -110,8 +109,6 @@ $ > hanami new fancy_app --hanami-head=true
       elsif application_name.nil?
         warn %(`hanami new` was called with no arguments\nUsage: `hanami new PROJECT_NAME`)
         exit(1)
-      elsif options[:architecture] == 'app'
-        Hanami::Commands::New::App.new(options, application_name).start
       else
         Hanami::Commands::New::Container.new(options, application_name).start
       end

--- a/lib/hanami/cli_sub_commands/destroy.rb
+++ b/lib/hanami/cli_sub_commands/destroy.rb
@@ -12,9 +12,9 @@ module Hanami
       long_desc <<-EOS
         `hanami destroy action` will destroy an an action, view and template along with specs and a route.
 
-        For Application architecture the application name is 'app'. For Container architecture the default application is called 'web'.
+        Note: the default application is named 'web'.
 
-        > $ hanami destroy action app cars#index
+        > $ hanami destroy action web cars#index
 
         > $ hanami destroy action other-app cars#index
 

--- a/lib/hanami/cli_sub_commands/generate.rb
+++ b/lib/hanami/cli_sub_commands/generate.rb
@@ -24,9 +24,9 @@ module Hanami
       long_desc <<-EOS
         `hanami generate action` generates an an action, view and template along with specs and a route.
 
-        For Application architecture the application name is 'app'. For Container architecture the default application is called 'web'.
+        Note: the default application is named 'web'.
 
-        > $ hanami generate action app cars#index
+        > $ hanami generate action web cars#index
 
         > $ hanami generate action other-app cars#index
 
@@ -108,8 +108,6 @@ module Hanami
       desc 'app APPLICATION_NAME', 'Generate an app'
       long_desc <<-EOS
         `hanami generate app` creates a new app inside the 'apps' directory.
-
-        It can only be called for hanami applications with container architecture.
 
         > $ hanami generate app admin
 

--- a/lib/hanami/commands/generate/action.rb
+++ b/lib/hanami/commands/generate/action.rb
@@ -227,15 +227,8 @@ module Hanami
           end
         end
 
-        # The directory of the application
-        # ./app for 'app' architecture
-        # ./apps/APPLICATION_NAME for 'container'
         def application_path
-          if environment.container?
-            applications_path.join(application_name_as_snake_case)
-          else
-            Pathname.new('app')
-          end
+          applications_path.join(application_name_as_snake_case)
         end
 
         # The parent dir of the application directory.

--- a/lib/hanami/commands/generate/app.rb
+++ b/lib/hanami/commands/generate/app.rb
@@ -17,7 +17,6 @@ module Hanami
 
           @target_path = Hanami.root
           assert_application_name!(application_name)
-          assert_architecture!
           assert_application_base_url!
 
           @application_name = ApplicationName.new(application_name)
@@ -112,12 +111,6 @@ module Hanami
         def assert_application_name!(value)
           if argument_blank?(value)
             raise ArgumentError.new('Application name is missing')
-          end
-        end
-
-        def assert_architecture!
-          if !environment.container?
-            raise ArgumentError.new('App generator is only available for container architecture.')
           end
         end
 

--- a/lib/hanami/commands/new/abstract.rb
+++ b/lib/hanami/commands/new/abstract.rb
@@ -14,7 +14,6 @@ module Hanami
 
         include Hanami::Generators::Generatable
 
-        DEFAULT_ARCHITECTURE = 'container'.freeze
         DEFAULT_APPLICATION_BASE_URL = '/'.freeze
 
         attr_reader :options, :target_path, :database_config,
@@ -27,7 +26,6 @@ module Hanami
 
           assert_options!
           assert_name!
-          assert_architecture!
 
           @hanami_model_version = '~> 1.0.0.beta1'
           @database_config = Hanami::Generators::DatabaseConfig.new(options[:database], project_name)
@@ -106,19 +104,9 @@ module Hanami
           !Hanami::Utils.jruby?
         end
 
-        def architecture
-          options.fetch(:architecture, DEFAULT_ARCHITECTURE)
-        end
-
         def assert_name!
           if argument_blank?(@name) || @name.include?(File::SEPARATOR)
             raise ArgumentError.new("APPLICATION_NAME is required and must not contain #{File::SEPARATOR}.")
-          end
-        end
-
-        def assert_architecture!
-          if !['app', 'container'].include?(architecture)
-            raise ArgumentError.new("Architecture must be one of 'app', 'container' but was '#{architecture}'")
           end
         end
 

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -110,19 +110,7 @@ module Hanami
 
     # @since 0.4.0
     # @api private
-    CONTAINER = 'container'.freeze
-
-    # @since 0.4.0
-    # @api private
-    CONTAINER_PATH = 'apps'.freeze
-
-    # @since 0.4.0
-    # @api private
-    APPLICATION = 'app'.freeze
-
-    # @since 0.4.0
-    # @api private
-    APPLICATION_PATH = 'app'.freeze
+    APPS_PATH = 'apps'.freeze
 
     # @since 0.4.0
     # @api private
@@ -420,17 +408,8 @@ module Hanami
 
     # @since 0.4.0
     # @api private
-    def architecture
-      @options.fetch(:architecture) do
-        puts "Cannot recognize Hanami architecture, please check `.hanamirc'"
-        exit 1
-      end
-    end
-
-    # @since 0.4.0
-    # @api private
     def container?
-      architecture == CONTAINER
+      true
     end
 
     # @since 0.6.0
@@ -456,12 +435,7 @@ module Hanami
     # @since 0.4.0
     # @api private
     def apps_path
-      @options.fetch(:path) {
-        case architecture
-        when CONTAINER   then CONTAINER_PATH
-        when APPLICATION then APPLICATION_PATH
-        end
-      }
+      @options.fetch(:path) { APPS_PATH }
     end
 
     # Serialize the most relevant settings into a Hash

--- a/lib/hanami/generators/application/container/hanamirc.tt
+++ b/lib/hanami/generators/application/container/hanamirc.tt
@@ -1,4 +1,3 @@
 <%= Hanami::Hanamirc::PROJECT_NAME %>=<%= config[:project_name] %>
-<%= Hanami::Hanamirc::ARCHITECTURE_KEY %>=<%= Hanami::Hanamirc::DEFAULT_ARCHITECTURE %>
 <%= Hanami::Hanamirc::TEST_KEY %>=<%= config[:test] %>
 <%= Hanami::Hanamirc::TEMPLATE_KEY %>=<%= config[:template] %>

--- a/lib/hanami/hanamirc.rb
+++ b/lib/hanami/hanamirc.rb
@@ -15,28 +15,6 @@ module Hanami
     # @see Hanami::Hanamirc#path_file
     FILE_NAME = '.hanamirc'.freeze
 
-    # Architecture default value
-    #
-    # @since 0.3.0
-    # @api private
-    #
-    # @see Hanami::Hanamirc#options
-    DEFAULT_ARCHITECTURE = 'container'.freeze
-
-    # Application architecture value
-    #
-    # @since 0.6.0
-    # @api private
-    APP_ARCHITECTURE = 'app'.freeze
-
-    # Architecture key for writing the hanamirc file
-    #
-    # @since 0.3.0
-    # @api private
-    #
-    # @see Hanami::Hanamirc#default_options
-    ARCHITECTURE_KEY = 'architecture'.freeze
-
     # Project name for writing the hanamirc file
     #
     # @since 0.8.0
@@ -98,12 +76,12 @@ module Hanami
     #
     # @example Default values if file doesn't exist
     #   Hanami::Hanamirc.new(Pathname.new(Dir.pwd)).options
-    #    # => { architecture: 'container', test: 'minitest', template: 'erb' }
+    #    # => { test: 'minitest', template: 'erb' }
     #
     # @example Custom values if file doesn't exist
-    #   options = { architect: 'application', test: 'rspec', template: 'slim' }
+    #   options = { test: 'rspec', template: 'slim' }
     #   Hanami::Hanamirc.new(Pathname.new(Dir.pwd), options).options
-    #    # => { architecture: 'application', test: 'rspec', template: 'slim' }
+    #    # => { test: 'rspec', template: 'slim' }
     def options
       @options ||= symbolize(default_options.merge(file_options))
     end
@@ -116,7 +94,6 @@ module Hanami
     # @see Hanami::Hanamirc#options
     def default_options
       @default_options ||= Utils::Hash.new({
-                                           ARCHITECTURE_KEY => DEFAULT_ARCHITECTURE,
                                            PROJECT_NAME     => project_name,
                                            TEST_KEY         => DEFAULT_TEST_SUITE,
                                            TEMPLATE_KEY     => DEFAULT_TEMPLATE

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -56,7 +56,6 @@ OUT
       #
       expect('.hanamirc').to have_file_content <<-END
 project=#{project}
-architecture=container
 test=minitest
 template=erb
 END
@@ -761,8 +760,6 @@ Usage:
 Options:
   -d, --db, [--database=DATABASE]                        # Application database (mysql/mysql2/postgresql/postgres/sqlite/sqlite3/filesystem/memory)
                                                          # Default: filesystem
-  -a, --arch, [--architecture=ARCHITECTURE]              # Project architecture (container/app)
-                                                         # Default: container
           [--application-name=APPLICATION_NAME]          # Application name, only for container
                                                          # Default: web
           [--application-base-url=APPLICATION_BASE_URL]  # Application base url
@@ -778,11 +775,11 @@ OUT
 # rubocop:disable Style/CommentIndentation
 # FIXME: this extra verbatim causes a spec failure
 # Description:
-#   `hanami new` creates a new hanami project. You can specify various options such as the database to be used as well as the path and architecture.
+#   `hanami new` creates a new hanami project. You can specify various options, like which database type, testing framework or templating engine the proejct will use.
 #
 #   $ > hanami new fancy_app --application_name=admin
 #
-#   $ > hanami new fancy_app --arch=app
+#   $ > hanami new fancy_app --database=postgresql
 #
 #   $ > hanami new fancy_app --hanami-head=true
 # rubocop:enable Style/CommentIndentation


### PR DESCRIPTION
We used to support a `container` architecture (default) and an `application` architecture. 
Now we only support what was called `container`, which we refer to as a a Hanami "project".

I'm not sure if this is ready to merge. 
Basically I'm not sure if I went too far, or not far enough in removing references to `container`. 
It's still a useful concept in the back-end, but perhaps it should be renamed to 'project'. I'm also not sure if we want to leave some of the configuration options around to make it easy for people to add their own architectures later (mostly if someone wants to add `application` architecture back).

Thoughts?