### PR TITLE
Remove broken Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Build Status](https://secure.travis-ci.org/hanami/hanami.svg?branch=master)](http://travis-ci.org/hanami/hanami?branch=master)
 [![Coverage](https://coveralls.io/repos/hanami/hanami/badge.svg?branch=master)](https://coveralls.io/r/hanami/hanami)
 [![Code Climate](https://codeclimate.com/github/hanami/hanami.svg)](https://codeclimate.com/github/hanami/hanami)
-[![Dependencies](https://gemnasium.com/hanami/hanami.svg)](https://gemnasium.com/hanami/hanami)
 [![Inline docs](http://inch-ci.org/github/hanami/hanami.svg)](http://inch-ci.org/github/hanami/hanami)
 
 # Hanami :cherry_blossom:


### PR DESCRIPTION
The Gemnasium badge is broken since they got bought by GitLab. This is explained in slightly more detail [here](https://docs.gitlab.com/ee/user/project/import/gemnasium.html#what-happened-to-my-badge)

This PR removes the broken badge until such a time that it can be updated or replace. 