### PR TITLE
[WIP] Colorize file generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 gem 'i18n'
 
-gem 'hanami-utils',       '~> 1.1', require: false, git: 'https://github.com/hanami/utils.git',       branch: '1.1.x'
+gem 'hanami-utils',       '~> 1.1', require: false, git: 'https://github.com/hanami/utils.git', branch: 'coloured_output'
 gem 'hanami-validations', '~> 1.1', require: false, git: 'https://github.com/hanami/validations.git', branch: '1.1.x'
 gem 'hanami-router',      '~> 1.1', require: false, git: 'https://github.com/hanami/router.git',      branch: '1.1.x'
 gem 'hanami-controller',  '~> 1.1', require: false, git: 'https://github.com/hanami/controller.git',  branch: '1.1.x'

--- a/lib/hanami/cli/commands/command.rb
+++ b/lib/hanami/cli/commands/command.rb
@@ -6,6 +6,7 @@ require 'hanami/cli/commands/project'
 require 'hanami/cli/commands/templates'
 require 'concurrent'
 require 'hanami/utils/files'
+require 'hanami/utils/shell_code'
 require 'erb'
 
 module Hanami
@@ -123,9 +124,13 @@ module Hanami
           end
         end
 
-        # @since 1.1.0
+        # @since x.x.x
         # @api private
-        SAY_FORMATTER = "%<operation>12s  %<path>s\n".freeze
+        COLUMN_WIDTH = 12
+
+        # @since x.x.x
+        # @api private
+        EXTRA_COLORIZE_WIDTH = 9
 
         # @since 1.1.0
         # @api private
@@ -160,7 +165,35 @@ module Hanami
         # @since 1.1.0
         # @api private
         def say(operation, path)
-          out.puts(SAY_FORMATTER % { operation: operation, path: path }) # rubocop:disable Style/FormatString
+          out.puts(_format_say(operation, path))
+        end
+
+        # @since x.x.x
+        # @api private
+        def _format_say(operation, path)
+        [
+          _colorize_operation(operation),
+          path
+        ].join("  ")
+        end
+
+        # @since x.x.x
+        # @api private
+        def _colorize_operation(operation)
+          case operation
+          when :create
+            _colorize_and_justify(operation, :green)
+          when :remove
+            _colorize_and_justify(operation, :red)
+          when :insert
+            _colorize_and_justify(operation, :blue)
+          when :append
+            _colorize_and_justify(operation, :cyan)
+          when :run
+            _colorize_and_justify(operation, :magenta)
+          else
+            operation.to_s.rjust(COLUMN_WIDTH)
+          end
         end
 
         # @since 1.1.0
@@ -173,6 +206,15 @@ module Hanami
         # @api private
         def requirements
           Hanami::Components
+        end
+
+        # @since x.x.x
+        # @api private
+        def _colorize_and_justify(operation, color)
+          # Colorize adds 9 characters. They're not visible but Ruby doesn't
+          # know that, so we have to compensate.
+          Hanami::Utils::ShellCode.colorize(operation, color: color)
+                                  .rjust(COLUMN_WIDTH + EXTRA_COLORIZE_WIDTH)
         end
       end
     end

--- a/lib/hanami/cli/commands/command.rb
+++ b/lib/hanami/cli/commands/command.rb
@@ -132,6 +132,16 @@ module Hanami
         # @api private
         EXTRA_COLORIZE_WIDTH = 9
 
+        # @since x.x.x
+        # @api private
+        OPERATION_COLORS = Hash[
+          create: :green,
+          remove: :red,
+          insert: :blue,
+          append: :cyan,
+          run:    :magenta,
+        ].freeze
+
         # @since 1.1.0
         # @api private
         attr_reader :out
@@ -180,17 +190,8 @@ module Hanami
         # @since x.x.x
         # @api private
         def _colorize_operation(operation)
-          case operation
-          when :create
-            _colorize_and_justify(operation, :green)
-          when :remove
-            _colorize_and_justify(operation, :red)
-          when :insert
-            _colorize_and_justify(operation, :blue)
-          when :append
-            _colorize_and_justify(operation, :cyan)
-          when :run
-            _colorize_and_justify(operation, :magenta)
+          if OPERATION_COLORS.key?(operation)
+            _colorize_and_justify(operation)
           else
             operation.to_s.rjust(COLUMN_WIDTH)
           end
@@ -210,7 +211,8 @@ module Hanami
 
         # @since x.x.x
         # @api private
-        def _colorize_and_justify(operation, color)
+        def _colorize_and_justify(operation)
+          color = OPERATION_COLORS.fetch(operation)
           # Colorize adds 9 characters. They're not visible but Ruby doesn't
           # know that, so we have to compensate.
           Hanami::Utils::ShellCode.colorize(operation, color: color)

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -3,12 +3,12 @@ RSpec.describe "hanami generate", type: :cli do
     it "generates action" do
       with_project('bookshelf_generate_action') do
         output = [
-          "create  spec/web/controllers/authors/index_spec.rb",
-          "create  apps/web/controllers/authors/index.rb",
-          "create  apps/web/views/authors/index.rb",
-          "create  apps/web/templates/authors/index.html.erb",
-          "create  spec/web/views/authors/index_spec.rb",
-          "insert  apps/web/config/routes.rb"
+          "\e[32mcreate\e[0m  spec/web/controllers/authors/index_spec.rb",
+          "\e[32mcreate\e[0m  apps/web/controllers/authors/index.rb",
+          "\e[32mcreate\e[0m  apps/web/views/authors/index.rb",
+          "\e[32mcreate\e[0m  apps/web/templates/authors/index.html.erb",
+          "\e[32mcreate\e[0m  spec/web/views/authors/index_spec.rb",
+          "\e[34minsert\e[0m  apps/web/config/routes.rb"
         ]
 
         run_command "hanami generate action web authors#index", output


### PR DESCRIPTION
Here's a work-in-progress for colorizing the CLI commands:

![image](https://user-images.githubusercontent.com/632942/36701613-4fbca042-1b11-11e8-8c0a-908e90e2e3ff.png)

You can see what changes will be necessary to the CLI specs. It's _a lot_ of manual work (or could be automated) but it'll cause a lot of diff noise, and make it much harder to edit the output of the specs in the future. 

We (@jodosha and I) have talked about extracting the file generation commands into `hanami/cli`. If we did that, then we could test these exact CLI things, without repeating the shellcodes a bunch of times in this repo. We could even write a helper to strip the shellcodes, if we wanted.

Thoughts? @jodosha @hanami/core? 