### PR TITLE
Add missing argument to Dotenv::Parser call

### DIFF
--- a/lib/hanami/env.rb
+++ b/lib/hanami/env.rb
@@ -56,7 +56,8 @@ module Hanami
       return unless defined?(Dotenv::Parser)
 
       contents = ::File.open(path, "rb:bom|utf-8", &:read)
-      parsed   = Dotenv::Parser.call(contents)
+      is_load  = false
+      parsed   = Dotenv::Parser.call(contents, is_load)
 
       parsed.each do |k, v|
         next if @env.has_key?(k)


### PR DESCRIPTION
Dotenv 2.3 release has broken `hanami server` as mentioned in #924 I've added missing argument to parser call to get `hanami server` working again.