### PR TITLE
Revert #873 (adding better_errors gem)

### DIFF
--- a/lib/hanami/cli/commands/new/Gemfile.erb
+++ b/lib/hanami/cli/commands/new/Gemfile.erb
@@ -33,9 +33,6 @@ gem 'haml'
 
 <%- if code_reloading -%>
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
-
   # Code reloading
   # See: http://hanamirb.org/guides/projects/code-reloading
   gem 'shotgun'

--- a/lib/hanami/cli/commands/new/config.ru.erb
+++ b/lib/hanami/cli/commands/new/config.ru.erb
@@ -1,8 +1,3 @@
 require './config/environment'
 
-if defined?(BetterErrors)
-  use BetterErrors::Middleware
-  BetterErrors.application_root = __dir__
-end
-
 run Hanami.app

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -130,9 +130,6 @@ gem 'hanami-model', '~> 1.1'
 gem 'sqlite3'
 
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
-
   # Code reloading
   # See: http://hanamirb.org/guides/projects/code-reloading
   gem 'shotgun'
@@ -183,11 +180,6 @@ END
       #
       expect('config.ru').to have_file_content <<-END
 require './config/environment'
-
-if defined?(BetterErrors)
-  use BetterErrors::Middleware
-  BetterErrors.application_root = __dir__
-end
 
 run Hanami.app
 END


### PR DESCRIPTION
Thanks to @igneus for pointing out a security vulnerability in the `better_errors` gem: https://github.com/hanami/hanami/commit/46de8b1596e70daca4a960d6098d423fe7217be6#commitcomment-26418678

It looks like this issue has _not_ been fixed in `better_errors`: https://github.com/charliesome/better_errors/issues/350