### PR TITLE
Disconnect database during the boot process.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'hanami-validations', '~> 1.0.0.beta1', require: false, github: 'hanami/vali
 gem 'hanami-router',      '~> 1.0.0.beta1', require: false, github: 'hanami/router',      branch: '1.0.x'
 gem 'hanami-controller',  '~> 1.0.0.beta1', require: false, github: 'hanami/controller',  branch: '1.0.x'
 gem 'hanami-view',        '~> 1.0.0.beta1', require: false, github: 'hanami/view',        branch: '1.0.x'
-gem 'hanami-model',       '~> 1.0.0.beta1', require: false, github: 'hanami/model',       branch: '1.0.x'
+gem 'hanami-model',       '~> 1.0.0.beta1', require: false, github: 'hanami/model',       branch: 'hanami-model-disconnect'
 gem 'hanami-helpers',     '~> 1.0.0.beta1', require: false, github: 'hanami/helpers',     branch: '1.0.x'
 gem 'hanami-mailer',      '~> 1.0.0.beta1', require: false, github: 'hanami/mailer',      branch: '1.0.x'
 gem 'hanami-assets',      '~> 1.0.0.beta1', require: false, github: 'hanami/assets',      branch: '1.0.x'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'hanami-validations', '~> 1.0.0.beta1', require: false, github: 'hanami/vali
 gem 'hanami-router',      '~> 1.0.0.beta1', require: false, github: 'hanami/router',      branch: '1.0.x'
 gem 'hanami-controller',  '~> 1.0.0.beta1', require: false, github: 'hanami/controller',  branch: '1.0.x'
 gem 'hanami-view',        '~> 1.0.0.beta1', require: false, github: 'hanami/view',        branch: '1.0.x'
-gem 'hanami-model',       '~> 1.0.0.beta1', require: false, github: 'hanami/model',       branch: 'hanami-model-disconnect'
+gem 'hanami-model',       '~> 1.0.0.beta1', require: false, github: 'hanami/model',       branch: '1.0.x'
 gem 'hanami-helpers',     '~> 1.0.0.beta1', require: false, github: 'hanami/helpers',     branch: '1.0.x'
 gem 'hanami-mailer',      '~> 1.0.0.beta1', require: false, github: 'hanami/mailer',      branch: '1.0.x'
 gem 'hanami-assets',      '~> 1.0.0.beta1', require: false, github: 'hanami/assets',      branch: '1.0.x'

--- a/lib/hanami/components/components.rb
+++ b/lib/hanami/components/components.rb
@@ -77,6 +77,10 @@ module Hanami
     register 'model' do
       requires 'logger', 'model.configuration', 'model.sql'
 
+      prepare do
+        Hanami::Model.disconnect if Components['model.configuration']
+      end
+
       resolve do
         if Components['model.configuration']
           Hanami::Model.load!

--- a/spec/isolation/components/model/with_hanami_model_spec.rb
+++ b/spec/isolation/components/model/with_hanami_model_spec.rb
@@ -10,5 +10,38 @@ RSpec.describe "Components: model", type: :cli do
         expect(Hanami::Model.configuration.logger).to eq(Hanami.logger)
       end
     end
+
+    it "disconnects database connections on reboot" do
+      with_project do
+        require Pathname.new(Dir.pwd).join("config", "environment")
+
+        # Simulate previous connection
+        Hanami::Components.resolve('model.configuration')
+        Hanami::Components.resolve('model.sql')
+        Hanami::Model.load!
+
+        #
+        Hanami::Model.configuration.connection.test_connection
+        # Current connections count is 1
+
+        #
+        Hanami::Components.resolve('model')
+        # Current connections count is 0
+
+        expect(Hanami::Components['model']).to     be(true)
+        expect(Hanami::Components['model.sql']).to be(true)
+        expect(Hanami::Model.configuration.logger).to eq(Hanami.logger)
+
+        # This is tight coupled to Sequel
+        #
+        # When `.disconnect` is invoked, it returns a collection of disconnected
+        # connections. Here we want to assert that `.disconnect` was invoked as
+        # part of the boot process.
+        #
+        # Invoking disconnect again **here in the test** should return an empty
+        # collection, because we haven't tryied to connect to the database again.
+        expect(Hanami::Model.disconnect).to be_empty
+      end
+    end
   end
 end

--- a/spec/isolation/components/model/with_hanami_model_spec.rb
+++ b/spec/isolation/components/model/with_hanami_model_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Components: model", type: :cli do
         # part of the boot process.
         #
         # Invoking disconnect again **here in the test** should return an empty
-        # collection, because we haven't tryied to connect to the database again.
+        # collection, because we haven't tried to connect to the database again.
         expect(Hanami::Model.disconnect).to be_empty
       end
     end


### PR DESCRIPTION
This is useful to restart projects in production, so the system can prune stale database connections.