### PR TITLE
Ensure `hanami db rollback` `steps` to be a positive integer

### DIFF
--- a/lib/hanami/cli/commands/db/rollback.rb
+++ b/lib/hanami/cli/commands/db/rollback.rb
@@ -1,3 +1,5 @@
+require "hanami/utils/kernel"
+
 module Hanami
   class CLI
     module Commands
@@ -19,7 +21,8 @@ module Hanami
           # @since 1.1.0
           # @api private
           def call(steps:, **)
-            context = Context.new(steps: steps.to_int)
+            context = Context.new(steps: steps)
+            context = assert_valid_steps!(context)
 
             rollback_database(context)
           end
@@ -28,9 +31,26 @@ module Hanami
 
           # @since 1.1.0
           # @api private
+          def assert_valid_steps!(context)
+            context = context.with(steps: Utils::Kernel.Integer(context.steps.to_s))
+            handle_error(context) unless context.steps.positive?
+            context
+          rescue TypeError
+            handle_error(context)
+          end
+
+          # @since 1.1.0
+          # @api private
           def rollback_database(context)
             require "hanami/model/migrator"
             Hanami::Model::Migrator.rollback(steps: context.steps)
+          end
+
+          # @since 1.1.0
+          # @api private
+          def handle_error(context)
+            warn "the number of steps must be a positive integer (you entered `#{context.steps}')."
+            exit(1)
           end
         end
       end

--- a/spec/integration/cli/db/rollback_spec.rb
+++ b/spec/integration/cli/db/rollback_spec.rb
@@ -40,6 +40,30 @@ RSpec.describe "hanami db", type: :cli do
       end
     end
 
+    it "returns an error when steps isn't an integer" do
+      with_project do
+        generate_migrations
+
+        hanami "db create"
+        hanami "db migrate"
+
+        output = "the number of steps must be a positive integer (you entered `quindici')."
+        run_command "hanami db rollback quindici", output, exit_status: 1
+      end
+    end
+
+    it "returns an error when steps is 0" do
+      with_project do
+        generate_migrations
+
+        hanami "db create"
+        hanami "db migrate"
+
+        output = "the number of steps must be a positive integer (you entered `0')."
+        run_command "hanami db rollback 0", output, exit_status: 1
+      end
+    end
+
     it 'prints help message' do
       with_project do
         output = <<-OUT


### PR DESCRIPTION
With `1.1.0.rc1`, `hanami db rollback` failed to accept integers:

```shell
➜ bundle exec hanami db rollback 2
undefined method `to_int' for "2":String
Did you mean?  to_i
               taint
```

---

This PR fixes the problem above and it also ensures `steps` to be a positive integer:

```shell
➜ bundle hanami db rollback quindici
the number of steps must be a positive integer (you entered `quindici').
```

```shell
➜ bundle exec hanami db rollback 0
the number of steps must be a positive integer (you entered `0').
```