### PR TITLE
Ensure that code from lib is loaded before mailer and model

### DIFF
--- a/lib/hanami/components/components.rb
+++ b/lib/hanami/components/components.rb
@@ -13,7 +13,7 @@ module Hanami
     # @since 0.9.0
     # @api private
     register 'all' do
-      requires 'logger', 'mailer', 'code', 'model', 'apps', 'finalizers'
+      requires 'logger', 'code', 'mailer', 'model', 'apps', 'finalizers'
 
       resolve { true }
     end
@@ -55,7 +55,7 @@ module Hanami
       run do
         directory = Hanami.root.join('lib')
 
-        if Hanami.code_reloading?
+        if Components['environment'].code_reloading?
           Utils.reload!(directory)
         else
           Utils.require!(directory)


### PR DESCRIPTION
The `code` component need to be solved before loading `mailer` so the classes are defined before `Hanami::Mailer.load!` is called to setup the library.

Fix #751