### PR TITLE
Overwrite when generating files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 gem 'i18n'
 
-gem 'hanami-utils',       '~> 1.1', require: false, git: 'https://github.com/hanami/utils.git',       branch: '1.1.x'
+gem 'hanami-utils',       '~> 1.1', require: false, git: 'https://github.com/hanami/utils.git',       branch: 'add-files-overwrite-flag'
 gem 'hanami-validations', '~> 1.1', require: false, git: 'https://github.com/hanami/validations.git', branch: '1.1.x'
 gem 'hanami-router',      '~> 1.1', require: false, git: 'https://github.com/hanami/router.git',      branch: '1.1.x'
 gem 'hanami-controller',  '~> 1.1', require: false, git: 'https://github.com/hanami/controller.git',  branch: '1.1.x'

--- a/lib/hanami/cli/commands/command.rb
+++ b/lib/hanami/cli/commands/command.rb
@@ -153,7 +153,8 @@ module Hanami
         def generate_file(source, destination, context)
           files.write(
             destination,
-            render(source, context)
+            render(source, context),
+            overwrite: true
           )
         end
 

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -45,6 +45,38 @@ END
       end
     end
 
+    it "generates action over existing file" do
+      with_project('bookshelf_generate_action_over_existing') do
+        write 'apps/web/controllers/authors/index.rb', <<-END
+module Web::Controllers::Authors
+  class Index
+    include Web::Action
+
+    def call(params)
+      # Adding a comment here...
+      # So we can check to make sure this file is replaced properly
+    end
+  end
+end
+END
+        run_command "hanami generate action web authors#index"
+
+        #
+        # apps/web/controllers/authors/index.rb
+        #
+        expect('apps/web/controllers/authors/index.rb').to have_file_content <<-END
+module Web::Controllers::Authors
+  class Index
+    include Web::Action
+
+    def call(params)
+    end
+  end
+end
+END
+      end
+    end
+
     it "generates namespaced action" do
       with_project('bookshelf_generate_action') do
         output = [


### PR DESCRIPTION
Adding this PR to show how https://github.com/hanami/utils/pull/239 would be implemented in this repo. (I created another branch, `add-files-overwrite-flag` used here, with the same content, because the old one had an inaccurate name `fix-write-to-append`).

This PR fails when using the `master` branch, and it also failed when `overwrite: true` is not added. The value is `false` default. An exception is raised in that case, which causes `run_command` to have a non-zero exit status, which causes the `run_command` expectation to fail.

We _could_ add more tests for this same behavior, but this behavior (nuances of generating files) should moved to `Hanami::CLI`. It's not specific to `action` at all, but rather than base `Command`. Want to get this fixed first though, before extracting the generating code into that gem.