### PR TITLE
Raise meaningful error when trying to access session/flash without enabled sessions

### DIFF
--- a/lib/hanami/frameworks.rb
+++ b/lib/hanami/frameworks.rb
@@ -14,3 +14,9 @@ Hanami::Controller.configure do
     include Hanami::Action::Glue
   end
 end
+
+Hanami::Controller::MissingSessionError.class_eval do
+  def initialize(session_method)
+    super("To use `#{session_method}', please enable sessions for the current app.")
+  end
+end

--- a/spec/integration/sessions_spec.rb
+++ b/spec/integration/sessions_spec.rb
@@ -64,6 +64,52 @@ RSpec.describe "Sessions", type: :integration do
     end
   end
 
+  context "when sessions aren't enabled" do
+    it "raises error when trying to use `session'" do
+      with_project do
+        generate "action web home#index --url=/"
+
+        rewrite "apps/web/controllers/home/index.rb", <<-EOF
+module Web::Controllers::Home
+  class Index
+    include Web::Action
+
+    def call(params)
+      self.body = session[:foo]
+    end
+  end
+end
+EOF
+        server do
+          visit "/"
+          expect(page).to have_content("To use `session', please enable sessions for the current app.")
+        end
+      end
+    end
+
+    it "raises error when trying to use `flash'" do
+      with_project do
+        generate "action web home#index --url=/"
+
+        rewrite "apps/web/controllers/home/index.rb", <<-EOF
+module Web::Controllers::Home
+  class Index
+    include Web::Action
+
+    def call(params)
+      self.body = flash[:notice]
+    end
+  end
+end
+EOF
+        server do
+          visit "/"
+          expect(page).to have_content("To use `flash', please enable sessions for the current app.")
+        end
+      end
+    end
+  end
+
   private
 
   def prepare


### PR DESCRIPTION
It prints one of the following error messages, if a dev tries to access `session` or `flash` from an action, without having enabled sessions for that app.

```
To use `session', please enable sessions for the current app.
```

```
To use `flash', please enable sessions for the current app.
```

---

Closes https://github.com/hanami/hanami/issues/859
Ref https://github.com/hanami/controller/pull/250