### PR TITLE
Hanami logger creates automatically all folders for the stream

### DIFF
--- a/spec/isolation/components/logger/with_arguments_spec.rb
+++ b/spec/isolation/components/logger/with_arguments_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe "Components: logger", type: :cli do
   it "accepts arbitrary arguments" do
     with_project do
-      FileUtils.mkpath('log')
       count = 5
       replace 'config/environment.rb', 'logger ', "logger #{count}, 128, stream: 'log/development.log'"
 


### PR DESCRIPTION
When using `stream` option in the logger, we can use a path for our file but if that path doesn't exist, application will crash. 

This test ensure that logger will create the path. 

Logger PR: https://github.com/hanami/utils/pull/231