### PR TITLE
Require Dotenv::Parser specifically

### DIFF
--- a/lib/hanami/env.rb
+++ b/lib/hanami/env.rb
@@ -1,5 +1,5 @@
 begin
-  require 'dotenv'
+  require 'dotenv/parser'
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
@@ -53,7 +53,7 @@ module Hanami
     # @since 0.9.0
     # @api private
     def load!(path)
-      return unless defined?(Dotenv)
+      return unless defined?(Dotenv::Parser)
 
       contents = ::File.open(path, "rb:bom|utf-8", &:read)
       parsed   = Dotenv::Parser.call(contents)


### PR DESCRIPTION
Fixes #807.

I opened this against `master`, since it's a bugfix that could be a patch release, rather than a minor release. Feel free to change to `develop` if desired.

I manually tested this, with two versions of dotenv (`0.10.0` and `2.2.1`) installed and that error didn't come up (whereas, it does come up with 0.10.0 installed without this patch).