### PR TITLE
Cache `Hanami::App` middleware stack

### DIFF
--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -28,6 +28,8 @@ module Hanami
       mount(configuration)
       middleware(configuration, environment)
       builder.run(routes)
+
+      @app = builder.to_app
     end
 
     # Implements Rack SPEC
@@ -39,10 +41,14 @@ module Hanami
     # @since 0.9.0
     # @api private
     def call(env)
-      builder.call(env)
+      app.call(env)
     end
 
     private
+
+    # @since x.x.x
+    # @api private
+    attr_reader :app
 
     # @since 0.9.0
     # @api private


### PR DESCRIPTION
During the work on hanami/webconsole#1, I discovered a performance problem: for each incoming request, we are building the project middleware stack over and over.

## Performance Penalty

This has a performance penalty. Without this patch, a new Hanami project, ran in production mode, can perform `5528.86` requests per second. With this patch, we have a boost of `~160` requests per second: `5688.40`.

Without this patch:

```shell
➜ wrk --threads 2 --duration 10 http://localhost:2300/
Running 10s test @ http://localhost:2300/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.73ms    1.60ms  55.07ms   94.45%
    Req/Sec     2.78k   572.72     3.56k    61.88%
  55843 requests in 10.10s, 37.92MB read
Requests/sec:   5528.86 # <<< READ THIS NUMBER
Transfer/sec:      3.75MB
```

With this patch:

```shell
➜ wrk --threads 2 --duration 10 http://localhost:2300/
Running 10s test @ http://localhost:2300/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.44ms    0.92ms  22.33ms   83.05%
    Req/Sec     2.86k   461.31     3.59k    58.91%
  57457 requests in 10.10s, 39.02MB read
Requests/sec:   5688.40 # <<< READ THIS NUMBER
Transfer/sec:      3.86MB
```

## Hard to setup with `hanami-webconsole`/`better_errors`

This isn't just important for perfomance. `hanami-webconsole` won't be able to inject a working `BetterErrors::Middleware` in a Hanami project (see hanami/hanami#880 and hanami/webconsole#1).

When a project raises an exception the `BetterErrors::Middleware` catches it, stores the informations in memory and renders an empty error page. With a subsequent AJAX request, it fetches the previously registered informations about the exception, and it populates the final version of the error page.

To recap, for each exception we have two responses: 1. is the error page when the app raises the exception 2. is the AJAX request that fetches the exception information and populates the console.

Because for each incoming request, we were building from scratch the `Hanami::App` middleware stack, the informations were lost. When the AJAX request tried to fetch the exception information, it found nothing and `better_errors` printed an error message.

> No exception information available
The application has been restarted since this page loaded, or the framework is reloading all gems before each request
>
> More about Better Errors

![screen shot 2018-02-04 at 15 38 03](https://user-images.githubusercontent.com/5089/35778640-80f09558-09c1-11e8-95ac-bca553f89c3f.png)
