### PR TITLE
Generate `/controller/action` routes for non-RESTful actions.

### DIFF
--- a/lib/hanami/cli/commands/generate/action.rb
+++ b/lib/hanami/cli/commands/generate/action.rb
@@ -200,17 +200,19 @@ module Hanami
           # @since 1.1.0
           # @api private
           RESOURCEFUL_ROUTE_URL_SUFFIXES = {
-            'show'    => '/:id',
-            'update'  => '/:id',
-            'destroy' => '/:id',
+            'index'   => '',
             'new'     => '/new',
-            'edit'    => '/:id/edit'
+            'create'  => '',
+            'edit'    => '/:id/edit',
+            'update'  => '/:id',
+            'show'    => '/:id',
+            'destroy' => '/:id'
           }.freeze
 
           # @since 1.1.0
           # @api private
           def route_resourceful_url_suffix(context)
-            RESOURCEFUL_ROUTE_URL_SUFFIXES.fetch(context.action) { "" }
+            RESOURCEFUL_ROUTE_URL_SUFFIXES.fetch(context.action) { "/#{context.action}" }
           end
 
           # @since 1.1.0

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -90,6 +90,17 @@ END
       end
     end
 
+    it "generates non-RESTful actions" do
+      with_project do
+        run_command "hanami generate action web sessions#sign_out"
+
+        #
+        # apps/web/config/routes.rb
+        #
+        expect('apps/web/config/routes.rb').to have_file_content(%r{get '/sessions/sign_out', to: 'sessions#sign_out'})
+      end
+    end
+
     it "fails with missing arguments" do
       with_project('bookshelf_generate_action_without_args') do
         output = <<-OUT


### PR DESCRIPTION
RESTful actions have their suffix conventions. Given the `books` resource here's the expected URLs:

```
hanami generate action web books#index => GET /books
hanami generate action web books#new => GET /books/new
hanami generate action web books#create => POST /books
hanami generate action web books#show => GET /books/:id
hanami generate action web books#edit => GET /books/:id/edit
hanami generate action web books#update => PUT /books/:id
hanami generate action web books#destroy => DELETE /books/:id
```

---

Non-RESTful actions, used to have unexpected route generation:

```
hanami generate action web books#on_sale => GET /books
```

As you can see, this overlaps with `index` URL.

---

This PR aims to enhance the route generation with the following change:

```
hanami generate action web books#on_sale => GET /books/on_sale
```

---

Closes #901 