### PR TITLE
Don't require `:plugins` `Gemfile` group when running `hanami new`

### DIFF
--- a/bin/hanami
+++ b/bin/hanami
@@ -2,5 +2,5 @@
 require 'bundler'
 require 'hanami/cli/commands'
 
-Bundler.require(:plugins)
+Bundler.require(:plugins) if File.exist?(ENV["BUNDLE_GEMFILE"] || "Gemfile")
 Hanami::CLI.new(Hanami::CLI::Commands).call

--- a/spec/integration/cli/plugins_spec.rb
+++ b/spec/integration/cli/plugins_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe "CLI plugins", type: :cli do
     end
   end
 
+  # See https://github.com/hanami/hanami/issues/838
+  it "guarantees 'hanami new' to generate a project" do
+    project = 'bookshelf_without_gemfile'
+
+    with_system_tmp_directory do
+      run_command_with_clean_env "hanami new #{project}"
+      destination = Pathname.new(Dir.pwd).join(project)
+
+      expect(destination).to exist
+    end
+  end
+
   private
 
   def with_project

--- a/spec/support/cli.rb
+++ b/spec/support/cli.rb
@@ -23,6 +23,11 @@ module RSpec
         expect(last_command_started).to have_exit_status(exit_status)
       end
 
+      def run_command_with_clean_env(cmd, successful: true)
+        result = ::Bundler.clean_system(cmd, out: File::NULL)
+        expect(result).to be(successful)
+      end
+
       def match_output(output)
         case output
         when String

--- a/spec/support/with_system_tmp_directory.rb
+++ b/spec/support/with_system_tmp_directory.rb
@@ -1,0 +1,17 @@
+require_relative 'with_tmp_directory'
+
+module RSpec
+  module Support
+    module WithSystemTmpDirectory
+      private
+
+      def with_system_tmp_directory(&blk)
+        with_tmp_directory(Dir.mktmpdir, &blk)
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include RSpec::Support::WithSystemTmpDirectory, type: :cli
+end

--- a/spec/support/with_tmp_directory.rb
+++ b/spec/support/with_tmp_directory.rb
@@ -1,4 +1,4 @@
-require 'fileutils'
+require 'hanami/utils/files'
 require_relative 'with_directory'
 
 module RSpec
@@ -6,14 +6,12 @@ module RSpec
     module WithTmpDirectory
       private
 
-      def with_tmp_directory
-        dir = Pathname.new('tmp').join('aruba')
-
+      def with_tmp_directory(dir = Pathname.new('tmp').join('aruba'))
         with_directory(dir) do
           yield
         end
       ensure
-        FileUtils.rm_rf(dir)
+        Hanami::Utils::Files.delete_directory(dir)
       end
     end
   end


### PR DESCRIPTION
Fixes: https://github.com/hanami/hanami/issues/838