### PR TITLE
Introduce configurable project Rack middleware stack

### DIFF
--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -26,7 +26,7 @@ module Hanami
       @routes  = Hanami::Router.new
 
       mount(configuration)
-      middleware(environment)
+      middleware(configuration, environment)
       builder.run(routes)
     end
 
@@ -62,9 +62,13 @@ module Hanami
 
     # @since 0.9.0
     # @api private
-    def middleware(environment)
+    def middleware(configuration, environment)
       builder.use Hanami::CommonLogger, Hanami.logger unless Hanami.logger.nil?
       builder.use Rack::ContentLength
+
+      configuration.middleware.each do |m, args, blk|
+        builder.use(m, *args, &blk)
+      end
 
       if middleware = environment.static_assets_middleware # rubocop:disable Lint/AssignmentInCondition
         builder.use middleware

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -1,5 +1,4 @@
 require 'concurrent'
-require 'delegate'
 require 'hanami/application'
 require 'hanami/utils/class'
 require 'hanami/utils/string'
@@ -7,17 +6,8 @@ require 'hanami/utils/string'
 module Hanami
   # @api private
   class Configuration
-    # @api private
-    class App < SimpleDelegator
-      # @api private
-      attr_reader :path_prefix
-
-      # @api private
-      def initialize(app, path_prefix)
-        super(app)
-        @path_prefix = path_prefix
-      end
-    end
+    require "hanami/configuration/app"
+    require "hanami/configuration/middleware"
 
     # @api private
     def initialize(&blk)
@@ -105,6 +95,11 @@ module Hanami
     # @api private
     def mounted
       settings.fetch_or_store(:mounted, {})
+    end
+
+    # @since x.x.x
+    def middleware
+      settings.fetch_or_store(:middleware, Configuration::Middleware.new)
     end
 
     # @since 0.9.0

--- a/lib/hanami/configuration/app.rb
+++ b/lib/hanami/configuration/app.rb
@@ -1,0 +1,18 @@
+require "delegate"
+
+module Hanami
+  # @api private
+  class Configuration
+    # @api private
+    class App < SimpleDelegator
+      # @api private
+      attr_reader :path_prefix
+
+      # @api private
+      def initialize(app, path_prefix)
+        super(app)
+        @path_prefix = path_prefix
+      end
+    end
+  end
+end

--- a/lib/hanami/configuration/middleware.rb
+++ b/lib/hanami/configuration/middleware.rb
@@ -1,0 +1,37 @@
+require "concurrent"
+
+module Hanami
+  # @api private
+  class Configuration
+    # Middleware configuration
+    class Middleware
+      # @api private
+      def initialize
+        @middleware = Concurrent::Array.new
+      end
+
+      # Use a Rack middleware
+      #
+      # @param middleware [#call] a Rack middleware
+      # @param args [Array<Object>] an optional set of options
+      # @param blk [Proc] an optional block to pass to the middleware
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   # config/environment.rb
+      #   # ...
+      #   Hanami.configure do
+      #     middleware.use MyRackMiddleware
+      #   end
+      def use(middleware, *args, &blk)
+        @middleware.push([middleware, args, blk])
+      end
+
+      # @api private
+      def each(&blk)
+        @middleware.each(&blk)
+      end
+    end
+  end
+end

--- a/spec/integration/middleware_spec.rb
+++ b/spec/integration/middleware_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe "Project middleware", type: :cli do
+  it "mounts Rack middleware" do
+    with_project do
+      generate_middleware
+
+      unshift "config/environment.rb", 'require "rack/etag"'
+      unshift "config/environment.rb", 'require_relative "./middleware/runtime"'
+      unshift "config/environment.rb", 'require_relative "./middleware/custom"'
+
+      inject_line_after "config/environment.rb", "Hanami.configure", <<-EOL
+middleware.use Middleware::Runtime
+middleware.use Middleware::Custom, "OK"
+middleware.use Rack::ETag
+EOL
+
+      generate "action web home#index --url=/"
+      rewrite "apps/web/controllers/home/index.rb", <<-EOF
+module Web::Controllers::Home
+  class Index
+    include Web::Action
+
+    def call(params)
+      self.body = "OK"
+    end
+  end
+end
+EOF
+
+      server do
+        get '/'
+
+        expect(last_response.status).to               eq(200)
+
+        expect(last_response.headers["X-Runtime"]).to eq("1ms")
+        expect(last_response.headers["X-Custom"]).to  eq("OK")
+        expect(last_response.headers["ETag"]).to_not  be_nil
+      end
+    end
+  end
+
+  private
+
+  def generate_middleware # rubocop:disable Metrics/MethodLength
+    write "config/middleware/runtime.rb", <<-EOF
+module Middleware
+  class Runtime
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      headers["X-Runtime"]  = "1ms"
+
+      [status, headers, body]
+    end
+  end
+end
+EOF
+
+    write "config/middleware/custom.rb", <<-EOF
+module Middleware
+  class Custom
+    def initialize(app, value)
+      @app   = app
+      @value = value
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      headers["X-Custom"]   = @value
+
+      [status, headers, body]
+    end
+  end
+end
+EOF
+  end
+end


### PR DESCRIPTION
In a nutshell:

```ruby
# config/environment.rb
Hanami.configure do
  middleware.use MyRackMiddleware
end
```

---

Please note that:

  1. This is kinda equivalent to add a middleware in `config.ru`.
  1. This PR does **NOT** changes the `config/environment.rb` that we generate for new projects. But a developer that needs to add a project wide middleware can use it.

---

Why this is important? For plugins.

A plugin may want to add a Rack middleware. On 1.1.x the only ways to add it are: 1. asking the developer to manual add it into `config.ru` 2. create a code generator that writes into `config.ru`. 

Both these solutions require manual intervention for newer versions of a plugin. Which isn't ideal both for developers and plugin authors. With this proposal, a plugin author can mount the middleware from the gem.