### PR TITLE
Introduce Hanami.plugin to let plugins to configure Hanami project

### DIFF
--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -21,6 +21,7 @@ module Hanami
   # @api private
   # @since 0.9.0
   @_mutex = Mutex.new
+  @_plugins = Concurrent::Array.new
 
   # Configure Hanami project
   #
@@ -81,9 +82,33 @@ module Hanami
   #
   # @see Hanami.configure
   #
-  # @since 1.2.0
+  # @since x.x.x
   def self.plugin(&blk)
-    configuration.instance_eval(&blk)
+    @_plugins << blk
+  end
+
+  # Plugins registry
+  #
+  # NOTE: We can't use `Components` registry.
+  #
+  # Plugins are loaded when Bundler requires `Gemfile` gems.
+  # During this phase the `Components` that we can resolve are erased by the
+  # first incoming request in development.
+  # They are erased by a workaround that we had to put in place in `Hanami.boot`.
+  # This workaround is `Components.release` and it was introduced because
+  # `shotgun` failed to reload components, so we have to release for each
+  # incoming request.
+  # After the `Components` registry is cleared up, Hanami is able to resolve all
+  # the components from scratch.
+  #
+  # When we'll switch to `hanami-reloader` for development, we can remove
+  # `Components.release` and we'll be able to store plugins in `Components` and
+  # remove `Hanami.plugins` as well.
+  #
+  # @since x.x.x
+  # @api private
+  def self.plugins
+    @_plugins
   end
 
   # Boot your Hanami project

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -77,6 +77,15 @@ module Hanami
     end
   end
 
+  # Configure a plugin
+  #
+  # @see Hanami.configure
+  #
+  # @since 1.2.0
+  def self.plugin(&blk)
+    configuration.instance_eval(&blk)
+  end
+
   # Boot your Hanami project
   #
   # NOTE: In case this is invoked many times, it guarantees that the boot

--- a/lib/hanami/components/components.rb
+++ b/lib/hanami/components/components.rb
@@ -323,7 +323,7 @@ module Hanami
     # @since 0.9.0
     # @api private
     register 'finalizers' do
-      requires 'finalizers.initializers'
+      requires 'plugins', 'finalizers.initializers'
 
       resolve { true }
     end
@@ -337,6 +337,18 @@ module Hanami
         Hanami::Utils.require!(
           Hanami.root.join('config', 'initializers')
         )
+      end
+    end
+
+    # Load plugins
+    #
+    # @since x.x.x
+    # @api private
+    register 'plugins' do
+      resolve do |configuration|
+        Hanami.plugins.each do |plugin_configuration|
+          configuration.instance_eval(&plugin_configuration)
+        end
       end
     end
 

--- a/spec/isolation/hanami/plugin/with_loaded_configuration_spec.rb
+++ b/spec/isolation/hanami/plugin/with_loaded_configuration_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "Hanami.plugin" do
+  it "configures plugin" do
+    application = double("app")
+
+    Hanami.configure{}
+    Hanami.plugin do
+      mount application, at: "/plugin"
+    end
+
+    app = Hanami.configuration.mounted.fetch(application)
+    expect(app).to be_kind_of(Hanami::Configuration::App)
+    expect(app.path_prefix).to eq("/plugin")
+  end
+end

--- a/spec/isolation/hanami/plugin/with_loaded_configuration_spec.rb
+++ b/spec/isolation/hanami/plugin/with_loaded_configuration_spec.rb
@@ -2,10 +2,11 @@ RSpec.describe "Hanami.plugin" do
   it "configures plugin" do
     application = double("app")
 
-    Hanami.configure{}
+    Hanami.configure {}
     Hanami.plugin do
       mount application, at: "/plugin"
     end
+    Hanami::Components.resolve("plugins")
 
     app = Hanami.configuration.mounted.fetch(application)
     expect(app).to be_kind_of(Hanami::Configuration::App)

--- a/spec/isolation/hanami/plugin/without_loaded_configuration_spec.rb
+++ b/spec/isolation/hanami/plugin/without_loaded_configuration_spec.rb
@@ -1,5 +1,0 @@
-RSpec.describe "Hanami.plugin" do
-  it "raises error when try to confiure plugin before Hanami project" do
-    expect { Hanami.plugin{} }.to raise_error(RuntimeError, "Hanami not configured")
-  end
-end

--- a/spec/isolation/hanami/plugin/without_loaded_configuration_spec.rb
+++ b/spec/isolation/hanami/plugin/without_loaded_configuration_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe "Hanami.plugin" do
+  it "raises error when try to confiure plugin before Hanami project" do
+    expect { Hanami.plugin{} }.to raise_error(RuntimeError, "Hanami not configured")
+  end
+end

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Hanami::Configuration do
+  describe "#initialize" do
+    it "isn't frozen when initialized" do
+      subject = described_class.new{}
+      expect(subject.frozen?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
In a nutshell: a plugin can configure a Hanami project.

---

Imagine a plugin that wants to mount a Rack middleware (#880 ). From the plugin code in the gem, the author can do:

```ruby
Hanami.plugin do
  middleware.use MyPluginMiddleware
end
```

or

```ruby
Hanami.plugin do
  mount Hanami::Admin::App, at: "/admin"
end
```

---

The yielded context is the same of `Hanami.configure`. A plugin can override/add settings from `config/environment.rb`