### PR TITLE
Generate and Destroy nested actions via CLI

### DIFF
--- a/lib/hanami/cli/commands/destroy/action.rb
+++ b/lib/hanami/cli/commands/destroy/action.rb
@@ -19,7 +19,7 @@ module Hanami
           # @api private
           def call(app:, action:, **options)
             app                = Utils::String.underscore(app)
-            controller, action = controller_and_action(action)
+            *controller, action = controller_and_action(action)
             action_name        = controller_and_action_name(controller, action)
 
             context = Context.new(app: app, controller: controller, action: action, action_name: action_name, options: options)
@@ -57,7 +57,13 @@ module Hanami
           # @api private
           def controller_and_action_name(controller, action)
             # FIXME: extract this separator
-            [controller, action].join("#")
+            [namespaced_controller(controller), action].join("#")
+          end
+
+          # @since 1.1.0
+          # #api private
+          def namespaced_controller(controller)
+            controller.join("/")
           end
 
           # @since 1.1.0

--- a/lib/hanami/cli/commands/generate/action/action.erb
+++ b/lib/hanami/cli/commands/generate/action/action.erb
@@ -1,4 +1,4 @@
-module <%= app.classify %>::Controllers::<%= controller.classify %>
+module <%= app.classify %>::Controllers::<%= classified_controller_name %>
   class <%= action.classify %>
     include <%= app.classify %>::Action
 

--- a/lib/hanami/cli/commands/generate/action/action_spec.minitest.erb
+++ b/lib/hanami/cli/commands/generate/action/action_spec.minitest.erb
@@ -1,7 +1,7 @@
 require_relative '../../../spec_helper'
 
-describe <%= app.classify %>::Controllers::<%= controller.classify %>::<%= action.classify %> do
-  let(:action) { <%= app.classify %>::Controllers::<%= controller.classify %>::<%= action.classify %>.new }
+describe <%= app.classify %>::Controllers::<%= classified_controller_name %>::<%= action.classify %> do
+  let(:action) { <%= app.classify %>::Controllers::<%= classified_controller_name %>::<%= action.classify %>.new }
   let(:params) { Hash[] }
 
   it 'is successful' do

--- a/lib/hanami/cli/commands/generate/action/action_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/action/action_spec.rspec.erb
@@ -1,4 +1,4 @@
-RSpec.describe <%= app.classify %>::Controllers::<%= controller.classify %>::<%= action.classify %> do
+RSpec.describe <%= app.classify %>::Controllers::<%= classified_controller_name %>::<%= action.classify %> do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 

--- a/lib/hanami/cli/commands/generate/action/action_without_view.erb
+++ b/lib/hanami/cli/commands/generate/action/action_without_view.erb
@@ -1,4 +1,4 @@
-module <%= app.classify %>::Controllers::<%= controller.classify %>
+module <%= app.classify %>::Controllers::<%= classified_controller_name %>
   class <%= action.classify %>
     include <%= app.classify %>::Action
 

--- a/lib/hanami/cli/commands/generate/action/view.erb
+++ b/lib/hanami/cli/commands/generate/action/view.erb
@@ -1,4 +1,4 @@
-module <%= app.classify %>::Views::<%= controller.classify %>
+module <%= app.classify %>::Views::<%= classified_controller_name %>
   class <%= action.classify %>
     include <%= app.classify %>::View
   end

--- a/lib/hanami/cli/commands/generate/action/view_spec.minitest.erb
+++ b/lib/hanami/cli/commands/generate/action/view_spec.minitest.erb
@@ -1,9 +1,9 @@
 require_relative '../../../spec_helper'
 
-describe <%= app.classify %>::Views::<%= controller.classify %>::<%= action.classify %> do
+describe <%= app.classify %>::Views::<%= classified_controller_name %>::<%= action.classify %> do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Hanami::View::Template.new('<%= template %>') }
-  let(:view)      { <%= app.classify %>::Views::<%= controller.classify %>::<%= action.classify %>.new(template, exposures) }
+  let(:view)      { <%= app.classify %>::Views::<%= classified_controller_name %>::<%= action.classify %>.new(template, exposures) }
   let(:rendered)  { view.render }
 
   it 'exposes #foo' do

--- a/lib/hanami/cli/commands/generate/action/view_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/action/view_spec.rspec.erb
@@ -1,4 +1,4 @@
-RSpec.describe <%= app.classify %>::Views::<%= controller.classify %>::<%= action.classify %> do
+RSpec.describe <%= app.classify %>::Views::<%= classified_controller_name %>::<%= action.classify %> do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Hanami::View::Template.new('<%= template %>') }
   let(:view)      { described_class.new(template, exposures) }

--- a/spec/integration/cli/destroy/action_spec.rb
+++ b/spec/integration/cli/destroy/action_spec.rb
@@ -24,6 +24,30 @@ RSpec.describe "hanami destroy", type: :cli do
       end
     end
 
+    it "destroys namespaced action" do
+      with_project do
+        generate "action web api/books#index"
+        output = [
+          "subtract  apps/web/config/routes.rb",
+          "remove  spec/web/views/api/books/index_spec.rb",
+          "remove  apps/web/templates/api/books/index.html.erb",
+          "remove  apps/web/views/api/books/index.rb",
+          "remove  apps/web/controllers/api/books/index.rb",
+          "remove  spec/web/controllers/api/books/index_spec.rb"
+        ]
+
+        run_command "hanami destroy action web api/books#index", output
+
+        expect('spec/web/controllers/api/books/index_spec.rb').to_not be_an_existing_file
+        expect('apps/web/controllers/api/books/index.rb').to_not      be_an_existing_file
+        expect('apps/web/views/api/books/index.rb').to_not            be_an_existing_file
+        expect('apps/web/templates/api/books/index.html.erb').to_not  be_an_existing_file
+        expect('spec/web/views/api/books/index_spec.rb').to_not       be_an_existing_file
+
+        expect('apps/web/config/routes.rb').to_not have_file_content(%r{get '/api/books', to: 'api/books#index'})
+      end
+    end
+
     it "destroys action without view" do
       with_project do
         generate "action web home#ping --skip-view --url=/ping"

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -45,6 +45,51 @@ END
       end
     end
 
+    it "generates namespaced action" do
+      with_project('bookshelf_generate_action') do
+        output = [
+          "create  spec/web/controllers/api/authors/index_spec.rb",
+          "create  apps/web/controllers/api/authors/index.rb",
+          "create  apps/web/views/api/authors/index.rb",
+          "create  apps/web/templates/api/authors/index.html.erb",
+          "create  spec/web/views/api/authors/index_spec.rb",
+          "insert  apps/web/config/routes.rb"
+        ]
+
+        run_command "hanami generate action web api/authors#index", output
+
+        #
+        # apps/web/controllers/api/authors/index.rb
+        #
+        expect('apps/web/controllers/api/authors/index.rb').to have_file_content <<-END
+module Web::Controllers::Api::Authors
+  class Index
+    include Web::Action
+
+    def call(params)
+    end
+  end
+end
+END
+
+        #
+        # apps/web/views/api/authors/index.rb
+        #
+        expect('apps/web/views/api/authors/index.rb').to have_file_content <<-END
+module Web::Views::Api::Authors
+  class Index
+    include Web::View
+  end
+end
+END
+
+        #
+        # apps/web/config/routes.rb
+        #
+        expect('apps/web/config/routes.rb').to have_file_content(%r{get '/api/authors', to: 'api/authors#index'})
+      end
+    end
+
     it "fails with missing arguments" do
       with_project('bookshelf_generate_action_without_args') do
         output = <<-OUT


### PR DESCRIPTION
cc @mereghost, @jodosha 

This PR fixes a bug described on #833.

### Changes to`Hanami::CLI::Commands::Generate::Action`

- assign `controller_and_action_name(action)` to `*controller` so it gets all the controller namespaces.
- pass `classfied_controller_name` to `Context` to be used in templates
- join `*controller` array with `"/"` to be used in the routes file

### Changes to action and view templates

- Use `classified_controller_name` instead of `controller.classify`

### Chagnes to `Hanami::CLI::Commands::Destroy::Action`

- Introduce `namespaced_controller` method
- Ensure `controller_and_action_name` handles namespaced controller using the new `namespaced_controller` method