### PR TITLE
Allow '.' as project name on new command

### DIFF
--- a/lib/hanami/cli/commands/new.rb
+++ b/lib/hanami/cli/commands/new.rb
@@ -282,14 +282,15 @@ module Hanami
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
         def call(project:, **options)
-          project         = Utils::String.underscore(project)
-          database_config = DatabaseConfig.new(options[:database], project)
+          project_name    = Utils::String.underscore(project)
+          project_name    = File.basename(Dir.pwd) if project == '.'
+          database_config = DatabaseConfig.new(options[:database], project_name)
           test_framework  = TestFramework.new(hanamirc, options[:test])
           template_engine = TemplateEngine.new(hanamirc, options[:template])
-          options[:project] = project
+          options[:project] = project_name
 
           context = Context.new(
-            project: project,
+            project: project_name,
             database: database_config.type,
             database_config_hash: database_config.to_hash,
             database_config: database_config,
@@ -302,7 +303,7 @@ module Hanami
             hanami_model_version: '~> 1.2',
             code_reloading: code_reloading?,
             hanami_version: hanami_version,
-            project_module: Utils::String.classify(project),
+            project_module: Utils::String.classify(project_name),
             options: options
           )
 


### PR DESCRIPTION
On current hanami implementation, `bundle exec  hanami new .` generate application files incorrectly and results is as follow.
```
...
      create  lib/..rb
      create  public/.gitkeep
      create  config/initializers/.gitkeep
      create  lib/./entities/.gitkeep
      create  lib/./repositories/.gitkeep
      create  lib/./mailers/.gitkeep
      create  lib/./mailers/templates/.gitkeep
      create  spec/./entities/.gitkeep
      create  spec/./repositories/.gitkeep
      create  spec/./mailers/.gitkeep
...
```

`.` is interpreted as project name, but we intend '.' as current directory name.
So we want to current directory name as project name when executing `bundle exec hanami new .`.
On `Ruby on Rails`, this command(`bundle exec rails new .`) work correctly as we want.

This command is important, because we don't want to install gem in system global and we want to do it in local with bundler.

So we want to install and generate hanami application as follows.
1. `mkdir {project_directory}`
2. `cd {project_directory}`
3. `bundle init` and modify Gemfile to install `hanami`
4. `bundle install --path=vendor/bundle`
5. `bundle exec hanami new .`
6. `bundle install`

This pull request solve them.
If we put '.', current directory name is interpreted as project name.