### PR TITLE
Gemfile plugins

### DIFF
--- a/bin/hanami
+++ b/bin/hanami
@@ -2,4 +2,5 @@
 require 'bundler'
 require 'hanami/cli/commands'
 
+Bundler.require(:plugins)
 Hanami::CLI.new(Hanami::CLI::Commands).call

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -391,6 +391,7 @@ module Hanami
     # @since 0.4.0
     # @api private
     def require_application_environment
+      Bundler.setup(*bundler_groups)
       require project_environment_configuration.to_s # if project_environment_configuration.exist?
     end
 

--- a/lib/hanami/rake_helper.rb
+++ b/lib/hanami/rake_helper.rb
@@ -17,7 +17,6 @@ module Hanami
     # @since 0.6.0
     # @api private
     #
-    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def install
       desc "Load the full project"
@@ -50,19 +49,30 @@ module Hanami
       #
       # This is the preferred way to run Hanami command line tasks.
       # Please use them when you're in control of your deployment environment.
+      #
+      # If you're not in control and your deployment requires these "standard"
+      # Rake tasks, they are here to solve this only specific problem.
       namespace :db do
         task :migrate do
-          system("bundle exec hanami db migrate") || exit($?.exitstatus)
+          run_hanami_command("db migrate")
         end
       end
 
       namespace :assets do
         task :precompile do
-          system("bundle exec hanami assets precompile") || exit($?.exitstatus)
+          run_hanami_command("assets precompile")
         end
       end
     end
+
+    private
+
+    # @since 1.1.0
+    # @api private
+    def run_hanami_command(command)
+      require "hanami/cli/commands"
+      Hanami::CLI.new(Hanami::CLI::Commands).call(arguments: command.split(/[[:space:]]/))
+    end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/spec/integration/cli/plugins_spec.rb
+++ b/spec/integration/cli/plugins_spec.rb
@@ -1,0 +1,10 @@
+require "pathname"
+
+RSpec.describe "CLI plugins", type: :cli do
+  it "includes its commands in CLI output" do
+    with_project("bookshelf", gems: { "hanami-plugin" => { groups: [:plugins], path: Pathname.new(__dir__).join("..", "..", "..", "spec", "support", "fixtures", "hanami-plugin").realpath.to_s } }) do
+      bundle_exec "hanami"
+      expect(out).to include("hanami plugin [SUBCOMMAND]")
+    end
+  end
+end

--- a/spec/integration/cli/plugins_spec.rb
+++ b/spec/integration/cli/plugins_spec.rb
@@ -2,9 +2,24 @@ require "pathname"
 
 RSpec.describe "CLI plugins", type: :cli do
   it "includes its commands in CLI output" do
-    with_project("bookshelf", gems: { "hanami-plugin" => { groups: [:plugins], path: Pathname.new(__dir__).join("..", "..", "..", "spec", "support", "fixtures", "hanami-plugin").realpath.to_s } }) do
+    with_project do
       bundle_exec "hanami"
       expect(out).to include("hanami plugin [SUBCOMMAND]")
+    end
+  end
+
+  it "executes command from plugin" do
+    with_project do
+      bundle_exec "hanami plugin version"
+      expect(out).to include("v0.1.0")
+    end
+  end
+
+  private
+
+  def with_project
+    super("bookshelf", gems: { "hanami-plugin" => { groups: [:plugins], path: Pathname.new(__dir__).join("..", "..", "..", "spec", "support", "fixtures", "hanami-plugin").realpath.to_s } }) do
+      yield
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,4 +24,9 @@ RSpec.configure do |config|
 end
 
 require 'hanami'
-Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+require 'hanami/utils/file_list'
+
+Hanami::Utils::FileList["./spec/support/**/*.rb"].each do |file|
+  next if file.include?("hanami-plugin")
+  require file
+end

--- a/spec/support/bundler.rb
+++ b/spec/support/bundler.rb
@@ -33,13 +33,22 @@ module RSpec
 
       attr_reader :out, :err, :exitstatus
 
-      def setup_gemfile(gems: [], exclude_gems: [], path: "Gemfile")
+      def setup_gemfile(gems: [], exclude_gems: [], path: "Gemfile") # rubocop:disable Metrics/MethodLength
         source     = "source 'file://#{cache}'"
         content    = ::File.readlines(path)
         content[0] = "#{source}\n"
 
-        unless gems.empty? # rubocop:disable Style/IfUnlessModifier
-          content.concat gems.map { |g| "gem '#{g}'\n" }
+        unless gems.empty?
+          gems = gems.map do |g|
+            case g
+            when String
+              "gem '#{g}'\n"
+            when Array
+              "gem '#{g.first}', #{g.last}\n"
+            end
+          end
+
+          content.concat(gems)
         end
 
         exclude_gems.each do |g|

--- a/spec/support/fixtures/hanami-plugin/.gitignore
+++ b/spec/support/fixtures/hanami-plugin/.gitignore
@@ -1,0 +1,9 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/spec/support/fixtures/hanami-plugin/Gemfile
+++ b/spec/support/fixtures/hanami-plugin/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in hanami-plugin.gemspec
+gemspec

--- a/spec/support/fixtures/hanami-plugin/README.md
+++ b/spec/support/fixtures/hanami-plugin/README.md
@@ -1,0 +1,35 @@
+# Hanami::Plugin
+
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/hanami/plugin`. To experiment with that code, run `bin/console` for an interactive prompt.
+
+TODO: Delete this and the text above, and describe your gem
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'hanami-plugin'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install hanami-plugin
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/jodosha/hanami-plugin.

--- a/spec/support/fixtures/hanami-plugin/Rakefile
+++ b/spec/support/fixtures/hanami-plugin/Rakefile
@@ -1,0 +1,2 @@
+require "bundler/gem_tasks"
+task :default => :spec

--- a/spec/support/fixtures/hanami-plugin/bin/console
+++ b/spec/support/fixtures/hanami-plugin/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "hanami/plugin"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/spec/support/fixtures/hanami-plugin/bin/setup
+++ b/spec/support/fixtures/hanami-plugin/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/spec/support/fixtures/hanami-plugin/hanami-plugin.gemspec
+++ b/spec/support/fixtures/hanami-plugin/hanami-plugin.gemspec
@@ -1,0 +1,27 @@
+# coding: utf-8
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "hanami/plugin/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "hanami-plugin"
+  spec.version       = Hanami::Plugin::VERSION
+  spec.authors       = ["Luca Guidi"]
+  spec.email         = ["me@lucaguidi.com"]
+
+  spec.summary       = %q{Hanami Plugin}
+  spec.description   = %q{Extend Hanami with super powers}
+  spec.homepage      = "http://hanamirb.org"
+
+    spec.metadata["allowed_push_host"] = "http://fakegemserver.hanamirb.org"
+
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "rake", "~> 10.0"
+end

--- a/spec/support/fixtures/hanami-plugin/lib/hanami/plugin.rb
+++ b/spec/support/fixtures/hanami-plugin/lib/hanami/plugin.rb
@@ -1,0 +1,6 @@
+module Hanami
+  module Plugin
+    require "hanami/plugin/version"
+    require "hanami/plugin/cli"
+  end
+end

--- a/spec/support/fixtures/hanami-plugin/lib/hanami/plugin/cli.rb
+++ b/spec/support/fixtures/hanami-plugin/lib/hanami/plugin/cli.rb
@@ -1,0 +1,17 @@
+require "hanami/cli/commands"
+
+module Hanami
+  module Plugin
+    module CLI
+      class Version < Hanami::CLI::Command
+        desc "Print Hanami plugin version"
+
+        def call(*)
+          puts "v#{Hanami::Plugin::VERSION}"
+        end
+      end
+    end
+  end
+end
+
+Hanami::CLI.register "plugin version", Hanami::Plugin::CLI::Version

--- a/spec/support/fixtures/hanami-plugin/lib/hanami/plugin/version.rb
+++ b/spec/support/fixtures/hanami-plugin/lib/hanami/plugin/version.rb
@@ -1,0 +1,5 @@
+module Hanami
+  module Plugin
+    VERSION = "0.1.0"
+  end
+end


### PR DESCRIPTION
Introduce a new convention for Hanami plugin gems: the `:plugins` `Gemfile` group.

---

## The problem

With 1.1 we'll introduce a way to register custom CLI commands for third party gems.

Let's say we have a fictional `hanami-foo` gem, which wants to register a `hanami foo setup` command. This gem was added by a developer in their `bookshelf` project `Gemfile`.

When we start `hanami` command, we **don't** eager load all the gems in `Gemfile`, because it isn't efficient to do so.

But if we don't load the bundled gems, that means our `hanami-foo` isn't loaded as well, so the commands cannot be registered.

This is a chicken-egg problem.

## The solution

Instead of eager loading **all** the gems in `Gemfile`, we can load **only a subset** of them that is strictly necessary: the `:plugins` group.

Here's how should look the `Gemfile` of a `bookshelf` project:

```ruby
source "https://rubygems.org"

# ...

group :plugins do
  gem "hanami-foo"
end
```

When we'll run `bundle exec hanami` the command `hanami foo setup` will be listed in the output.
