### PR TITLE
Create migrations folder if not present

### DIFF
--- a/lib/hanami/commands/generate/model.rb
+++ b/lib/hanami/commands/generate/model.rb
@@ -23,6 +23,8 @@ module Hanami
           @model_name = Utils::String.new(@input).classify
           @table_name = Utils::String.new(@input).pluralize
 
+          FileUtils.mkdir_p("#{target_path}/db/migrations") unless File.exist?("#{target_path}/db/migrations")
+
           unless skip_migration?
             Components.resolve('model.configuration')
           end

--- a/spec/integration/cli/generate/model_spec.rb
+++ b/spec/integration/cli/generate/model_spec.rb
@@ -38,6 +38,18 @@ END
       end
     end
 
+    context "with a missing migration folder" do
+      it "will create a migration file and folder" do
+        model_name = "book"
+        project = "missing_migrations_folder"
+        with_project(project) do
+          FileUtils.rm_rf('db/migrations')
+          run_command "hanami generate model #{model_name}"
+          expect(Pathname.new('db/migrations')).to be_directory
+        end
+      end
+    end
+
     context "with skip-migration" do
       it "doesn't create a migration file" do
         model_name = "user"


### PR DESCRIPTION
Hey, this PR relates to #785 which was saying that if your migrations folder is missing within the db folder it would throw an error when you would try to create a model. It indeed would throw an error since the directory does not exist.

I wasn't sure what the proper way of getting the path of the project is, so if there is a more defined way of getting it please let me know. (or if you think there is a better solution available)