### PR TITLE
Evaluate configuration from master .env file

### DIFF
--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -48,11 +48,17 @@ module Hanami
     # @api private
     RACK_ENV_DEPLOYMENT = 'deployment'.freeze
 
-    # Default `.env` per environment file name
+    # Default `.env` file name
     #
     # @since 0.2.0
     # @api private
-    DEFAULT_DOTENV_ENV = '.env.%s'.freeze
+    DEFAULT_DOTENV_ENV = '.env'.freeze
+
+    # Specific `.env` per environment file name
+    #
+    # @since 1.0.0
+    # @api private
+    SPECIFIC_DOTENV_ENV = '.env.%s'.freeze
 
     # Default configuration directory under application root
     #
@@ -501,7 +507,8 @@ module Hanami
     # @since 0.1.0
     # @api private
     def set_env_vars!
-      set_application_env_vars!
+      set_application_env_vars!(DEFAULT_DOTENV_ENV)
+      set_application_env_vars!(SPECIFIC_DOTENV_ENV % environment)
       set_hanami_env_vars!
     end
 
@@ -515,8 +522,8 @@ module Hanami
 
     # @since 0.2.0
     # @api private
-    def set_application_env_vars!
-      dotenv = root.join(DEFAULT_DOTENV_ENV % environment)
+    def set_application_env_vars!(dotenv_filename)
+      dotenv = root.join(dotenv_filename)
       return unless dotenv.exist?
 
       env.load!(dotenv)

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -21,20 +21,19 @@ RSpec.describe Hanami::Environment do
 
   describe "#initialize" do
     context "global .env" do
-      it "doesn't set env vars from .env" do
+      it "sets env vars from .env" do
         with_directory('spec/support/fixtures') do
           described_class.new(env: env)
 
-          expect(env['FOO']).to be_nil # see spec/support/fixtures/.env
+          expect(env['FOO']).to eq('bar') # see spec/support/fixtures/.env
         end
       end
 
-      it "doesn't sets port" do
+      it "sets port from .env" do
         with_directory('spec/support/fixtures') do
           subject = described_class.new(env: env)
 
-          # returns default instead the value from spec/support/fixtures/.env
-          expect(subject.port).to eq(2300)
+          expect(subject.port).to eq(42)
         end
       end
     end


### PR DESCRIPTION
Documentation says that both `.env` and `.env.*` files are evaluated, but actually `.env` does not.

This pull request fixes it.