### PR TITLE
Generate new projects with dotenv ~> 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ end
 gem 'sass',          require: false
 gem 'coffee-script', require: false
 
-gem 'dotenv',    '~> 2.0', require: false
+gem 'dotenv',    '~> 2.4', require: false
 gem 'shotgun',   '~> 0.9', require: false
 
 gem 'hanami-devtools', require: false, git: 'https://github.com/hanami/devtools.git'

--- a/lib/hanami/cli/commands/new/Gemfile.erb
+++ b/lib/hanami/cli/commands/new/Gemfile.erb
@@ -41,7 +41,7 @@ end
 
 <%- end -%>
 group :test, :development do
-  gem 'dotenv', '~> 2.0'
+  gem 'dotenv', '~> 2.4'
 end
 
 group :test do

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -137,7 +137,7 @@ group :development do
 end
 
 group :test, :development do
-  gem 'dotenv', '~> 2.0'
+  gem 'dotenv', '~> 2.4'
 end
 
 group :test do
@@ -162,7 +162,7 @@ gem 'hanami-model', '~> 1.2'
 gem 'jdbc-sqlite3'
 
 group :test, :development do
-  gem 'dotenv', '~> 2.0'
+  gem 'dotenv', '~> 2.4'
 end
 
 group :test do


### PR DESCRIPTION
`dotenv-2.3.0` introduced a change that breaks `hanami server` command, if `dotenv` is bundled (development and test envs).

In the meantime `dotenv-2.4.0` was released to fix that problem. To be clear, that version of `dotenv` broke a lot of apps, so their release is not specifically for Hanami.

---

This PR bumps the minimum version of `dotenv` to `~> 2.4`. In this way, new generated apps, won't run into the same problem. See https://github.com/hanami/hanami/issues/924

---

Fixes https://github.com/hanami/hanami/issues/924
Ref https://github.com/hanami/hanami/pull/925