### PR TITLE
Remove references to 'architecture'

### DIFF
--- a/lib/hanami/application_configuration.rb
+++ b/lib/hanami/application_configuration.rb
@@ -1012,10 +1012,6 @@ module Hanami
 
     # Defines a relative pattern to find controllers.
     #
-    # Hanami supports multiple architectures (aka application structures), this
-    # setting helps to understand the namespace where to find applications'
-    # controllers and actions.
-    #
     # By default this equals to <tt>"Controllers::%{controller}::%{action}"</tt>
     # That means controllers must be structured like this:
     # <tt>Bookshelf::Controllers::Dashboard::Index</tt>, where <tt>Bookshelf</tt>
@@ -1142,10 +1138,6 @@ module Hanami
     end
 
     # Defines a relative pattern to find views:.
-    #
-    # Hanami supports multiple architectures (aka application structures), this
-    # setting helps to understand the namespace where to find applications'
-    # views:.
     #
     # By default this equals to <tt>"Views::%{controller}::%{action}"</tt>
     # That means views must be structured like this:

--- a/lib/hanami/cli/commands/new/hanamirc.erb
+++ b/lib/hanami/cli/commands/new/hanamirc.erb
@@ -1,4 +1,3 @@
 <%= Hanami::Hanamirc::PROJECT_NAME %>=<%= project %>
-<%= Hanami::Hanamirc::ARCHITECTURE_KEY %>=<%= Hanami::Hanamirc::DEFAULT_ARCHITECTURE %>
 <%= Hanami::Hanamirc::TEST_KEY %>=<%= test %>
 <%= Hanami::Hanamirc::TEMPLATE_KEY %>=<%= template_engine.name %>

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -110,19 +110,7 @@ module Hanami
 
     # @since 0.4.0
     # @api private
-    CONTAINER = 'container'.freeze
-
-    # @since 0.4.0
-    # @api private
-    CONTAINER_PATH = 'apps'.freeze
-
-    # @since 0.4.0
-    # @api private
-    APPLICATION = 'app'.freeze
-
-    # @since 0.4.0
-    # @api private
-    APPLICATION_PATH = 'app'.freeze
+    APPS_PATH = 'apps'.freeze
 
     # @since 0.4.0
     # @api private
@@ -432,21 +420,6 @@ module Hanami
       @options.fetch(:code_reloading) { !!CODE_RELOADING[environment] }
     end
 
-    # @since 0.4.0
-    # @api private
-    def architecture
-      @options.fetch(:architecture) do
-        puts "Cannot recognize Hanami architecture, please check `.hanamirc'"
-        exit 1
-      end
-    end
-
-    # @since 0.4.0
-    # @api private
-    def container?
-      architecture == CONTAINER
-    end
-
     # @since 0.6.0
     # @api private
     def serve_static_assets?
@@ -470,12 +443,7 @@ module Hanami
     # @since 0.4.0
     # @api private
     def apps_path
-      @options.fetch(:path) {
-        case architecture
-        when CONTAINER   then CONTAINER_PATH
-        when APPLICATION then APPLICATION_PATH
-        end
-      }
+      @options.fetch(:path, APPS_PATH)
     end
 
     # Serialize the most relevant settings into a Hash

--- a/lib/hanami/hanamirc.rb
+++ b/lib/hanami/hanamirc.rb
@@ -15,28 +15,6 @@ module Hanami
     # @see Hanami::Hanamirc#path_file
     FILE_NAME = '.hanamirc'.freeze
 
-    # Architecture default value
-    #
-    # @since 0.3.0
-    # @api private
-    #
-    # @see Hanami::Hanamirc#options
-    DEFAULT_ARCHITECTURE = 'container'.freeze
-
-    # Application architecture value
-    #
-    # @since 0.6.0
-    # @api private
-    APP_ARCHITECTURE = 'app'.freeze
-
-    # Architecture key for writing the hanamirc file
-    #
-    # @since 0.3.0
-    # @api private
-    #
-    # @see Hanami::Hanamirc#default_options
-    ARCHITECTURE_KEY = 'architecture'.freeze
-
     # Project name for writing the hanamirc file
     #
     # @since 0.8.0
@@ -98,12 +76,12 @@ module Hanami
     #
     # @example Default values if file doesn't exist
     #   Hanami::Hanamirc.new(Pathname.new(Dir.pwd)).options
-    #    # => { architecture: 'container', test: 'minitest', template: 'erb' }
+    #    # => { test: 'minitest', template: 'erb' }
     #
     # @example Custom values if file doesn't exist
-    #   options = { architect: 'application', test: 'rspec', template: 'slim' }
+    #   options = { test: 'rspec', template: 'slim' }
     #   Hanami::Hanamirc.new(Pathname.new(Dir.pwd), options).options
-    #    # => { architecture: 'application', test: 'rspec', template: 'slim' }
+    #    # => { test: 'rspec', template: 'slim' }
     def options
       @options ||= symbolize(default_options.merge(file_options))
     end
@@ -116,7 +94,6 @@ module Hanami
     # @see Hanami::Hanamirc#options
     def default_options
       @default_options ||= Utils::Hash.new({
-                                           ARCHITECTURE_KEY => DEFAULT_ARCHITECTURE,
                                            PROJECT_NAME     => project_name,
                                            TEST_KEY         => DEFAULT_TEST_SUITE,
                                            TEMPLATE_KEY     => DEFAULT_TEMPLATE

--- a/lib/hanami/middleware.rb
+++ b/lib/hanami/middleware.rb
@@ -141,10 +141,8 @@ module Hanami
     # @since 0.2.0
     def load_default_stack
       @default_stack_loaded ||= begin
-        _load_assets_middleware
         _load_session_middleware
         _load_default_welcome_page
-        _load_method_override_middleware
 
         true
       end
@@ -168,30 +166,6 @@ module Hanami
     def _load_session_middleware
       if configuration.sessions.enabled?
         prepend(*configuration.sessions.middleware)
-      end
-    end
-
-    # Use static assets middleware
-    #
-    # @api private
-    # @since 0.6.0
-    def _load_assets_middleware
-      env = Hanami.environment
-
-      if !env.container? && (middleware = env.static_assets_middleware)
-        use middleware
-      end
-    end
-
-    # Use MethodOverride middleware
-    #
-    # @api private
-    # @since 0.8.0
-    def _load_method_override_middleware
-      env = Hanami.environment
-
-      if !env.container?
-        use Rack::MethodOverride
       end
     end
   end

--- a/lib/hanami/static.rb
+++ b/lib/hanami/static.rb
@@ -2,7 +2,7 @@ require 'rack/static'
 
 module Hanami
   # Serve static assets in deployment environments (production, staging) where
-  # the architecture doesn't include a web server.
+  # the stack doesn't include a web server.
   #
   # Web servers like Nginx are the ideal candidate to serve static assets.
   # They are faster than Ruby application servers (eg. Puma) and they should be

--- a/lib/hanami/templates/welcome.html.erb
+++ b/lib/hanami/templates/welcome.html.erb
@@ -32,7 +32,7 @@
 
       <h3>Hanami is Open Source Software for MVC web development with Ruby.</h3>
 
-      <p>Please generate a new action with:<br><code>bundle exec hanami generate action<%= application_name %> home#index --url=/</code></p>
+      <p>Please generate a new action with:<br><code>bundle exec hanami generate action <%= application_name %> home#index --url=/</code></p>
 
       <hr style="margin-top: 4em;"/>
       <div id="content">

--- a/lib/hanami/welcome.rb
+++ b/lib/hanami/welcome.rb
@@ -21,26 +21,16 @@ module Hanami
 
     # @api private
     def application_name
-      " #{ app }" if container?
+      application_class.app_name
     end
 
     private
-
-    # @api private
-    def container?
-      Environment.new.container?
-    end
 
     # @api private
     def application_class
       Hanami.configuration.apps do |app|
         return app if @request_path.include?(app.path_prefix)
       end
-    end
-
-    # @api private
-    def app
-      application_class.app_name
     end
   end
 end

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -57,7 +57,6 @@ OUT
       #
       expect('.hanamirc').to have_file_content <<-END
 project=#{project}
-architecture=container
 test=minitest
 template=erb
 END


### PR DESCRIPTION
Since we don't support different architectures anymore (we used to have 'app' architecture, now it's all 'container'), we can remove code dealing with that.


This is a re-do of #737, but done with the new CLI. Many of the different templates were already removed as part of that integration.

I'm confident I removed all the references to 'container', but looking for 'app' is much harder, since there are many uses of that term. 

@hanami/core what do we think about renaming [`Hanami::App`](https://github.com/hanami/hanami/blob/develop/lib/hanami/app.rb), which is the "Main application that mounts many Rack and/or Hanami applications." to `Hanami::ProjectApp`, or similar? It's confusing having both `Application` and `App`.

🌸 