### PR TITLE
Restrict shotgun gem in new projects' Gemfiles to working platforms

### DIFF
--- a/lib/hanami/cli/commands/new/Gemfile.erb
+++ b/lib/hanami/cli/commands/new/Gemfile.erb
@@ -35,7 +35,7 @@ gem 'haml'
 group :development do
   # Code reloading
   # See: http://hanamirb.org/guides/projects/code-reloading
-  gem 'shotgun'
+  gem 'shotgun', platforms: :ruby
 end
 
 <%- end -%>


### PR DESCRIPTION
This adds `"platforms: :ruby"` to the Shotgun gem's options in the Gemfile of newly created Hanami projects, so that Hanami will work out of the box on Windows and JRuby, rather than needing to remove that line from the Gemfile manually, or start the server with `--no-code-reloading` every time.

This fixes the second issue described in https://github.com/hanami/hanami/issues/726, which I just ran into.

If this is accepted, it'd also make sense to update http://hanamirb.org/guides/projects/code-reloading/ at some point - maybe after a version with the change is released?