### PR TITLE
Generate empty `lib/<project-name>.rb` file

### DIFF
--- a/lib/hanami/commands/new/abstract.rb
+++ b/lib/hanami/commands/new/abstract.rb
@@ -6,6 +6,7 @@ require 'hanami/generators/test_framework'
 require 'hanami/generators/template_engine'
 require 'hanami/utils'
 require 'hanami/utils/hash'
+require 'hanami/utils/string'
 
 module Hanami
   # @api private
@@ -97,6 +98,11 @@ module Hanami
         # @api private
         def project_name
           ApplicationName.new(real_project_name)
+        end
+
+        # @api private
+        def project_module
+          Utils::String.new(project_name).classify
         end
 
         # @api private

--- a/lib/hanami/commands/new/container.rb
+++ b/lib/hanami/commands/new/container.rb
@@ -25,6 +25,7 @@ module Hanami
         def template_options
           {
             project_name:         project_name,
+            project_module:       project_module,
             hanami_head:          hanami_head?,
             code_reloading:       code_reloading?,
             test:                 test_framework.framework,

--- a/lib/hanami/generators/application/container/lib/project.rb.tt
+++ b/lib/hanami/generators/application/container/lib/project.rb.tt
@@ -1,0 +1,2 @@
+module <%= config[:project_module] %>
+end

--- a/lib/hanami/generators/application/container/lib/project.rb.tt
+++ b/lib/hanami/generators/application/container/lib/project.rb.tt
@@ -1,1 +1,0 @@
-Hanami::Utils.require!("#{__dir__}/<%= config[:project_name] %>")

--- a/spec/integration/cli/console_spec.rb
+++ b/spec/integration/cli/console_spec.rb
@@ -21,6 +21,31 @@ RSpec.describe "hanami console", type: :cli do
         expect(out).to include("SELECT `id`, `title` FROM `books` ORDER BY `books`.`id`")
       end
     end
+
+    it "starts console without hanami-model" do
+      project_without_hanami_model("bookshelf", gems: ['dry-struct'], console: :irb) do
+        write "lib/entities/access_token.rb", <<-EOF
+require 'dry-struct'
+require 'securerandom'
+
+module Types
+  include Dry::Types.module
+end
+
+class AccessToken < Dry::Struct
+  attribute :id,     Types::String.default { SecureRandom.uuid }
+  attribute :secret, Types::String
+  attribute :digest, Types::String
+end
+EOF
+        console do |input, _, _|
+          input.puts("AccessToken.new(id: '1', secret: 'shh', digest: 'def')")
+          input.puts("exit")
+        end
+
+        expect(out).to include('#<AccessToken id="1" secret="shh" digest="def">')
+      end
+    end
   end # irb
 
   # TODO: test with pry

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -208,10 +208,13 @@ Hanami.configure do
 end
 END
 
+      project_module = Hanami::Utils::String.new(project).classify
       #
       # lib/<project>.rb
       #
       expect("lib/#{project}.rb").to have_file_content <<-END
+module #{project_module}
+end
 END
 
       #

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -212,7 +212,6 @@ END
       # lib/<project>.rb
       #
       expect("lib/#{project}.rb").to have_file_content <<-END
-Hanami::Utils.require!("\#{__dir__}/#{project}")
 END
 
       #

--- a/spec/support/shared_examples/cli/new.rb
+++ b/spec/support/shared_examples/cli/new.rb
@@ -44,7 +44,6 @@ RSpec.shared_examples "a new project" do
       # lib/<project>.rb
       #
       expect("lib/#{project}.rb").to have_file_content <<-END
-Hanami::Utils.require!("\#{__dir__}/#{project}")
 END
 
       #

--- a/spec/support/shared_examples/cli/new.rb
+++ b/spec/support/shared_examples/cli/new.rb
@@ -40,10 +40,14 @@ RSpec.shared_examples "a new project" do
       #
       expect('config/environment.rb').to have_file_content %r{require_relative '../lib/#{project}'}
 
+      project_module = Hanami::Utils::String.new(project).classify
+
       #
       # lib/<project>.rb
       #
       expect("lib/#{project}.rb").to have_file_content <<-END
+module #{project_module}
+end
 END
 
       #


### PR DESCRIPTION
This PR implements [a suggested solution](https://github.com/hanami/hanami/issues/758#issuecomment-290316265) to fix #758 

/cc @ixti and @hanami/core for review.