### PR TITLE
raise error if config/environment.erb miss necessary environment valuable

### DIFF
--- a/lib/hanami/cli/commands/new/config/environment.erb
+++ b/lib/hanami/cli/commands/new/config/environment.erb
@@ -16,7 +16,7 @@ Hanami.configure do
     #    adapter :sql, 'postgresql://localhost/<%= project %>_development'
     #    adapter :sql, 'mysql://localhost/<%= project %>_development'
     #
-    adapter :<%= database_config_hash[:type] %>, ENV['DATABASE_URL']
+    adapter :<%= database_config_hash[:type] %>, ENV.fetch('DATABASE_URL')
 
     <%- if database_config.sql? -%>
     ##
@@ -43,7 +43,7 @@ Hanami.configure do
     logger level: :info, formatter: :json, filter: []
 
     mailer do
-      delivery :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
+      delivery :smtp, address: ENV.fetch('SMTP_HOST'), port: ENV.fetch('SMTP_PORT')
     end
   end
 end

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -216,7 +216,7 @@ Hanami.configure do
     #    adapter :sql, 'postgresql://localhost/#{project}_development'
     #    adapter :sql, 'mysql://localhost/#{project}_development'
     #
-    adapter :sql, ENV['DATABASE_URL']
+    adapter :sql, ENV.fetch('DATABASE_URL')
 
     ##
     # Migrations
@@ -241,7 +241,7 @@ Hanami.configure do
     logger level: :info, formatter: :json, filter: []
 
     mailer do
-      delivery :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
+      delivery :smtp, address: ENV.fetch('SMTP_HOST'), port: ENV.fetch('SMTP_PORT')
     end
   end
 end

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -452,7 +452,7 @@ Hanami.configure do
     #    adapter :sql, 'postgresql://localhost/#{project}_development'
     #    adapter :sql, 'mysql://localhost/#{project}_development'
     #
-    adapter :sql, ENV['DATABASE_URL']
+    adapter :sql, ENV.fetch('DATABASE_URL')
 
     ##
     # Migrations
@@ -477,7 +477,7 @@ Hanami.configure do
     logger level: :info, formatter: :json, filter: []
 
     mailer do
-      delivery :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
+      delivery :smtp, address: ENV.fetch('SMTP_HOST'), port: ENV.fetch('SMTP_PORT')
     end
   end
 end


### PR DESCRIPTION
Making easy to find what is wrong when missing necessary environment valuable.

before:
```
Boot Error
Something went wrong while loading /your/repository/sample_hanami/config.ru

Hanami::Model::Error: LoadError: cannot load such file -- sequel/adapters/

/your/repository/sample_hanami/vendor/bundle/ruby/2.4.0/bundler/gems/model-22eb4b172cb5/lib/hanami/model/configuration.rb:144:in `rescue in load!'
/your/repository/sample_hanami/vendor/bundle/ruby/2.4.0/bundler/gems/model-22eb4b172cb5/lib/hanami/model/configuration.rb:134:in `load!'
...

```

after:
```
Boot Error
Something went wrong while loading /your/repository/sample_hanami/config.ru

KeyError: key not found: "DATABASE_URL"

/your/repository/sample_hanami/config/environment.rb:21:in `fetch'
/your/repository/sample_hanami/config/environment.rb:21:in `block (2 levels) in <top (required)>'
...

```