### PR TITLE
Add --table-name options to model generator (Issue #823)

### DIFF
--- a/lib/hanami/cli_sub_commands/generate.rb
+++ b/lib/hanami/cli_sub_commands/generate.rb
@@ -79,6 +79,8 @@ module Hanami
       EOS
       method_option :test, desc: 'Defines the testing Framework to be used. Default is defined through your .hanamirc file.'
       method_option :skip_migration, desc: 'Skips the generation of a migration to create the model\'s table', default: false, type: :boolean
+      method_option :table_name, desc: 'Defines the table name. If not set, pluralized model name will be used', type: :string
+
       # @api private
       def model(name)
         if options[:help]

--- a/lib/hanami/commands/generate/model.rb
+++ b/lib/hanami/commands/generate/model.rb
@@ -21,7 +21,11 @@ module Hanami
           super(options)
           @input      = Utils::String.new(model_name).underscore
           @model_name = Utils::String.new(@input).classify
-          @table_name = Utils::String.new(@input).pluralize
+          @table_name = if override_table_name?
+                          options[:table_name]
+                        else
+                          Utils::String.new(@input).pluralize
+                        end
 
           unless skip_migration?
             Components.resolve('model.configuration')
@@ -52,7 +56,8 @@ module Hanami
         def template_options
           {
             model_name: model_name,
-            table_name: table_name
+            table_name: table_name,
+            override_table_name: override_table_name?
           }
         end
 
@@ -88,6 +93,11 @@ module Hanami
         # @api private
         def skip_migration?
           options.fetch(:skip_migration, false)
+        end
+
+        # @api private
+        def override_table_name?
+          !options.fetch(:table_name, '').empty?
         end
 
         # @api private

--- a/lib/hanami/generators/model/repository.rb.tt
+++ b/lib/hanami/generators/model/repository.rb.tt
@@ -1,2 +1,5 @@
 class <%= config[:model_name] %>Repository < Hanami::Repository
+<%- if config[:override_table_name] -%>
+  self.relation = '<%= config[:table_name] %>'
+<%- end -%>
 end

--- a/spec/integration/cli/generate/model_spec.rb
+++ b/spec/integration/cli/generate/model_spec.rb
@@ -57,6 +57,38 @@ END
       end
     end
 
+    context 'with table-name option' do
+      let(:project)    { 'generate_model_with_table_name' }
+      let(:model_name) { 'stimulus' }
+      let(:class_name) { 'Stimulus' }
+      let(:table_name) { 'stimuli' }
+      let(:generate_cmd) { "hanami generate model #{model_name} --table-name=#{table_name}" }
+
+      it 'creates correct migration' do
+        with_project(project) do
+          run_command generate_cmd
+
+          migration = Pathname.new('db').join('migrations').children.find do |child|
+            child.to_s.include?("create_#{table_name}")
+          end
+
+          expect(migration).to_not be(nil)
+        end
+      end
+
+      it 'set correct `relation` in repository' do
+        with_project(project) do
+          run_command generate_cmd
+
+          expect("lib/#{project}/repositories/#{model_name}_repository.rb").to have_file_content <<-END
+class #{class_name}Repository < Hanami::Repository
+  self.relation = '#{table_name}'
+end
+END
+        end
+      end
+    end
+
     context "with skip-migration" do
       it "doesn't create a migration file" do
         model_name = "user"


### PR DESCRIPTION
Hello!
This commit provides  `--table-name` option to model generator as described in #823.