### PR TITLE
Implement rollback command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,11 @@ gem 'hanami-validations', '1.1.0.beta1', require: false, git: 'https://github.co
 gem 'hanami-router',      '1.1.0.beta1', require: false, git: 'https://github.com/hanami/router.git',      branch: 'develop'
 gem 'hanami-controller',  '1.1.0.beta1', require: false, git: 'https://github.com/hanami/controller.git',  branch: 'develop'
 gem 'hanami-view',        '1.1.0.beta1', require: false, git: 'https://github.com/hanami/view.git',        branch: 'develop'
-gem 'hanami-model',       '1.1.0.beta1', require: false, git: 'https://github.com/hanami/model.git',       branch: 'develop'
+gem 'hanami-model',       require: false, git: 'https://github.com/hanami/model.git',       branch: 'develop'
 gem 'hanami-helpers',     '1.1.0.beta1', require: false, git: 'https://github.com/hanami/helpers.git',     branch: 'develop'
 gem 'hanami-mailer',      '1.1.0.beta1', require: false, git: 'https://github.com/hanami/mailer.git',      branch: 'develop'
 gem 'hanami-assets',      '1.1.0.beta1', require: false, git: 'https://github.com/hanami/assets.git',      branch: 'develop'
-gem 'hanami-cli',         '0.1.0.beta1', require: false, git: 'https://github.com/hanami/cli.git',         branch: 'develop'
+gem 'hanami-cli',         require: false, git: 'https://github.com/hanami/cli.git',         branch: 'develop'
 
 platforms :ruby do
   gem 'sqlite3'

--- a/lib/hanami/cli/commands/db.rb
+++ b/lib/hanami/cli/commands/db.rb
@@ -11,6 +11,7 @@ module Hanami
         require "hanami/cli/commands/db/create"
         require "hanami/cli/commands/db/drop"
         require "hanami/cli/commands/db/migrate"
+        require "hanami/cli/commands/db/rollback"
         require "hanami/cli/commands/db/prepare"
         require "hanami/cli/commands/db/apply"
         require "hanami/cli/commands/db/console"
@@ -18,13 +19,14 @@ module Hanami
     end
 
     register "db" do |prefix|
-      prefix.register "version", Commands::Db::Version
-      prefix.register "create",  Commands::Db::Create
-      prefix.register "drop",    Commands::Db::Drop
-      prefix.register "migrate", Commands::Db::Migrate
-      prefix.register "prepare", Commands::Db::Prepare
-      prefix.register "apply",   Commands::Db::Apply
-      prefix.register "console", Commands::Db::Console
+      prefix.register "version",  Commands::Db::Version
+      prefix.register "create",   Commands::Db::Create
+      prefix.register "drop",     Commands::Db::Drop
+      prefix.register "migrate",  Commands::Db::Migrate
+      prefix.register "rollback", Commands::Db::Rollback
+      prefix.register "prepare",  Commands::Db::Prepare
+      prefix.register "apply",    Commands::Db::Apply
+      prefix.register "console",  Commands::Db::Console
     end
   end
 end

--- a/lib/hanami/cli/commands/db/rollback.rb
+++ b/lib/hanami/cli/commands/db/rollback.rb
@@ -1,0 +1,39 @@
+module Hanami
+  class CLI
+    module Commands
+      module Db
+        # @since x.x.x
+        # @api private
+        class Rollback < Command
+          requires "model.sql"
+
+          desc "Rollback the database"
+
+          argument :steps, desc: "Number of versions to rollback the database", default: 1
+
+          example [
+            "  # Rollback lastest version",
+            "2 # Rollbacks two versions"
+          ]
+
+          # @since x.x.x
+          # @api private
+          def call(steps:, **options)
+            context = Context.new(steps: steps.to_i)
+
+            rollback_database(context)
+          end
+
+          private
+
+          # @since x.x.x
+          # @api private
+          def rollback_database(context)
+            require "hanami/model/migrator"
+            Hanami::Model::Migrator.rollback(steps: context.steps)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/cli/db/rollback_spec.rb
+++ b/spec/integration/cli/db/rollback_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe "hanami db", type: :cli do
+  describe "rollback" do
+    it "rollbacks database" do
+      project = "bookshelf_db_rollback"
+
+      with_project(project) do
+        generate_migrations
+
+        hanami "db create"
+        hanami "db migrate"
+        hanami "db rollback"
+
+        db = Pathname.new("db").join("#{project}_development.sqlite")
+
+        users = `sqlite3 #{db} ".schema users"`
+        expect(users).to include("CREATE TABLE `users`(`id` integer DEFAULT (NULL) NOT NULL PRIMARY KEY AUTOINCREMENT, `name` varchar(255) DEFAULT (NULL) NULL);")
+
+        version = `sqlite3 #{db} "SELECT filename FROM schema_migrations ORDER BY filename DESC LIMIT 1"`
+        expect(version).to_not include("add_age_to_users")
+      end
+    end
+
+    it "rollbacks database using custom steps" do
+      project = "bookshelf_db_migrate_custom_steps"
+
+      with_project(project) do
+        generate_migrations
+
+        hanami "db create"
+        hanami "db migrate"
+        hanami "db rollback 2"
+
+        db = Pathname.new("db").join("#{project}_development.sqlite")
+
+        users = `sqlite3 #{db} ".schema users"`
+        expect(users).to_not include("CREATE TABLE `users`(`id` integer DEFAULT (NULL) NOT NULL PRIMARY KEY AUTOINCREMENT, `name` varchar(255) DEFAULT (NULL) NULL);")
+
+        version = `sqlite3 #{db} "SELECT filename FROM schema_migrations ORDER BY filename DESC LIMIT 1"`
+        expect(version).to_not include("create_users")
+      end
+    end
+
+    it 'prints help message' do
+      with_project do
+        output = <<-OUT
+Command:
+  hanami db rollback
+
+Usage:
+  hanami db rollback [STEPS]
+
+Description:
+  Rollback the database
+
+Arguments:
+  STEPS               	# Number of versions to rollback the database
+
+Options:
+  --help, -h                      	# Print this help
+
+Examples:
+  hanami db rollback   # Rollback lastest version
+  hanami db rollback 2 # Rollbacks two versions
+OUT
+        run_command 'hanami db rollback --help', output
+      end
+    end
+  end
+end

--- a/spec/integration/cli/db_spec.rb
+++ b/spec/integration/cli/db_spec.rb
@@ -9,6 +9,7 @@ Commands:
   hanami db drop                            # Drop the database (only for development/test)
   hanami db migrate [VERSION]               # Migrate the database
   hanami db prepare                         # Drop, create, and migrate the database (only for development/test)
+  hanami db rollback [STEPS]                # Rollback the database
   hanami db version                         # Print the current migrated version
 OUT
 


### PR DESCRIPTION
This PR implements #603 

Model PR: https://github.com/hanami/model/pull/439

As discussed in that issue, we support migrate a version using `hanami db migrate VERSION` but for better user experience, we are implementing `hanami db rollback` by default it will rollback only one version but you can pass a number `hanami db rollback 3`, it will rollback 3 versions.

IMO this will improve the user experience because you don't have to see the version, sometime you'll know to search all the version and then copy&paste, I think it's better make a simple rollback using a command for that purpose and using a number of steps.

cc @hanami/core 