### PR TITLE
Unify logic for env prepending in app generator

### DIFF
--- a/lib/hanami/cli/commands/generate/app.rb
+++ b/lib/hanami/cli/commands/generate/app.rb
@@ -208,18 +208,20 @@ module Hanami
           # @since 1.1.0
           # @api private
           def append_development_http_session_secret(context)
-            content     = %(#{context.app.upcase}_SESSIONS_SECRET="#{project.app_sessions_secret}")
-            destination = project.env(context, "development")
-
-            files.append(destination, content)
-            say(:append, destination)
+            append_env_to_http_session_secret(context, "development")
           end
 
           # @since 1.1.0
           # @api private
           def append_test_http_session_secret(context)
+            append_env_to_http_session_secret(context, "test")
+          end
+
+          private
+
+          def append_env_to_http_session_secret(context, env)
             content     = %(#{context.app.upcase}_SESSIONS_SECRET="#{project.app_sessions_secret}")
-            destination = project.env(context, "test")
+            destination = project.env(context, env)
 
             files.append(destination, content)
             say(:append, destination)


### PR DESCRIPTION
This duplication was referenced by codeclimate

https://codeclimate.com/github/hanami/hanami/issues?category=duplication&engine_name%5B%5D=structure&engine_name%5B%5D=duplication

A new method encapsulating the env prepending logic was added in order to provide more clarity to the code.
