### PR TITLE
Use `:format` as default exposure for view unit tests.

### DIFF
--- a/lib/hanami/cli/commands/generate/action/view_spec.minitest.erb
+++ b/lib/hanami/cli/commands/generate/action/view_spec.minitest.erb
@@ -1,15 +1,12 @@
 require_relative '../../../spec_helper'
 
 describe <%= app.classify %>::Views::<%= classified_controller_name %>::<%= action.classify %> do
-  let(:exposures) { Hash[foo: 'bar'] }
+  let(:exposures) { Hash[format: :html] }
   let(:template)  { Hanami::View::Template.new('<%= template %>') }
   let(:view)      { <%= app.classify %>::Views::<%= classified_controller_name %>::<%= action.classify %>.new(template, exposures) }
   let(:rendered)  { view.render }
 
-  it 'exposes #foo' do
-    skip 'This is an auto-generated test. Edit it and add your own tests.'
-
-    # Example
-    view.foo.must_equal exposures.fetch(:foo)
+  it 'exposes #format' do
+    view.format.must_equal exposures.fetch(:format)
   end
 end

--- a/lib/hanami/cli/commands/generate/action/view_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/action/view_spec.rspec.erb
@@ -1,13 +1,10 @@
 RSpec.describe <%= app.classify %>::Views::<%= classified_controller_name %>::<%= action.classify %>, type: :view do
-  let(:exposures) { Hash[foo: 'bar'] }
+  let(:exposures) { Hash[format: :html] }
   let(:template)  { Hanami::View::Template.new('<%= template %>') }
   let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
-  it 'exposes #foo' do
-    pending 'This is an auto-generated test. Edit it and add your own tests.'
-
-    # Example
-    expect(view.foo).to eq exposures.fetch(:foo)
+  it 'exposes #format' do
+    expect(view.format).to eq exposures.fetch(:format)
   end
 end

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -304,16 +304,13 @@ END
 require_relative '../../../spec_helper'
 
 describe Web::Views::Books::Index do
-  let(:exposures) { Hash[foo: 'bar'] }
+  let(:exposures) { Hash[format: :html] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/index.html.erb') }
   let(:view)      { Web::Views::Books::Index.new(template, exposures) }
   let(:rendered)  { view.render }
 
-  it 'exposes #foo' do
-    skip 'This is an auto-generated test. Edit it and add your own tests.'
-
-    # Example
-    view.foo.must_equal exposures.fetch(:foo)
+  it 'exposes #format' do
+    view.format.must_equal exposures.fetch(:format)
   end
 end
 END
@@ -351,16 +348,13 @@ END
           #
           expect('spec/web/views/books/index_spec.rb').to have_file_content <<-END
 RSpec.describe Web::Views::Books::Index, type: :view do
-  let(:exposures) { Hash[foo: 'bar'] }
+  let(:exposures) { Hash[format: :html] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/index.html.erb') }
   let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
-  it 'exposes #foo' do
-    pending 'This is an auto-generated test. Edit it and add your own tests.'
-
-    # Example
-    expect(view.foo).to eq exposures.fetch(:foo)
+  it 'exposes #format' do
+    expect(view.format).to eq exposures.fetch(:format)
   end
 end
 END


### PR DESCRIPTION
This is a proposal for both a fix and a small enhancement for view unit tests.

## The Fix

If you're running unit tests of a view that renders a template, without `format: :html` in the `exposures`, it raises an error. See https://github.com/hanami/view/issues/137

So instead of generating unit tests with bogus exposures (`foo: "bar"`), we can generate with useful exposures (`format: :html`).

## The enhancement

Given we were setting bogus exposures, we took the decision of marking that unit tests as [pending](https://github.com/hanami/hanami/pull/664). Now that we have real exposures, it's worth to test for real that the view is using `:html` as a format.

So the proposal is to generate unit tests that are no longer pending.

---

This is related to the proposals that @cllns made with #831

---

Fixes https://github.com/hanami/view/issues/137
Closes https://github.com/hanami/hanami/issues/831
Ref https://github.com/hanami/hanami/pull/664