### PR TITLE
Provide stack trace when exception is caught

### DIFF
--- a/lib/hanami/cli/commands/command.rb
+++ b/lib/hanami/cli/commands/command.rb
@@ -85,6 +85,7 @@ module Hanami
             super(options)
           rescue StandardError => e
             warn e.message
+            warn e.backtrace.join("\n\t")
             exit(1)
           end
         end


### PR DESCRIPTION
Without this, the user has no idea what has caused the exception (what file, what line number).
This makes it much easier on the user.