### PR TITLE
Add type tags to rspec templates

### DIFF
--- a/lib/hanami/cli/commands/generate/action/action_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/action/action_spec.rspec.erb
@@ -1,4 +1,4 @@
-RSpec.describe <%= app.classify %>::Controllers::<%= classified_controller_name %>::<%= action.classify %> do
+RSpec.describe <%= app.classify %>::Controllers::<%= classified_controller_name %>::<%= action.classify %>, type: :action do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 

--- a/lib/hanami/cli/commands/generate/action/view_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/action/view_spec.rspec.erb
@@ -1,4 +1,4 @@
-RSpec.describe <%= app.classify %>::Views::<%= classified_controller_name %>::<%= action.classify %> do
+RSpec.describe <%= app.classify %>::Views::<%= classified_controller_name %>::<%= action.classify %>, type: :view do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Hanami::View::Template.new('<%= template %>') }
   let(:view)      { described_class.new(template, exposures) }

--- a/lib/hanami/cli/commands/generate/app/layout_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/app/layout_spec.rspec.erb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe <%= app.classify %>::Views::ApplicationLayout do
+RSpec.describe <%= app.classify %>::Views::ApplicationLayout, type: :view do
   let(:layout)   { <%= app.classify %>::Views::ApplicationLayout.new(template, {}) }
   let(:rendered) { layout.render }
   let(:template) { Hanami::View::Template.new('apps/<%= app %>/templates/application.html.<%= template %>') }

--- a/lib/hanami/cli/commands/generate/mailer/mailer_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/mailer/mailer_spec.rspec.erb
@@ -1,4 +1,4 @@
-RSpec.describe Mailers::<%= mailer.classify %> do
+RSpec.describe Mailers::<%= mailer.classify %>, type: :mailer do
   it 'delivers email' do
     mail = Mailers::<%= mailer.classify %>.deliver
   end

--- a/lib/hanami/cli/commands/generate/model/entity_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/model/entity_spec.rspec.erb
@@ -1,3 +1,3 @@
-RSpec.describe <%= model.classify %> do
+RSpec.describe <%= model.classify %>, type: :entity do
   # place your tests here
 end

--- a/lib/hanami/cli/commands/generate/model/repository_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/model/repository_spec.rspec.erb
@@ -1,3 +1,3 @@
-RSpec.describe <%= model.classify %>Repository do
+RSpec.describe <%= model.classify %>Repository, type: :repository do
   # place your tests here
 end

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -335,7 +335,7 @@ END
           # spec/web/controllers/books/index_spec.rb
           #
           expect('spec/web/controllers/books/index_spec.rb').to have_file_content <<-END
-RSpec.describe Web::Controllers::Books::Index do
+RSpec.describe Web::Controllers::Books::Index, type: :action do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 
@@ -350,7 +350,7 @@ END
           # spec/web/views/books/index_spec.rb
           #
           expect('spec/web/views/books/index_spec.rb').to have_file_content <<-END
-RSpec.describe Web::Views::Books::Index do
+RSpec.describe Web::Views::Books::Index, type: :view do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/index.html.erb') }
   let(:view)      { described_class.new(template, exposures) }

--- a/spec/integration/cli/generate/mailer_spec.rb
+++ b/spec/integration/cli/generate/mailer_spec.rb
@@ -54,7 +54,7 @@ END
           # spec/bookshelf_generate_mailer/mailers/welcome_spec.rb
           #
           expect('spec/bookshelf_generate_mailer/mailers/welcome_spec.rb').to have_file_content <<-END
-RSpec.describe Mailers::Welcome do
+RSpec.describe Mailers::Welcome, type: :mailer do
   it 'delivers email' do
     mail = Mailers::Welcome.deliver
   end

--- a/spec/integration/cli/generate/model_spec.rb
+++ b/spec/integration/cli/generate/model_spec.rb
@@ -237,7 +237,7 @@ END
           # spec/<project>/entities/<model>_spec.rb
           #
           expect("spec/#{project}/entities/#{model}_spec.rb").to have_file_content <<-END
-RSpec.describe #{class_name} do
+RSpec.describe #{class_name}, type: :entity do
   # place your tests here
 end
 END
@@ -246,7 +246,7 @@ END
           # spec/<project>/repositories/<model>_repository_spec.rb
           #
           expect("spec/#{project}/repositories/#{model}_repository_spec.rb").to have_file_content <<-END
-RSpec.describe BookRepository do
+RSpec.describe BookRepository, type: :repository do
   # place your tests here
 end
 END

--- a/spec/integration/cli/new/test_spec.rb
+++ b/spec/integration/cli/new/test_spec.rb
@@ -241,7 +241,7 @@ END
           expect("spec/web/views/application_layout_spec.rb").to have_file_content <<-END
 require "spec_helper"
 
-RSpec.describe Web::Views::ApplicationLayout do
+RSpec.describe Web::Views::ApplicationLayout, type: :view do
   let(:layout)   { Web::Views::ApplicationLayout.new(template, {}) }
   let(:rendered) { layout.render }
   let(:template) { Hanami::View::Template.new('apps/web/templates/application.html.erb') }


### PR DESCRIPTION
Like [rspec-rails](https://github.com/rspec/rspec-rails), I added `type` tags to rspec templates which is generated by `hanami generate` command.
 
I think users can include shared_contexts, shared_examples or helpers, by using this tag.