### PR TITLE
fix mistake of README#how-to-use-hanami-head

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you want to test Hanami's HEAD to try a new feature or to test a bug fix, her
 ```
 git clone https://github.com/hanami/hanami.git
 cd hanami && bundle
-bundle exec hanami new --hanami-head=true bookshelf
+bundle exec hanami new --hanami-head bookshelf
 cd bookshelf
 vim Gemfile # edit with: gem 'hanami', path: '..'
 bundle


### PR DESCRIPTION
It causes error.

```bash
 $ bundle exec hanami new --hanami-head=true bookshelf
Error: Invalid param provided
```

The boolean option should be used without value.

refs: https://github.com/hanami/cli/#boolean-options