### PR TITLE
Early Hints

### DIFF
--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -68,6 +68,9 @@ module Hanami
 
     # @since 0.9.0
     # @api private
+    #
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def middleware(configuration, environment)
       builder.use Hanami::CommonLogger, Hanami.logger unless Hanami.logger.nil?
       builder.use Rack::ContentLength
@@ -76,11 +79,18 @@ module Hanami
         builder.use(m, *args, &blk)
       end
 
+      if configuration.early_hints
+        require 'hanami/early_hints'
+        builder.use Hanami::EarlyHints
+      end
+
       if middleware = environment.static_assets_middleware # rubocop:disable Lint/AssignmentInCondition
         builder.use middleware
       end
 
       builder.use Rack::MethodOverride
     end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -102,6 +102,31 @@ module Hanami
       settings.fetch_or_store(:middleware, Configuration::Middleware.new)
     end
 
+    # Setup Early Hints feature
+    #
+    # @since x.x.x
+    #
+    # @example Enable for all the environments
+    #   # config/environment.rb
+    #   Hanami.configure do
+    #     early_hints true
+    #   end
+    #
+    # @example Enable only for production
+    #   # config/environment.rb
+    #   Hanami.configure do
+    #     environment :production do
+    #       early_hints true
+    #     end
+    #   end
+    def early_hints(value = nil)
+      if value.nil?
+        settings.fetch(:early_hints, false)
+      else
+        settings[:early_hints] = value
+      end
+    end
+
     # @since 0.9.0
     # @api private
     def apps

--- a/lib/hanami/early_hints.rb
+++ b/lib/hanami/early_hints.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Hanami
+  # HTTP/2 Early Hints Rack middleware
+  #
+  # It sends extra responses **before** the main reponse is sent.
+  # These extra responses are HTTP/2 Early Hints (103).
+  # They specify the web assets (javascripts, stylesheets, etc..) to be "pushed",
+  # so modern browsers pre-fetch them in parallel with the main HTTP response.
+  #
+  # @see https://tools.ietf.org/html/draft-ietf-httpbis-early-hints-05
+  #
+  # @since x.x.x
+  # @api private
+  class EarlyHints
+    # @since x.x.x
+    # @api private
+    class NotSupportedByServerError < ::StandardError
+      # @since x.x.x
+      # @api private
+      def initialize
+        super("Current Ruby server doesn't support Early Hints.\nPlease make sure to use Puma with Early Hints enabled.")
+      end
+    end
+
+    # @since x.x.x
+    # @api private
+    def initialize(app)
+      @app = app
+    end
+
+    # @param env [Hash] Rack env
+    #
+    # @return [Array,Rack::Response] a Rack response
+    #
+    # @raise [Hanami::EarlyHints::NotSupportedByServerError] if the current Ruby
+    #   server doesn't support Early Hints
+    #
+    # @since x.x.x
+    # @api private
+    def call(env)
+      @app.call(env).tap do
+        send_early_hints(env)
+      end
+    end
+
+    private
+
+    # Pushing a lot of assets may exceed the limit of HTTP headers of a single
+    # Early Hints (103) response.
+    #
+    # For this reason we send multiple Early Hints (103) responses for each `n`
+    # assets. We call this `n` number `BATCH_SIZE`.
+    #
+    # If the current page needs to push 23 assets, it will send 3 Early Hints
+    # (103) responses:
+    #
+    #   1. Response #1: 10 assets
+    #   2. Response #2: 10 assets
+    #   3. Response #3: 3 assets
+    #
+    # @since x.x.x
+    # @api private
+    BATCH_SIZE = 10
+
+    # Rack servers that support Early Hints (only Puma for now),
+    # inject an object into the Rack env to send multiple Early Hints (103)
+    # responses.
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see https://github.com/puma/puma/pull/1403
+    RACK_EARLY_HINTS_ENV_KEY = "rack.early_hints"
+
+    # This cache key is used by `hanami-assets` to collect the assets that are
+    # eligible to be pushed.
+    #
+    # It stores these values in a thread-local variable.
+    #
+    # NOTE: if changing this key here, it MUST be changed into `hanami-assets` as well
+    #
+    # @since x.x.x
+    # @api private
+    CACHE_KEY = :__hanami_assets
+
+    # Tries to send multiple Early Hints (103) HTTP responses, if there are
+    # assets eligible.
+    #
+    # @param env [Hash] Rack env
+    #
+    # @raise [Hanami::EarlyHints::NotSupportedByServerError] if the current Ruby
+    #   server doesn't support Early Hints
+    #
+    # @since x.x.x
+    # @api private
+    def send_early_hints(env)
+      return if Thread.current[CACHE_KEY].nil?
+
+      Thread.current[CACHE_KEY].each_slice(BATCH_SIZE) do |slice|
+        link = slice.map do |asset, options|
+          ret = %(<#{asset}>; rel=preload)
+          ret += "; as=#{options[:as]}" unless options[:as].nil?
+          ret += "; crossorigin" if options[:crossorigin]
+          ret
+        end.join("\n")
+
+        send_early_hints_response(env, link)
+      end
+    end
+
+    # Tries to send an Early Hints (103) HTTP response for a batch of assets
+    #
+    # @param env [Hash] Rack env
+    # @param link [String] the serialized HTTP `Link` headers
+    #
+    # @raise [Hanami::EarlyHints::NotSupportedByServerError] if the current Ruby
+    #   server doesn't support Early Hints
+    #
+    # @since x.x.x
+    # @api private
+    def send_early_hints_response(env, link)
+      env[RACK_EARLY_HINTS_ENV_KEY].call("Link" => link)
+    rescue NoMethodError => exception
+      raise exception if env.key?(RACK_EARLY_HINTS_ENV_KEY)
+      raise NotSupportedByServerError
+    end
+  end
+end

--- a/lib/hanami/early_hints.rb
+++ b/lib/hanami/early_hints.rb
@@ -19,7 +19,7 @@ module Hanami
       # @since x.x.x
       # @api private
       def initialize
-        super("Current Ruby server doesn't support Early Hints.\nPlease make sure to use Puma with Early Hints enabled.")
+        super("Current Ruby server doesn't support Early Hints.\nPlease make sure to use a web server with Early Hints enabled (only Puma for now).")
       end
     end
 

--- a/spec/integration/early_hints_spec.rb
+++ b/spec/integration/early_hints_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe "Early Hints", type: :integration do
+  it "pushes assets" do
+    skip "curl not installed" if which("curl").nil?
+
+    with_project("bookshelf", server: :puma) do
+      generate "action web home#index --url=/"
+
+      write "apps/web/assets/javascripts/application.css", <<-EOF
+body { margin: 0; }
+      EOF
+
+      inject_line_after "apps/web/templates/application.html.erb", /favicon/, %(<%= stylesheet "application" %>)
+      inject_line_after "config/environment.rb", /mount/, "early_hints true"
+
+      write "config/puma.rb", <<-EOF
+early_hints true
+EOF
+
+      port = RSpec::Support::RandomPort.call
+      server(port: port) do
+        sleep 2
+
+        # The Ruby HTTP client that we use for testing (excon), fails to connect to the server.
+        # It's very likely that it assumes that for each request, the server will return only one response.
+        # But in case of Early Hints (103) the returned response are multiple: `n` Early Hints (103) + OK (200).
+        #
+        # For this reason we fall back to cURL for this test.
+        system_exec("curl -i -v http://localhost:#{port}/")
+        expect(out).to include("Link: </assets/application.css>; rel=preload; as=style")
+      end
+    end
+  end
+end

--- a/spec/unit/early_hints_spec.rb
+++ b/spec/unit/early_hints_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hanami::EarlyHints do
 
   let(:assets) do
     (1..23).each_with_object({}) do |i, memo|
-      memo["/assets/stylesheet-#{i}.css"] = { as: "stylesheet", crossorigin: true }
+      memo["/assets/stylesheet-#{i}.css"] = { as: "style", crossorigin: true }
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe Hanami::EarlyHints do
           links = early_hints.links
           expect(links.count).to be(3) # (23 / Hanami::EarlyHints::BATCH_SIZE) + 1 == 3
 
-          expect(links.first).to include(%(</assets/stylesheet-1.css>; rel=preload; as=stylesheet; crossorigin))
+          expect(links.first).to include(%(</assets/stylesheet-1.css>; rel=preload; as=style; crossorigin))
         end
 
         context "with broken implementation" do
@@ -88,7 +88,7 @@ RSpec.describe Hanami::EarlyHints do
         it "raises informative error" do
           expect do
             subject.call(env)
-          end.to raise_error(Hanami::EarlyHints::NotSupportedByServerError, "Current Ruby server doesn't support Early Hints.\nPlease make sure to use Puma with Early Hints enabled.")
+          end.to raise_error(Hanami::EarlyHints::NotSupportedByServerError, "Current Ruby server doesn't support Early Hints.\nPlease make sure to use a web server with Early Hints enabled (only Puma for now).")
         end
       end
 

--- a/spec/unit/early_hints_spec.rb
+++ b/spec/unit/early_hints_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "hanami/early_hints"
+
+class EarlyHintsTest
+  attr_reader :links
+
+  def initialize
+    @links = []
+  end
+
+  def call(links)
+    @links.push(links.fetch("Link"))
+  end
+end
+
+class BrokenEarlyHintsTest
+  def call(*)
+    raise NoMethodError.new("boom")
+  end
+end
+
+RSpec.describe Hanami::EarlyHints do
+  subject { described_class.new(app) }
+  let(:app) { ->(*) { [200, {}, ["OK"]] } }
+
+  let(:assets) do
+    (1..23).each_with_object({}) do |i, memo|
+      memo["/assets/stylesheet-#{i}.css"] = { as: "stylesheet", crossorigin: true }
+    end
+  end
+
+  describe "#call" do
+    before do
+      Thread.current[:__hanami_assets] = nil
+    end
+
+    it "returns response from app" do
+      response = subject.call({})
+      expect(response).to eq([200, {}, ["OK"]])
+    end
+
+    context "with a server that supports Early Hints" do
+      let(:early_hints) { EarlyHintsTest.new }
+      let(:env) { Hash["rack.early_hints" => early_hints] }
+
+      context "with pushed assets" do
+        before do
+          Thread.current[:__hanami_assets] = assets
+        end
+
+        it "sends Early Hints (103) responses" do
+          subject.call(env)
+
+          links = early_hints.links
+          expect(links.count).to be(3) # (23 / Hanami::EarlyHints::BATCH_SIZE) + 1 == 3
+
+          expect(links.first).to include(%(</assets/stylesheet-1.css>; rel=preload; as=stylesheet; crossorigin))
+        end
+
+        context "with broken implementation" do
+          let(:early_hints) { BrokenEarlyHintsTest.new }
+
+          it "raises original error" do
+            expect do
+              subject.call(env)
+            end.to raise_error(NoMethodError, "boom")
+          end
+        end
+      end
+
+      context "without pushed assets" do
+        it "doesn't send Early Hints (103) responses" do
+          subject.call(env)
+          expect(early_hints.links).to be_empty
+        end
+      end
+    end
+
+    context "with a server that doesn't support Early Hints" do
+      let(:env) { Hash[] }
+
+      context "with pushed assets" do
+        before do
+          Thread.current[:__hanami_assets] = assets
+        end
+
+        it "raises informative error" do
+          expect do
+            subject.call(env)
+          end.to raise_error(Hanami::EarlyHints::NotSupportedByServerError, "Current Ruby server doesn't support Early Hints.\nPlease make sure to use Puma with Early Hints enabled.")
+        end
+      end
+
+      context "without pushed assets" do
+        it "doesn't send Early Hints (103) responses" do
+          response = subject.call(env)
+          expect(response).to eq([200, {}, ["OK"]])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Historical Background

I experimented with Early Hints (EH) in the summer of 2015, when the project was still Lotus:

  * https://github.com/jodosha/instants
  * https://www.youtube.com/watch?v=XCgsXUKLsOc&feature=youtu.be&t=31m4s

At that time, I used the term "Push Promise" instead of "Early Hints".

We didn't ship this feature because there was the lack of support in Rack and any other Ruby web server. I had to write a toy HTTP/2 web server for Rack https://github.com/jodosha/panther

Fast forwarding to today, both Rack and Puma have support for Early Hints: see https://github.com/puma/puma/pull/1403

## Setup

In order to use it, you need to use Puma with Early Hints feature enabled.

```ruby
# config/puma.rb
# ...
early_hints true
```

Inside the project configuration you can simply enable like this:

```ruby
# config/environment.rb
Hanami.configure do
  # ...
  early_hints true
end
```

As last step, you need a web server that supports HTTP/2 and Early Hints: eg. [h2o](https://h2o.examp1e.net/).

**If you're looking for a full working example, please check this [demo app](https://github.com/jodosha/hall_of_fame)**.

## Usage

Google Chrome ignores the Early Hint responses after the server pushed 100 assets.
In order to avoid this limit I decided to not push all the assets by default.

### Automatic opted-in assets

Assets like JavaScripts and Stylesheets are **automatically** opted in to be pushed.

This will be pushed:

```erb
<%= stylesheet "application" %>
```

To opt-out:

```erb
<%= stylesheet "application", push: false %>
```

### Automatic opted-out assets

Other assets like images, audio, video, and generic assets are **not** pushed by default.

This won't be sent:

```erb
<%= audio "song.ogg" %>
```

To opt-in:

```erb
<%= audio "song.ogg", push: true %>
```

For a complete syntax reference, please have a look at https://github.com/hanami/assets/pull/85

---

Ref https://github.com/hanami/assets/pull/27
Ref https://github.com/hanami/assets/pull/85
Ref https://github.com/puma/puma/pull/1403
Ref https://github.com/hanami/hanami/pull/880
Ref https://trello.com/c/c4NGy33K/1-http-2-early-hints