### PR TITLE
Start hanami server in tests on random ports

### DIFF
--- a/spec/support/hanami_commands.rb
+++ b/spec/support/hanami_commands.rb
@@ -1,6 +1,7 @@
 require_relative 'bundler'
 require_relative 'files'
 require_relative 'retry'
+require_relative 'random_port'
 require 'hanami/utils/string'
 
 module RSpec
@@ -9,13 +10,16 @@ module RSpec
       private
 
       def rackup(args = {}, &blk)
-        bundle_exec "rackup -p 2300" do |_, _, wait_thr|
+        args[:port] ||= RandomPort.call
+
+        bundle_exec "rackup -p #{args[:port]}" do |_, _, wait_thr|
           exec_server_tests(args, wait_thr, &blk)
         end
       end
 
       def server(args = {}, &blk)
-        args[:port] ||= rand(2300..9999)
+        args[:port] ||= RandomPort.call
+
         hanami "server#{_hanami_server_args(args)}" do |_, _, wait_thr|
           exec_server_tests(args, wait_thr, &blk)
         end

--- a/spec/support/hanami_commands.rb
+++ b/spec/support/hanami_commands.rb
@@ -15,6 +15,7 @@ module RSpec
       end
 
       def server(args = {}, &blk)
+        args[:port] ||= rand(2300..9999)
         hanami "server#{_hanami_server_args(args)}" do |_, _, wait_thr|
           exec_server_tests(args, wait_thr, &blk)
         end

--- a/spec/support/random_port.rb
+++ b/spec/support/random_port.rb
@@ -1,0 +1,41 @@
+require 'socket'
+require 'timeout'
+
+module RSpec
+  module Support
+    module RandomPort
+      HOST       = "localhost".freeze
+      PORT_RANGE = 1024..65_535
+      TIMEOUT    = 1 # second
+
+      def self.call
+        result = -1
+
+        loop do
+          result = Kernel.rand(PORT_RANGE)
+          break unless open?(result)
+        end
+
+        result
+      end
+
+      def self.open?(port) # rubocop:disable Metrics/MethodLength
+        Timeout.timeout(TIMEOUT) do
+          begin
+            s = TCPSocket.new(HOST, port)
+            s.close
+            return true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            return false
+          end
+        end
+
+        false
+      rescue Timeout::Error
+        false
+      end
+
+      private_class_method :open?
+    end
+  end
+end


### PR DESCRIPTION
Regarding our gitter discussion, I set up random port value for each `hanami server` call in specs