### PR TITLE
Render 500 custom template if an exception happens in a view or template

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ AllCops:
     - "vendor/**/*"
     - "spec/support/**/*"
     - "**/*.gemspec"
+Style/IndentHeredoc:
+  Enabled: true
 Style/MixinGrouping:
   Exclude:
     - "spec/support/**/*"

--- a/lib/hanami/application_configuration.rb
+++ b/lib/hanami/application_configuration.rb
@@ -40,10 +40,11 @@ module Hanami
     # @since 0.1.0
     # @api private
     def initialize(namespace, configurations, path_prefix, env: Environment.new)
-      @namespace      = namespace
-      @configurations = configurations
-      @path_prefix    = path_prefix
-      @env            = env
+      @namespace         = namespace
+      @configurations    = configurations
+      @path_prefix       = path_prefix
+      @env               = env
+      @handle_exceptions = true
 
       evaluate_configurations!
     end

--- a/spec/integration/handle_exceptions_spec.rb
+++ b/spec/integration/handle_exceptions_spec.rb
@@ -25,17 +25,199 @@ RSpec.describe "handle exceptions", type: :cli do
     end
   end
 
-  it "handles exceptions in production mode" do
-    with_project do
-      generate_action
+  context "when handles exceptions in production mode" do
+    it "it returns the expected status" do
+      with_project do
+        generate_action
 
-      RSpec::Support::Env['HANAMI_ENV']   = 'production'
-      RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"
+        RSpec::Support::Env['HANAMI_ENV']   = 'production'
+        RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"
 
-      server do
-        get '/books/1'
+        server do
+          get '/books/1'
 
-        expect(last_response.status).to eq(400)
+          expect(last_response.status).to eq(400)
+        end
+      end
+    end
+
+    context "and an exception is raised from a template" do
+      it "it returns a 500 and it renders a custom template if it exists" do
+        with_project do
+          generate "action web books#show --url=/books/:id"
+
+          rewrite "apps/web/templates/books/show.html.erb", <<~EOF
+            <%= raise ArgumentError.new("oh nooooo") %>
+          EOF
+
+          write "apps/web/templates/500.html.erb", <<~EOF
+            This is a custom template for 500 error
+          EOF
+
+          RSpec::Support::Env['HANAMI_ENV']   = 'production'
+          RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"
+
+          server do
+            get '/books/1'
+
+            expect(last_response.status).to eq(500)
+            expect(last_response.body).to eq("This is a custom template for 500 error\n")
+          end
+        end
+      end
+
+      it "it returns a 500 and it renders the default template if custom template doesn't exist" do
+        with_project do
+          generate "action web books#show --url=/books/:id"
+
+          rewrite "apps/web/templates/books/show.html.erb", <<~EOF
+            <%= raise ArgumentError.new("oh nooooo") %>
+          EOF
+
+          RSpec::Support::Env['HANAMI_ENV']   = 'production'
+          RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"
+
+          server do
+            get '/books/1'
+
+            expect(last_response.status).to eq(500)
+            expect(last_response.body).to include("<h2>500 - Internal Server Error</h2>")
+          end
+        end
+      end
+
+      it "it returns a 500 and renders backtrace error if an exception is raised from 500 custom template" do
+        with_project do
+          generate "action web books#show --url=/books/:id"
+
+          rewrite "apps/web/templates/books/show.html.erb", <<~EOF
+            <%= raise ArgumentError.new("oh nooooo") %>
+          EOF
+
+          write "apps/web/templates/500.html.erb", <<~EOF
+            <%= raise ArgumentError.new("Error from custom template") %>
+            This is a custom template for 500 error
+          EOF
+
+          RSpec::Support::Env['HANAMI_ENV']   = 'production'
+          RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"
+
+          server do
+            get '/books/1'
+
+            expect(last_response.status).to eq(500)
+            expect(last_response.body).to_not include("This is a custom template for 500 error")
+            expect(last_response.body).to include("<h1>Boot Error</h1><p>Something went wrong while loading")
+          end
+        end
+      end
+    end
+
+    context "and an exception is raised from a view" do
+      it "it returns a 500 and it renders a custom template if it exists" do
+        with_project do
+          generate "action web books#show --url=/books/:id"
+
+          rewrite "apps/web/views/books/show.rb", <<~EOF
+            module Web::Views::Books
+              class Show
+                include Web::View
+
+                def header
+                  raise ArgumentError.new("oh nooooo")
+                end
+              end
+            end
+          EOF
+
+          rewrite "apps/web/templates/books/show.html.erb", <<~EOF
+            <%= header %>
+          EOF
+
+          write "apps/web/templates/500.html.erb", <<~EOF
+            This is a custom template for 500 error
+          EOF
+
+          RSpec::Support::Env['HANAMI_ENV']   = 'production'
+          RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"
+
+          server do
+            get '/books/1'
+
+            expect(last_response.status).to eq(500)
+            expect(last_response.body).to eq("This is a custom template for 500 error\n")
+          end
+        end
+      end
+
+      it "it returns a 500 and it renders the default template if custom template doesn't exist" do
+        with_project do
+          generate "action web books#show --url=/books/:id"
+
+          rewrite "apps/web/views/books/show.rb", <<~EOF
+            module Web::Views::Books
+              class Show
+                include Web::View
+
+                def header
+                  raise ArgumentError.new("oh nooooo")
+                end
+              end
+            end
+          EOF
+
+          rewrite "apps/web/templates/books/show.html.erb", <<~EOF
+            <%= header %>
+          EOF
+
+          RSpec::Support::Env['HANAMI_ENV']   = 'production'
+          RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"
+
+          server do
+            get '/books/1'
+
+            expect(last_response.status).to eq(500)
+            expect(last_response.body).to include("<h2>500 - Internal Server Error</h2>")
+          end
+        end
+      end
+
+      it "it returns a 500 and renders backtrace error if an exception is raised from 500 custom template" do
+        with_project do
+          generate "action web books#show --url=/books/:id"
+
+          rewrite "apps/web/views/books/show.rb", <<~EOF
+            module Web::Views::Books
+              class Show
+                include Web::View
+
+                def header
+                  raise ArgumentError.new("oh nooooo")
+                end
+              end
+            end
+          EOF
+
+          rewrite "apps/web/templates/books/show.html.erb", <<~EOF
+            <%= header %>
+          EOF
+
+          write "apps/web/templates/500.html.erb", <<~EOF
+            <%= raise ArgumentError.new("Error from custom template") %>
+            This is a custom template for 500 error
+          EOF
+
+          RSpec::Support::Env['HANAMI_ENV']   = 'production'
+          RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"
+
+          server do
+            get '/books/1'
+
+            expect(last_response.status).to eq(500)
+            expect(last_response.body).to_not include("This is a custom template for 500 error")
+            expect(last_response.body).to include("<h1>Boot Error</h1><p>Something went wrong while loading")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes #865 

It will render the 500 custom template if an exception happens in a view or template, in addition it sets `handle_exceptions` to true by default, in controller level it was true for not in hanami application level, https://github.com/hanami/hanami/blob/master/lib/hanami/application_configuration.rb#L1272 