### PR TITLE
Use compact module definition in application_layout.rb generated by cli

### DIFF
--- a/lib/hanami/generators/app/views/application_layout.rb.tt
+++ b/lib/hanami/generators/app/views/application_layout.rb.tt
@@ -1,7 +1,5 @@
-module <%= config[:classified_app_name] %>
-  module Views
-    class ApplicationLayout
-      include <%= config[:classified_app_name] %>::Layout
-    end
+module <%= config[:classified_app_name] %>::Views
+  class ApplicationLayout
+    include <%= config[:classified_app_name] %>::Layout
   end
 end

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -377,11 +377,9 @@ END
       # apps/<app>/views/application_layout.rb
       #
       expect("apps/#{app}/views/application_layout.rb").to have_file_content <<-END
-module #{app_name}
-  module Views
-    class ApplicationLayout
-      include #{app_name}::Layout
-    end
+module #{app_name}::Views
+  class ApplicationLayout
+    include #{app_name}::Layout
   end
 end
 END


### PR DESCRIPTION
Any other templates are using compact module definition like `Application::Views`.
So, I unified it.

FYI, Rubocop has a rule for module definition. And I was noticed by that.
https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/class_and_module_children.rb
