### PR TITLE
Make application.rb conform to 80 char line length

### DIFF
--- a/lib/hanami/generators/app/application.rb.tt
+++ b/lib/hanami/generators/app/application.rb.tt
@@ -13,7 +13,9 @@ module <%= config[:classified_app_name] %>
       #
       root __dir__
 
-      # Relative load paths where this application will recursively load the code.
+      # Relative load paths where this application will recursively load the
+      # code.
+      #
       # When you add new directories, remember to add them here.
       #
       load_paths << [
@@ -47,8 +49,10 @@ module <%= config[:classified_app_name] %>
       # host 'example.org'
 
       # URI port used by the routing system to generate absolute URLs
-      # Argument: An object coercible to integer, default to 80 if the scheme is http and 443 if it's https
-      # This SHOULD be configured only in case the application listens to that non standard ports
+      # Argument: An object coercible to integer, defaults to 80 if the scheme
+      # is http and 443 if it's https
+      #
+      # This should only be configured if app listens to non-standard ports
       #
       # port 443
 
@@ -56,13 +60,16 @@ module <%= config[:classified_app_name] %>
       # Argument: boolean to toggle the feature
       #           A Hash with options
       #
-      # Options: :domain   - The domain (String - nil by default, not required)
-      #          :path     - Restrict cookies to a relative URI (String - nil by default)
-      #          :max_age  - Cookies expiration expressed in seconds (Integer - nil by default)
-      #          :secure   - Restrict cookies to secure connections
-      #                      (Boolean - Automatically set on true if currently using a secure connection)
-      #                      See #scheme and #ssl?
-      #          :httponly - Prevent JavaScript access (Boolean - true by default)
+      # Options:
+      #   :domain   - The domain (String - nil by default, not required)
+      #   :path     - Restrict cookies to a relative URI
+      #               (String - nil by default)
+      #   :max_age  - Cookies expiration expressed in seconds
+      #               (Integer - nil by default)
+      #   :secure   - Restrict cookies to secure connections
+      #               (Boolean - Automatically true when using HTTPS)
+      #               See #scheme and #ssl?
+      #   :httponly - Prevent JavaScript access (Boolean - true by default)
       #
       # cookies true
       # or
@@ -81,24 +88,25 @@ module <%= config[:classified_app_name] %>
       # middleware.use Rack::Protection
 
       # Default format for the requests that don't specify an HTTP_ACCEPT header
-      # Argument: A symbol representation of a mime type, default to :html
+      # Argument: A symbol representation of a mime type, defaults to :html
       #
       # default_request_format :html
 
-      # Default format for responses that doesn't take into account the request format
-      # Argument: A symbol representation of a mime type, default to :html
+      # Default format for responses that don't consider the request format
+      # Argument: A symbol representation of a mime type, defaults to :html
       #
       # default_response_format :html
 
       # HTTP Body parsers
       # Parse non GET responses body for a specific mime type
-      # Argument: Symbol, which represent the format of the mime type (only `:json` is supported)
+      # Argument: Symbol, which represent the format of the mime type
+      #             (only `:json` is supported)
       #           Object, the parser
       #
       # body_parsers :json
 
       # When it's true and the router receives a non-encrypted request (http),
-      # it redirects to the secure equivalent resource (https). Default disabled.
+      # it redirects to the secure equivalent (https). Disabled by default.
       #
       # force_ssl true
 
@@ -180,8 +188,8 @@ module <%= config[:classified_app_name] %>
       #
       security.x_content_type_options 'nosniff'
 
-      # X-XSS-Protection is a HTTP header to determine the behavior of the browser
-      # in case an XSS attack is detected.
+      # X-XSS-Protection is a HTTP header to determine the behavior of the
+      # browser in case an XSS attack is detected.
       #
       # Read more at:
       #
@@ -190,16 +198,16 @@ module <%= config[:classified_app_name] %>
       #
       security.x_xss_protection '1; mode=block'
 
-      # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
-      # It determines trusted sources of execution for dynamic contents
-      # (JavaScript) or other web related assets: stylesheets, images, fonts,
-      # plugins, etc.
+      # Content-Security-Policy (CSP) is a HTTP header supported by modern
+      # browsers. It determines trusted sources of execution for dynamic
+      # contents (JavaScript) or other web related assets: stylesheets, images,
+      # fonts, plugins, etc.
       #
       # Web applications can send this header to mitigate Cross Site Scripting
       # (XSS) attacks.
       #
-      # The default value allows images, scripts, AJAX, fonts and CSS from the same
-      # origin, and does not allow any other resources to load (eg object,
+      # The default value allows images, scripts, AJAX, fonts and CSS from the
+      # same origin, and does not allow any other resources to load (eg object,
       # frame, media, etc).
       #
       # Inline JavaScript is NOT allowed. To enable it, please use:

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -336,7 +336,9 @@ module Web
       #
       root __dir__
 
-      # Relative load paths where this application will recursively load the code.
+      # Relative load paths where this application will recursively load the
+      # code.
+      #
       # When you add new directories, remember to add them here.
       #
       load_paths << [
@@ -370,8 +372,10 @@ module Web
       # host 'example.org'
 
       # URI port used by the routing system to generate absolute URLs
-      # Argument: An object coercible to integer, default to 80 if the scheme is http and 443 if it's https
-      # This SHOULD be configured only in case the application listens to that non standard ports
+      # Argument: An object coercible to integer, defaults to 80 if the scheme
+      # is http and 443 if it's https
+      #
+      # This should only be configured if app listens to non-standard ports
       #
       # port 443
 
@@ -379,13 +383,16 @@ module Web
       # Argument: boolean to toggle the feature
       #           A Hash with options
       #
-      # Options: :domain   - The domain (String - nil by default, not required)
-      #          :path     - Restrict cookies to a relative URI (String - nil by default)
-      #          :max_age  - Cookies expiration expressed in seconds (Integer - nil by default)
-      #          :secure   - Restrict cookies to secure connections
-      #                      (Boolean - Automatically set on true if currently using a secure connection)
-      #                      See #scheme and #ssl?
-      #          :httponly - Prevent JavaScript access (Boolean - true by default)
+      # Options:
+      #   :domain   - The domain (String - nil by default, not required)
+      #   :path     - Restrict cookies to a relative URI
+      #               (String - nil by default)
+      #   :max_age  - Cookies expiration expressed in seconds
+      #               (Integer - nil by default)
+      #   :secure   - Restrict cookies to secure connections
+      #               (Boolean - Automatically true when using HTTPS)
+      #               See #scheme and #ssl?
+      #   :httponly - Prevent JavaScript access (Boolean - true by default)
       #
       # cookies true
       # or
@@ -404,24 +411,25 @@ module Web
       # middleware.use Rack::Protection
 
       # Default format for the requests that don't specify an HTTP_ACCEPT header
-      # Argument: A symbol representation of a mime type, default to :html
+      # Argument: A symbol representation of a mime type, defaults to :html
       #
       # default_request_format :html
 
-      # Default format for responses that doesn't take into account the request format
-      # Argument: A symbol representation of a mime type, default to :html
+      # Default format for responses that don't consider the request format
+      # Argument: A symbol representation of a mime type, defaults to :html
       #
       # default_response_format :html
 
       # HTTP Body parsers
       # Parse non GET responses body for a specific mime type
-      # Argument: Symbol, which represent the format of the mime type (only `:json` is supported)
+      # Argument: Symbol, which represent the format of the mime type
+      #             (only `:json` is supported)
       #           Object, the parser
       #
       # body_parsers :json
 
       # When it's true and the router receives a non-encrypted request (http),
-      # it redirects to the secure equivalent resource (https). Default disabled.
+      # it redirects to the secure equivalent (https). Disabled by default.
       #
       # force_ssl true
 
@@ -503,8 +511,8 @@ module Web
       #
       security.x_content_type_options 'nosniff'
 
-      # X-XSS-Protection is a HTTP header to determine the behavior of the browser
-      # in case an XSS attack is detected.
+      # X-XSS-Protection is a HTTP header to determine the behavior of the
+      # browser in case an XSS attack is detected.
       #
       # Read more at:
       #
@@ -513,16 +521,16 @@ module Web
       #
       security.x_xss_protection '1; mode=block'
 
-      # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
-      # It determines trusted sources of execution for dynamic contents
-      # (JavaScript) or other web related assets: stylesheets, images, fonts,
-      # plugins, etc.
+      # Content-Security-Policy (CSP) is a HTTP header supported by modern
+      # browsers. It determines trusted sources of execution for dynamic
+      # contents (JavaScript) or other web related assets: stylesheets, images,
+      # fonts, plugins, etc.
       #
       # Web applications can send this header to mitigate Cross Site Scripting
       # (XSS) attacks.
       #
-      # The default value allows images, scripts, AJAX, fonts and CSS from the same
-      # origin, and does not allow any other resources to load (eg object,
+      # The default value allows images, scripts, AJAX, fonts and CSS from the
+      # same origin, and does not allow any other resources to load (eg object,
       # frame, media, etc).
       #
       # Inline JavaScript is NOT allowed. To enable it, please use:

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -49,7 +49,9 @@ module #{app_name}
       #
       root __dir__
 
-      # Relative load paths where this application will recursively load the code.
+      # Relative load paths where this application will recursively load the
+      # code.
+      #
       # When you add new directories, remember to add them here.
       #
       load_paths << [
@@ -83,8 +85,10 @@ module #{app_name}
       # host 'example.org'
 
       # URI port used by the routing system to generate absolute URLs
-      # Argument: An object coercible to integer, default to 80 if the scheme is http and 443 if it's https
-      # This SHOULD be configured only in case the application listens to that non standard ports
+      # Argument: An object coercible to integer, defaults to 80 if the scheme
+      # is http and 443 if it's https
+      #
+      # This should only be configured if app listens to non-standard ports
       #
       # port 443
 
@@ -92,13 +96,16 @@ module #{app_name}
       # Argument: boolean to toggle the feature
       #           A Hash with options
       #
-      # Options: :domain   - The domain (String - nil by default, not required)
-      #          :path     - Restrict cookies to a relative URI (String - nil by default)
-      #          :max_age  - Cookies expiration expressed in seconds (Integer - nil by default)
-      #          :secure   - Restrict cookies to secure connections
-      #                      (Boolean - Automatically set on true if currently using a secure connection)
-      #                      See #scheme and #ssl?
-      #          :httponly - Prevent JavaScript access (Boolean - true by default)
+      # Options:
+      #   :domain   - The domain (String - nil by default, not required)
+      #   :path     - Restrict cookies to a relative URI
+      #               (String - nil by default)
+      #   :max_age  - Cookies expiration expressed in seconds
+      #               (Integer - nil by default)
+      #   :secure   - Restrict cookies to secure connections
+      #               (Boolean - Automatically true when using HTTPS)
+      #               See #scheme and #ssl?
+      #   :httponly - Prevent JavaScript access (Boolean - true by default)
       #
       # cookies true
       # or
@@ -117,24 +124,25 @@ module #{app_name}
       # middleware.use Rack::Protection
 
       # Default format for the requests that don't specify an HTTP_ACCEPT header
-      # Argument: A symbol representation of a mime type, default to :html
+      # Argument: A symbol representation of a mime type, defaults to :html
       #
       # default_request_format :html
 
-      # Default format for responses that doesn't take into account the request format
-      # Argument: A symbol representation of a mime type, default to :html
+      # Default format for responses that don't consider the request format
+      # Argument: A symbol representation of a mime type, defaults to :html
       #
       # default_response_format :html
 
       # HTTP Body parsers
       # Parse non GET responses body for a specific mime type
-      # Argument: Symbol, which represent the format of the mime type (only `:json` is supported)
+      # Argument: Symbol, which represent the format of the mime type
+      #             (only `:json` is supported)
       #           Object, the parser
       #
       # body_parsers :json
 
       # When it's true and the router receives a non-encrypted request (http),
-      # it redirects to the secure equivalent resource (https). Default disabled.
+      # it redirects to the secure equivalent (https). Disabled by default.
       #
       # force_ssl true
 
@@ -216,8 +224,8 @@ module #{app_name}
       #
       security.x_content_type_options 'nosniff'
 
-      # X-XSS-Protection is a HTTP header to determine the behavior of the browser
-      # in case an XSS attack is detected.
+      # X-XSS-Protection is a HTTP header to determine the behavior of the
+      # browser in case an XSS attack is detected.
       #
       # Read more at:
       #
@@ -226,16 +234,16 @@ module #{app_name}
       #
       security.x_xss_protection '1; mode=block'
 
-      # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
-      # It determines trusted sources of execution for dynamic contents
-      # (JavaScript) or other web related assets: stylesheets, images, fonts,
-      # plugins, etc.
+      # Content-Security-Policy (CSP) is a HTTP header supported by modern
+      # browsers. It determines trusted sources of execution for dynamic
+      # contents (JavaScript) or other web related assets: stylesheets, images,
+      # fonts, plugins, etc.
       #
       # Web applications can send this header to mitigate Cross Site Scripting
       # (XSS) attacks.
       #
-      # The default value allows images, scripts, AJAX, fonts and CSS from the same
-      # origin, and does not allow any other resources to load (eg object,
+      # The default value allows images, scripts, AJAX, fonts and CSS from the
+      # same origin, and does not allow any other resources to load (eg object,
       # frame, media, etc).
       #
       # Inline JavaScript is NOT allowed. To enable it, please use:


### PR DESCRIPTION
Honestly, I find some of these changes to make the formatting look slightly worse, but it does pass the default RuboCop `Metrics/LineLength` check mentioned in #734. Please have a look if this is okay, or if there's a nicer way of formatting it that still passes this check - if not I'm also okay with closing the PR. :) 

Closes #734 