### PR TITLE
Disconnect `Hanami::Model` directly inside `Hanami.boot`

### DIFF
--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -88,6 +88,7 @@ module Hanami
   def self.boot
     Components.release if code_reloading?
     Components.resolve('all')
+    Hanami::Model.disconnect if defined?(Hanami::Model)
   end
 
   # Main application that mounts many Rack and/or Hanami applications.

--- a/lib/hanami/components/components.rb
+++ b/lib/hanami/components/components.rb
@@ -78,10 +78,6 @@ module Hanami
     register 'model' do
       requires 'logger', 'model.configuration', 'model.sql'
 
-      prepare do
-        Hanami::Model.disconnect if Components['model.configuration']
-      end
-
       resolve do
         if Components['model.configuration']
           Hanami::Model.load!

--- a/spec/isolation/components/model/with_hanami_model_spec.rb
+++ b/spec/isolation/components/model/with_hanami_model_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe "Components: model", type: :cli do
     it "resolves model" do
       with_project do
         require Pathname.new(Dir.pwd).join("config", "environment")
-        expect(Hanami::Model).to receive(:disconnect)
         Hanami::Components.resolve('model')
 
         expect(Hanami::Components['model']).to     be(true)

--- a/spec/isolation/hanami/boot/with_hanami_model_spec.rb
+++ b/spec/isolation/hanami/boot/with_hanami_model_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Hanami.boot", type: :cli do
         generate "app admin"
 
         require Pathname.new(Dir.pwd).join("config", "environment")
+        expect(Hanami::Model).to receive(:disconnect)
         Hanami.boot
 
         expect(Hanami::Components['all']).to  be(true)


### PR DESCRIPTION
This supposed to be fixed by #748 but the problem is still there.

I have a project on Heroku, running with Puma:

```ruby
# config/puma.rb
workers Integer(ENV['WEB_CONCURRENCY'] || 2)
threads_count = Integer(ENV['MAX_THREADS'] || 5)
threads threads_count, threads_count

preload_app!

rackup      DefaultRackup
port        ENV['PORT']     || 2300
environment ENV['RACK_ENV'] || ENV['HANAMI_ENV'] || 'development'

on_worker_boot do
  Hanami.boot
end
```

During the deploy/reboot process, stale connections used to stay around. That used to cause intermittent errors for the requests that were hitting the database. Specifically, the connection failed to read data from the socket:

```
2017-03-29T12:43:18.856203+00:00 app[web.1]: Hanami::Model::Error: PG::ConnectionBad: PQconsumeInput() SSL error: decryption failed or bad record mac
2017-03-29T12:43:18.856205+00:00 app[web.1]:
2017-03-29T12:43:18.856205+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-model-1.0.0.beta3/lib/hanami/repository.rb:404:in `rescue in find'
2017-03-29T12:43:18.856206+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-model-1.0.0.beta3/lib/hanami/repository.rb:402:in `find'
2017-03-29T12:43:18.856207+00:00 app[web.1]: 	/app/config/initializers/warden.rb:8:in `block in <top (required)>'
2017-03-29T12:43:18.856208+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/warden-1.2.7/lib/warden/session_serializer.rb:35:in `fetch'
2017-03-29T12:43:18.856209+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/warden-1.2.7/lib/warden/proxy.rb:213:in `user'
2017-03-29T12:43:18.856209+00:00 app[web.1]: 	/app/apps/web/controllers/authentication.rb:35:in `current_user'
2017-03-29T12:43:18.856210+00:00 app[web.1]: 	/app/apps/web/controllers/authentication.rb:31:in `signed_in?'
2017-03-29T12:43:18.856211+00:00 app[web.1]: 	/app/apps/web/controllers/authentication.rb:43:in `authenticate!'
2017-03-29T12:43:18.856212+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-utils-1.0.0.beta3/lib/hanami/utils/callbacks.rb:274:in `call'
2017-03-29T12:43:18.856212+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-utils-1.0.0.beta3/lib/hanami/utils/callbacks.rb:274:in `call'
2017-03-29T12:43:18.856213+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-utils-1.0.0.beta3/lib/hanami/utils/callbacks.rb:147:in `block in run'
2017-03-29T12:43:18.856214+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-utils-1.0.0.beta3/lib/hanami/utils/callbacks.rb:146:in `each'
2017-03-29T12:43:18.856214+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-utils-1.0.0.beta3/lib/hanami/utils/callbacks.rb:146:in `run'
2017-03-29T12:43:18.856215+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-controller-1.0.0.beta3/lib/hanami/action/callbacks.rb:203:in `_run_before_callbacks'
2017-03-29T12:43:18.856216+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-controller-1.0.0.beta3/lib/hanami/action/callbacks.rb:194:in `call'
2017-03-29T12:43:18.856217+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-controller-1.0.0.beta3/lib/hanami/action/callable.rb:71:in `block in call'
2017-03-29T12:43:18.856217+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-controller-1.0.0.beta3/lib/hanami/action/throwable.rb:145:in `block in _rescue'
2017-03-29T12:43:18.856218+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-controller-1.0.0.beta3/lib/hanami/action/throwable.rb:143:in `catch'
2017-03-29T12:43:18.856219+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-controller-1.0.0.beta3/lib/hanami/action/throwable.rb:143:in `_rescue'
2017-03-29T12:43:18.856219+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-controller-1.0.0.beta3/lib/hanami/action/callable.rb:67:in `call'
2017-03-29T12:43:18.856220+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-router-1.0.0.beta3/lib/hanami/routing/endpoint.rb:90:in `call'
2017-03-29T12:43:18.856221+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/http_router-0.11.2/lib/http_router.rb:193:in `process_destination_path'
2017-03-29T12:43:18.856236+00:00 app[web.1]: 	(eval):161:in `call'
2017-03-29T12:43:18.856237+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/http_router-0.11.2/lib/http_router.rb:288:in `raw_call'
2017-03-29T12:43:18.856237+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-router-1.0.0.beta3/lib/hanami/routing/http_router.rb:156:in `raw_call'
2017-03-29T12:43:18.856238+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/http_router-0.11.2/lib/http_router.rb:142:in `call'
2017-03-29T12:43:18.856239+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-router-1.0.0.beta3/lib/hanami/router.rb:1016:in `call'
2017-03-29T12:43:18.856239+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/omniauth-1.6.1/lib/omniauth/strategy.rb:189:in `call!'
2017-03-29T12:43:18.856240+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/omniauth-1.6.1/lib/omniauth/strategy.rb:167:in `call'
2017-03-29T12:43:18.856241+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/omniauth-1.6.1/lib/omniauth/builder.rb:63:in `call'
2017-03-29T12:43:18.856242+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/warden-1.2.7/lib/warden/manager.rb:36:in `block in call'
2017-03-29T12:43:18.856242+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/warden-1.2.7/lib/warden/manager.rb:35:in `catch'
2017-03-29T12:43:18.856243+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/warden-1.2.7/lib/warden/manager.rb:35:in `call'
2017-03-29T12:43:18.856244+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.1/lib/rack/session/abstract/id.rb:222:in `context'
2017-03-29T12:43:18.856245+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.1/lib/rack/session/abstract/id.rb:216:in `call'
2017-03-29T12:43:18.856245+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.1/lib/rack/builder.rb:153:in `call'
2017-03-29T12:43:18.856246+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/bundler/gems/hanami-7898fe1aa941/lib/hanami/middleware.rb:52:in `call'
2017-03-29T12:43:18.856246+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/bundler/gems/hanami-7898fe1aa941/lib/hanami/application.rb:169:in `call'
2017-03-29T12:43:18.856247+00:00 app[web.1]: 	/app/vendor/ruby-2.4.1/lib/ruby/2.4.0/delegate.rb:83:in `method_missing'
2017-03-29T12:43:18.856248+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/http_router-0.11.2/lib/http_router.rb:193:in `process_destination_path'
2017-03-29T12:43:18.856249+00:00 app[web.1]: 	(eval):15:in `call'
2017-03-29T12:43:18.856249+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/http_router-0.11.2/lib/http_router.rb:288:in `raw_call'
2017-03-29T12:43:18.856273+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-router-1.0.0.beta3/lib/hanami/routing/http_router.rb:156:in `raw_call'
2017-03-29T12:43:18.856275+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/http_router-0.11.2/lib/http_router.rb:142:in `call'
2017-03-29T12:43:18.856275+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/hanami-router-1.0.0.beta3/lib/hanami/router.rb:1016:in `call'
2017-03-29T12:43:18.856276+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.1/lib/rack/method_override.rb:22:in `call'
2017-03-29T12:43:18.856277+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.1/lib/rack/static.rb:149:in `call'
2017-03-29T12:43:18.856278+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.1/lib/rack/content_length.rb:15:in `call'
2017-03-29T12:43:18.856278+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.1/lib/rack/common_logger.rb:33:in `call'
2017-03-29T12:43:18.856279+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.1/lib/rack/builder.rb:153:in `call'
2017-03-29T12:43:18.856279+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/bundler/gems/hanami-7898fe1aa941/lib/hanami/app.rb:42:in `call'
2017-03-29T12:43:18.856280+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/puma-3.8.2/lib/puma/configuration.rb:224:in `call'
2017-03-29T12:43:18.856281+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/puma-3.8.2/lib/puma/server.rb:600:in `handle_request'
2017-03-29T12:43:18.856281+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/puma-3.8.2/lib/puma/server.rb:435:in `process_client'
2017-03-29T12:43:18.856282+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/puma-3.8.2/lib/puma/server.rb:299:in `block in run'
2017-03-29T12:43:18.891506+00:00 app[web.1]: 	/app/vendor/bundle/ruby/2.4.0/gems/puma-3.8.2/lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```

---

Why #748 didn't fixed the problem? Because `Hanami::Model.disconnect` used to be invoked in a `prepare` block of the `"model"` component. The `prepare` block is only evaluated once only when the component wasn't resolved yet.

During the reboot, we already have all the components resolved, so the `prepare` block wasn't invoked anymore.

---

I also tried to write a `"model.disconnector"` component to be invoked every time (it uses `run` instead of `resolve`), but for some reason it won't work as well.

---

So I ended to include the `Hanami::Model.disconnect` call inside `Hanami.boot`. This fixes the problem.

---

/cc @hanami/core 