### PR TITLE
Add --table-name options to model generator (Issue #823)

### DIFF
--- a/lib/hanami/cli/commands/generate/model.rb
+++ b/lib/hanami/cli/commands/generate/model.rb
@@ -11,12 +11,12 @@ module Hanami
 
           argument :model, required: true, desc: "Model name (eg. `user`)"
           option :skip_migration, type: :boolean, default: false, desc: "Skip migration"
-          option :table_name, type: :string, desc: "Name of table to create, default: pluralized model name"
+          option :relation_name, type: :string, desc: "Name of relation, default: pluralized model name"
 
           example [
-            "user                       # Generate `User` entity, `UserRepository` repository, and the migration",
-            "user --skip-migration      # Generate `User` entity and `UserRepository` repository",
-            "user --table-name=accounts # Generate `User` entity, `UserRepository` and migration to create `accounts` table"
+            "user                          # Generate `User` entity, `UserRepository` repository, and the migration",
+            "user --skip-migration         # Generate `User` entity and `UserRepository` repository",
+            "user --relation-name=accounts # Generate `User` entity, `UserRepository` and migration to create `accounts` table"
           ]
 
           # @since 1.1.0
@@ -98,7 +98,7 @@ module Hanami
           # @api private
           def relation_name(options, model)
             if override_relation_name?(options)
-              options[:table_name]
+              options[:relation_name]
             else
               Utils::String.pluralize(model)
             end
@@ -107,7 +107,7 @@ module Hanami
           # @since 1.1.0
           # @api private
           def override_relation_name?(options)
-            !options.fetch(:table_name, '').empty?
+            !options.fetch(:relation_name, '').empty?
           end
         end
       end

--- a/lib/hanami/cli/commands/generate/model/repository.erb
+++ b/lib/hanami/cli/commands/generate/model/repository.erb
@@ -1,2 +1,5 @@
 class <%= model.classify %>Repository < Hanami::Repository
+<%- if override_relation_name -%>
+  self.relation = '<%= relation %>'
+<%- end -%>
 end


### PR DESCRIPTION
Hello!
This commit provides `--table-name` option to model generator as described in #823.

This is rework of #834 against `develop` branch.