### PR TITLE
Generate Application Layout spec

### DIFF
--- a/lib/hanami/commands/generate/app.rb
+++ b/lib/hanami/commands/generate/app.rb
@@ -36,6 +36,8 @@ module Hanami
           add_mapping('views/application_layout.rb.tt', 'views/application_layout.rb')
           add_mapping("templates/application.html.#{ template_engine.name }.tt", "templates/application.html.#{ template_engine.name }")
           add_mapping('favicon.ico', 'assets/favicon.ico')
+          add_mapping("spec/views/application_layout_spec.rb.#{ test_framework.framework }.tt",
+            "../../spec/#{ app_name }/views/application_layout_spec.rb")
 
           add_mapping('.gitkeep', 'controllers/.gitkeep')
           add_mapping('.gitkeep', 'assets/images/.gitkeep')
@@ -43,7 +45,6 @@ module Hanami
           add_mapping('.gitkeep', 'assets/stylesheets/.gitkeep')
           add_mapping('.gitkeep', "../../spec/#{ app_name }/features/.gitkeep")
           add_mapping('.gitkeep', "../../spec/#{ app_name }/controllers/.gitkeep")
-          add_mapping('.gitkeep', "../../spec/#{ app_name }/views/.gitkeep")
         end
 
         # @api private

--- a/lib/hanami/commands/new/app.rb
+++ b/lib/hanami/commands/new/app.rb
@@ -70,10 +70,12 @@ module Hanami
             add_mapping('spec_helper.rb.rspec.tt', 'spec/spec_helper.rb')
             add_mapping('features_helper.rb.rspec.tt', 'spec/features_helper.rb')
             add_mapping('capybara.rb.rspec.tt', 'spec/support/capybara.rb')
+            add_mapping("spec/views/application_layout_spec.rb.rspec.tt", "spec/#{ app_name }/views/application_layout_spec.rb")
           else
             add_mapping('Rakefile.minitest.tt', 'Rakefile')
             add_mapping('spec_helper.rb.minitest.tt', 'spec/spec_helper.rb')
             add_mapping('features_helper.rb.minitest.tt', 'spec/features_helper.rb')
+            add_mapping("spec/views/application_layout_spec.rb.minitest.tt", "spec/#{ app_name }/views/application_layout_spec.rb")
           end
         end
 
@@ -81,7 +83,6 @@ module Hanami
         def add_empty_directories
           add_mapping('.gitkeep', 'config/initializers/.gitkeep')
           add_mapping('.gitkeep', 'app/controllers/.gitkeep')
-          add_mapping('.gitkeep', 'app/views/.gitkeep')
           add_mapping('.gitkeep', 'app/assets/images/.gitkeep')
           add_mapping('.gitkeep', 'app/assets/javascripts/.gitkeep')
           add_mapping('.gitkeep', 'app/assets/stylesheets/.gitkeep')
@@ -93,7 +94,6 @@ module Hanami
 
           add_mapping('.gitkeep', 'spec/features/.gitkeep')
           add_mapping('.gitkeep', 'spec/controllers/.gitkeep')
-          add_mapping('.gitkeep', 'spec/views/.gitkeep')
           add_mapping('.gitkeep', "spec/#{ app_name }/entities/.gitkeep")
           add_mapping('.gitkeep', "spec/#{ app_name }/repositories/.gitkeep")
           add_mapping('.gitkeep', "spec/#{ app_name }/mailers/.gitkeep")

--- a/lib/hanami/generators/app/spec/views/application_layout_spec.rb.minitest.tt
+++ b/lib/hanami/generators/app/spec/views/application_layout_spec.rb.minitest.tt
@@ -1,0 +1,12 @@
+require "spec_helper"
+require_relative "../../../apps/<%= config[:app_name] %>/views/application_layout"
+
+describe <%= config[:classified_app_name] %>::Views::ApplicationLayout do
+  let(:layout)   { <%= config[:classified_app_name] %>::Views::ApplicationLayout.new(template, {}) }
+  let(:rendered) { layout.render }
+  let(:template) { Hanami::View::Template.new('apps/<%= config[:app_name] %>/templates/application.html.<%= config[:template] %>') }
+
+  it 'contains application name' do
+    rendered.must_include('<%= config[:classified_app_name] %>')
+  end
+end

--- a/lib/hanami/generators/app/spec/views/application_layout_spec.rb.rspec.tt
+++ b/lib/hanami/generators/app/spec/views/application_layout_spec.rb.rspec.tt
@@ -1,0 +1,12 @@
+require "spec_helper"
+require_relative "../../../apps/<%= config[:app_name] %>/views/application_layout"
+
+describe <%= config[:classified_app_name] %>::Views::ApplicationLayout do
+  let(:layout)   { <%= config[:classified_app_name] %>::Views::ApplicationLayout.new(template, {}) }
+  let(:rendered) { layout.render }
+  let(:template) { Hanami::View::Template.new('apps/<%= config[:app_name] %>/templates/application.html.<%= config[:template] %>') }
+
+  it 'contains application name' do
+    expect(rendered).to include('<%= config[:classified_app_name] %>')
+  end
+end

--- a/spec/integration/cli/destroy/app_spec.rb
+++ b/spec/integration/cli/destroy/app_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "hanami destroy", type: :cli do
           "remove  apps/admin/assets/stylesheets/.gitkeep",
           "remove  spec/admin/features/.gitkeep",
           "remove  spec/admin/controllers/.gitkeep",
-          "remove  spec/admin/views/.gitkeep",
+          "remove  spec/admin/views/application_layout_spec.rb",
           "subtract  config/environment.rb",
           "subtract  config/environment.rb",
           "subtract  .env.development",

--- a/spec/integration/cli/generate/app_spec.rb
+++ b/spec/integration/cli/generate/app_spec.rb
@@ -119,7 +119,6 @@ END
       end
     end # haml
 
-
     context "slim" do
       it "generates app" do
         with_project('bookshelf_generate_app_slim', template: :slim) do

--- a/spec/integration/cli/generate/app_spec.rb
+++ b/spec/integration/cli/generate/app_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe "hanami generate", type: :cli do
   </body>
 </html>
 END
+          #
+          # spec/admin/views/application_layout_spec.rb
+          #
+          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{apps/admin/templates/application.html.erb})
         end
       end
     end # erb
@@ -105,10 +109,16 @@ END
     = favicon
   %body
     = yield
-END
+ END
+
+          #
+          # spec/admin/views/application_layout_spec.rb
+          #
+          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{apps/admin/templates/application.html.haml})
         end
       end
     end # haml
+
 
     context "slim" do
       it "generates app" do
@@ -134,6 +144,11 @@ html
   body
     = yield
 END
+
+          #
+          # spec/admin/views/application_layout_spec.rb
+          #
+          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{apps/admin/templates/application.html.slim})
         end
       end
     end # slim

--- a/spec/integration/cli/new/test_spec.rb
+++ b/spec/integration/cli/new/test_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "hanami new", type: :cli do
         project = 'bookshelf_minitest'
         output  = [
           "create  spec/spec_helper.rb",
-          "create  spec/features_helper.rb"
+          "create  spec/features_helper.rb",
+          "create  spec/web/views/application_layout_spec.rb"
         ]
 
         run_command "hanami new #{project} --test=minitest", output
@@ -45,6 +46,24 @@ class MiniTest::Spec
   include Capybara::DSL
 end
 END
+
+          #
+          # spec/<app>/views/application_layout_spec.rb
+          #
+          expect("spec/web/views/application_layout_spec.rb").to have_file_content <<-END
+require "spec_helper"
+require_relative "../../../apps/web/views/application_layout"
+
+describe Web::Views::ApplicationLayout do
+  let(:layout)   { Web::Views::ApplicationLayout.new(template, {}) }
+  let(:rendered) { layout.render }
+  let(:template) { Hanami::View::Template.new('apps/web/templates/application.html.erb') }
+
+  it 'contains application name' do
+    rendered.must_include('Web')
+  end
+end
+END
         end
       end
     end # minitest
@@ -55,7 +74,8 @@ END
         output  = [
           "create  spec/spec_helper.rb",
           "create  spec/features_helper.rb",
-          "create  spec/support/capybara.rb"
+          "create  spec/support/capybara.rb",
+          "create  spec/web/views/application_layout_spec.rb"
         ]
 
         run_command "hanami new #{project} --test=rspec", output
@@ -206,6 +226,26 @@ module RSpec
   end
 end
 END
+
+          #
+          # spec/<app>/views/application_layout_spec.rb
+          #
+          expect("spec/web/views/application_layout_spec.rb").to have_file_content <<-END
+require "spec_helper"
+require_relative "../../../apps/web/views/application_layout"
+
+describe Web::Views::ApplicationLayout do
+  let(:layout)   { Web::Views::ApplicationLayout.new(template, {}) }
+  let(:rendered) { layout.render }
+  let(:template) { Hanami::View::Template.new('apps/web/templates/application.html.erb') }
+
+  it 'contains application name' do
+    expect(rendered).to include('Web')
+  end
+end
+END
+
+
         end
       end
     end # rspec

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe 'hanami new', type: :cli do
       create  apps/web/views/application_layout.rb
       create  apps/web/templates/application.html.erb
       create  apps/web/assets/favicon.ico
+      create  spec/web/views/application_layout_spec.rb
       create  apps/web/controllers/.gitkeep
       create  apps/web/assets/images/.gitkeep
       create  apps/web/assets/javascripts/.gitkeep
       create  apps/web/assets/stylesheets/.gitkeep
       create  spec/web/features/.gitkeep
       create  spec/web/controllers/.gitkeep
-      create  spec/web/views/.gitkeep
       insert  config/environment.rb
       insert  config/environment.rb
       append  .env.development
@@ -725,11 +725,6 @@ END
       # spec/web/controllers/.gitkeep
       #
       expect("spec/web/controllers/.gitkeep").to be_an_existing_file
-
-      #
-      # spec/web/views/.gitkeep
-      #
-      expect("spec/web/views/.gitkeep").to be_an_existing_file
     end
   end
 

--- a/spec/integration/rake/with_minitest_spec.rb
+++ b/spec/integration/rake/with_minitest_spec.rb
@@ -24,7 +24,7 @@ end
 EOF
 
         bundle_exec "rake"
-        expect(out).to include("1 runs, 1 assertions, 0 failures, 0 errors, 0 skips")
+        expect(out).to include("2 runs, 3 assertions, 0 failures, 0 errors, 0 skips")
 
         assert_development_data
       end

--- a/spec/integration/rake/with_rspec_spec.rb
+++ b/spec/integration/rake/with_rspec_spec.rb
@@ -26,7 +26,7 @@ EOF
         bundle_exec "rake"
 
         # The default mailer_spec fails on purpose so you set the correct delivery information.
-        expect(out).to include("2 examples, 1 failure")
+        expect(out).to include("3 examples, 1 failure")
 
         assert_development_data
       end

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -15,13 +15,13 @@ RSpec.shared_examples "a new app" do
       create  apps/#{app}/views/application_layout.rb
       create  apps/#{app}/templates/application.html.erb
       create  apps/#{app}/assets/favicon.ico
+      create  spec/#{app}/views/application_layout_spec.rb
       create  apps/#{app}/controllers/.gitkeep
       create  apps/#{app}/assets/images/.gitkeep
       create  apps/#{app}/assets/javascripts/.gitkeep
       create  apps/#{app}/assets/stylesheets/.gitkeep
       create  spec/#{app}/features/.gitkeep
       create  spec/#{app}/controllers/.gitkeep
-      create  spec/#{app}/views/.gitkeep
       insert  config/environment.rb
       insert  config/environment.rb
       append  .env.development
@@ -392,6 +392,11 @@ END
       expect("apps/#{app}/assets/favicon.ico").to be_an_existing_file
 
       #
+      # spec/<app>/views/application_layout_spec.rb
+      #
+      expect("spec/#{app}/views/application_layout_spec.rb").to be_an_existing_file
+
+      #
       # apps/<app>/controllers/.gitkeep
       #
       expect("apps/#{app}/controllers/.gitkeep").to be_an_existing_file
@@ -420,11 +425,6 @@ END
       # spec/<app>/controllers/.gitkeep
       #
       expect("spec/#{app}/controllers/.gitkeep").to be_an_existing_file
-
-      #
-      # spec/<app>/views/.gitkeep
-      #
-      expect("spec/#{app}/views/.gitkeep").to be_an_existing_file
 
       #
       # config/environment.rb


### PR DESCRIPTION
This Pull Request

* Adds two templates (minitest and rspec) for application_layout_spec.rb
* Tweaks `new` and `generate` commands to generate the spec file as well
* Contains various test fixes and additions.
* Hopefully closes #735

*Note*: I wasn't sure where to place template files. Is there any better place?