### PR TITLE
Create simple one file template for hanami model with sqlite adapter

### DIFF
--- a/templates/model_sqlite.rb
+++ b/templates/model_sqlite.rb
@@ -1,0 +1,74 @@
+begin
+  require "bundler/inline"
+rescue LoadError => e
+  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
+  raise e
+end
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  gem "rake"
+  gem "hanami-model", github: "hanami/model"
+  gem "sqlite3"
+  gem "rspec"
+  gem "rspec-core"
+end
+
+require 'hanami/model'
+require 'hanami/model/sql'
+
+Hanami::Model.configure do
+  adapter :sql, "sqlite:///#{Dir.pwd}/hanami_model_template.db"
+end
+
+Hanami::Model.migration do
+  change do
+    create_table :authors do
+      primary_key :id
+
+      column :name, String
+    end
+
+    create_table :books do
+      primary_key :id
+
+      foreign_key :author_id, :authors, null: false
+
+      column :title, String
+    end
+  end
+end.run
+
+class Book < Hanami::Entity
+end
+
+class BookRepository < Hanami::Repository
+end
+
+class Author < Hanami::Entity
+end
+
+class AuthorRepository < Hanami::Repository
+  associations do
+    has_many :books
+  end
+
+  def add_book(author, data)
+    assoc(:books, author).add(data)
+  end
+end
+
+Hanami::Model.load!
+
+require 'rspec'
+require 'rspec/autorun'
+
+RSpec.describe 'Model' do
+  let(:author_repository) { AuthorRepository.new }
+  let(:book_repository) { BookRepository.new }
+
+  subject { author_repository.create(name: "Leo Tolstoy") }
+
+  it { expect { subject }.to change { author_repository.all.count }.by(1) }
+end


### PR DESCRIPTION
I created a simple part of https://github.com/hanami/hanami/issues/786. Thanks https://github.com/hanami/hanami/pull/826 for helping with some code.

## Manual testing
```
$ ruby templates/model_sqlite.rb
```

After you'll see something like this:
![screenshot 2018-02-20 20 28 29](https://user-images.githubusercontent.com/1147484/36439414-ead8e5a6-167d-11e8-94fa-cdf35dca5ad4.jpeg)
