### PR TITLE
Correctly removing migration file when model destroying

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ You can give back to Open Source, by supporting Hanami development via a [donati
 
 ### Supporters
 
+  * [Trung Lê](https://github.com/joneslee85)
   * [James Carlson](https://github.com/jxxcarlson)
+  * [Creditas](https://www.creditas.com.br/)
 
 ## Contact
 

--- a/lib/hanami/commands/generate/model.rb
+++ b/lib/hanami/commands/generate/model.rb
@@ -103,9 +103,24 @@ module Hanami
         # @since 0.9.1
         # @api private
         def migration_path
+          existing_migration_path || new_migration_path
+        end
+
+        # @since 1.1.0
+        # @api private
+        def new_migration_path
           timestamp = Time.now.utc.strftime(Migration::TIMESTAMP_FORMAT)
-          filename = Migration::FILENAME_PATTERN % { timestamp: timestamp, name: "create_#{table_name}"}
+          filename = Migration::FILENAME_PATTERN % { timestamp: timestamp, name: migration_name_underscored }
+
           Hanami::Model.configuration.migrations.join(filename)
+        end
+
+        # @since 1.1.0
+        # @api private
+        def existing_migration_path
+          Utils::FileList["#{Hanami::Model.configuration.migrations}/*.rb"].find do |filename|
+            %r{/\d{14}_#{migration_name_underscored}.rb\z} =~ filename
+          end
         end
 
         # @since 0.5.0
@@ -125,6 +140,12 @@ module Hanami
         # @api private
         def model_name_underscored
           input
+        end
+
+        # @since 1.1.0
+        # @api private
+        def migration_name_underscored
+          "create_#{table_name}"
         end
       end
     end

--- a/spec/integration/cli/destroy/model_spec.rb
+++ b/spec/integration/cli/destroy/model_spec.rb
@@ -5,13 +5,12 @@ RSpec.describe "hanami destroy", type: :cli do
     it "destroys model" do
       with_project do
         generate "model user"
-        _migration = Dir.glob(Pathname.new("db").join("migrations", "*_create_users.rb")).first.to_s
+        migration = Dir.glob(Pathname.new("db").join("migrations", "*_create_users.rb")).first.to_s
 
         output = [
           "remove  lib/bookshelf/entities/user.rb",
           "remove  lib/bookshelf/repositories/user_repository.rb",
-          # FIXME: with Hanami 1.1
-          # "remove  #{migration}",
+          "remove  #{migration}",
           "remove  spec/bookshelf/entities/user_spec.rb",
           "remove  spec/bookshelf/repositories/user_repository_spec.rb"
         ]
@@ -20,8 +19,30 @@ RSpec.describe "hanami destroy", type: :cli do
 
         expect("lib/bookshelf/entities/user.rb").to_not                      be_an_existing_file
         expect("lib/bookshelf/repositories/user_repository.rb").to_not       be_an_existing_file
+        expect(migration).to_not                                             be_an_existing_file
         expect("spec/bookshelf/entities/user_spec.rb").to_not                be_an_existing_file
         expect("spec/bookshelf/repositories/user_repository_spec.rb").to_not be_an_existing_file
+      end
+    end
+
+    it "destroys model even if migration was deleted manually" do
+      with_project do
+        generate "model user"
+        migration = Dir.glob(Pathname.new("db").join("migrations", "*_create_users.rb")).first.to_s
+
+        run_simple "rm #{migration}"
+
+        expect(migration).to_not be_an_existing_file
+
+        output = [
+          "remove  lib/bookshelf/entities/user.rb",
+          "remove  lib/bookshelf/repositories/user_repository.rb",
+          /remove.+_create_users\.rb/,
+          "remove  spec/bookshelf/entities/user_spec.rb",
+          "remove  spec/bookshelf/repositories/user_repository_spec.rb"
+        ]
+
+        run_command "hanami destroy model user", output
       end
     end
 

--- a/spec/isolation/rake/environment_spec.rb
+++ b/spec/isolation/rake/environment_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe "Rake: environment", type: :cli do
   it "loads the project" do
     with_project do
       generate_migrations
-      generate_model "user"
+      generate_model "author"
       hanami "db prepare"
 
       append "Rakefile", <<-EOF
 task database_counts: :environment do
-puts "users: \#{UserRepository.new.all.count}"
+puts "users: \#{AuthorRepository.new.all.count}"
 end
 EOF
 


### PR DESCRIPTION
When I generate and then destroy model through generator, migration file doesn't removed.

Please, see [issue](https://github.com/hanami/hanami/issues/784).

With this fix we have identical names of migration file for generating and destroying.