### PR TITLE
Remove architecture references in CLI, since it's not supported

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -93,16 +93,13 @@ module Hanami
     desc 'new PROJECT_NAME', 'Generate a new hanami project'
     long_desc <<-EOS
 `hanami new` creates a new hanami project.
-You can specify various options such as the database to be used as well as the path and architecture.
+You can specify various options such as the database to be used as well as the path.
 
 $ > hanami new fancy_app --application_name=admin
-
-$ > hanami new fancy_app --arch=app
 
 $ > hanami new fancy_app --hanami-head=true
     EOS
     method_option :database, aliases: ['-d', '--db'], desc: "Application database (#{Hanami::Generators::DatabaseConfig::SUPPORTED_ENGINES.keys.join('/')})", default: Hanami::Generators::DatabaseConfig::DEFAULT_ENGINE
-    method_option :architecture, aliases: ['-a', '--arch'], desc: 'Project architecture (container/app)', default: Hanami::Commands::New::Abstract::DEFAULT_ARCHITECTURE
     method_option :application_name, desc: 'Application name, only for container', default: Hanami::Commands::New::Container::DEFAULT_APPLICATION_NAME
     method_option :application_base_url, desc: 'Application base url', default: Hanami::Commands::New::Abstract::DEFAULT_APPLICATION_BASE_URL
     method_option :template, desc: "Template engine (#{Hanami::Generators::TemplateEngine::SUPPORTED_ENGINES.join('/')})", default: Hanami::Generators::TemplateEngine::DEFAULT_ENGINE
@@ -116,8 +113,6 @@ $ > hanami new fancy_app --hanami-head=true
       elsif application_name.nil?
         warn %(`hanami new` was called with no arguments\nUsage: `hanami new PROJECT_NAME`)
         exit(1)
-      elsif options[:architecture] == 'app'
-        Hanami::Commands::New::App.new(options, application_name).start
       else
         Hanami::Commands::New::Container.new(options, application_name).start
       end

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -771,8 +771,6 @@ Usage:
 Options:
   -d, --db, [--database=DATABASE]                        # Application database (mysql/mysql2/postgresql/postgres/sqlite/sqlite3/filesystem/memory)
                                                          # Default: filesystem
-  -a, --arch, [--architecture=ARCHITECTURE]              # Project architecture (container/app)
-                                                         # Default: container
           [--application-name=APPLICATION_NAME]          # Application name, only for container
                                                          # Default: web
           [--application-base-url=APPLICATION_BASE_URL]  # Application base url
@@ -788,7 +786,7 @@ OUT
 # rubocop:disable Style/CommentIndentation
 # FIXME: this extra verbatim causes a spec failure
 # Description:
-#   `hanami new` creates a new hanami project. You can specify various options such as the database to be used as well as the path and architecture.
+#   `hanami new` creates a new hanami project. You can specify various options such as the database to be used as well as the path.
 #
 #   $ > hanami new fancy_app --application_name=admin
 #


### PR DESCRIPTION
Having this in the CLI is causing some confusion: #845, so we should consider removing it.

This is intentionally against `master`, since this should be in the next patch release (`1.0.1`). 

The idea of different architectures was mostly removed before 1.0, but the CLI option was retained accidentally. 

Trying to do `hanami _1.0.0_ new bookshelf --architecture=app` errors out, since there's missing code. It shouldn't have been included in `1.0.0` release. This doesn't fully remove all references to architecture (still exists in `.hanamirc` for example), but since this will be an old version, I think it should be fine. (Happy to go through and remove more, if others think it's a good idea).

#815 removed this for 1.1 (on `develop` branch), so that'll be taken care of.