### PR TITLE
Cleanup generated readme

### DIFF
--- a/lib/hanami/cli/commands/new/README.md.erb
+++ b/lib/hanami/cli/commands/new/README.md.erb
@@ -1,4 +1,4 @@
-# <%= project %>
+# <%= Hanami::Utils::String.titleize(project) %>
 
 Welcome to your new Hanami project!
 

--- a/lib/hanami/cli/commands/new/README.md.erb
+++ b/lib/hanami/cli/commands/new/README.md.erb
@@ -22,14 +22,12 @@ How to run the development server:
 % bundle exec hanami server
 ```
 
-How to create and migrate DB for development and test ENVs:
+How to prepare (create and migrate) DB for `development` and `test` environments:
 
 ```
-% bundle exec hanami db create
-% bundle exec hanami db migrate
+% bundle exec hanami db prepare
 
-% HANAMI_ENV=test bundle exec hanami db create
-% HANAMI_ENV=test bundle exec hanami db migrate
+% HANAMI_ENV=test bundle exec hanami db prepare
 ```
 
 Explore Hanami [guides](http://hanamirb.org/guides/), [API docs](http://hanamirb.org/docs/1.0.0/), or jump in [chat](http://chat.hanamirb.org) for help. Enjoy! 🌸

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -81,7 +81,7 @@ END
       # README.md
       #
       expect('README.md').to have_file_content <<-END
-# bookshelf
+# Bookshelf
 
 Welcome to your new Hanami project!
 

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -105,14 +105,12 @@ How to run the development server:
 % bundle exec hanami server
 ```
 
-How to create and migrate DB for development and test ENVs:
+How to prepare (create and migrate) DB for `development` and `test` environments:
 
 ```
-% bundle exec hanami db create
-% bundle exec hanami db migrate
+% bundle exec hanami db prepare
 
-% HANAMI_ENV=test bundle exec hanami db create
-% HANAMI_ENV=test bundle exec hanami db migrate
+% HANAMI_ENV=test bundle exec hanami db prepare
 ```
 
 Explore Hanami [guides](http://hanamirb.org/guides/), [API docs](http://hanamirb.org/docs/1.0.0/), or jump in [chat](http://chat.hanamirb.org) for help. Enjoy! 🌸


### PR DESCRIPTION
1) Titleizes header from `# bookshelf` to `# Bookshelf`

2) Simplifies `db create` and `db migrate` as `db prepare`

@davydovanton I was going to fix the hardcoded `1.0.0` to the docs page at the bottom, but it looks like that's the only docs version we are generating. What are the plans for that? What versions of docs will we generate? (Maybe not alphas/betas/rcs, but just proper releases?)