### PR TITLE
Avoid using Hanami::Utils.reload! when code_reloading is disabled

### DIFF
--- a/lib/hanami/components/components.rb
+++ b/lib/hanami/components/components.rb
@@ -61,7 +61,7 @@ module Hanami
       run do
         directory = Hanami.root.join('lib')
 
-        if Components['environment'].code_reloading?
+        if Hanami.code_reloading?
           Utils.reload!(directory)
         else
           Utils.require!(directory)


### PR DESCRIPTION
Code reloading causes 'already initialized constants' warnings for me, due to the use of `load`, so I want to disable it. It appears the way to do this is to remove the shotgun gem, but the check that decides whether to use `Hanami::Utils.reload!` or `Hanami::Utils.require!` seems to be wrong. I think it should use either `Hanami::Components['code_reloading']` or `Hanami.code_reloading?`, and the latter is used elsewhere in this file for all other checks while this is the only exception (so I'm assuming it was an oversight). With this change, when shotgun is not available, it will use `Hanami::Utils.require!`.

Please correct me if I've misunderstood the way this is supposed to work!