### PR TITLE
Allow to use logger not based on ::Logger class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ gem 'shotgun',   '~> 0.9', require: false
 
 gem 'hanami-devtools', require: false, git: 'https://github.com/hanami/devtools.git'
 gem 'hanami-webconsole', require: false, git: 'https://github.com/hanami/webconsole.git'
-gem 'semantic_logger'
 
 # https://github.com/hanami/hanami/issues/893
 gem 'builder'

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'shotgun',   '~> 0.9', require: false
 
 gem 'hanami-devtools', require: false, git: 'https://github.com/hanami/devtools.git'
 gem 'hanami-webconsole', require: false, git: 'https://github.com/hanami/webconsole.git'
+gem 'semantic_logger'
 
 # https://github.com/hanami/hanami/issues/893
 gem 'builder'

--- a/lib/hanami/components/component.rb
+++ b/lib/hanami/components/component.rb
@@ -46,6 +46,12 @@ module Hanami
 
       private
 
+      # @since x.x.x
+      # @api private
+      #
+      # @see Hanami::Component#logger_interface?
+      LOGGER_METHODS = %i[info warn debug]
+
       # Component name
       #
       # @return [String]
@@ -162,6 +168,14 @@ module Hanami
       # @see Hanami::Components.resolved
       def resolved(name, value = nil, &blk)
         Components.resolved(name, value, &blk)
+      end
+
+      # Check that instance has logger interfaces (#info, #warn and #debug)
+      #
+      # @since x.x.x
+      # @api private
+      def logger_interface?(instance)
+        LOGGER_METHODS.all? { |method| instance.respond_to?(method) }
       end
     end
   end

--- a/lib/hanami/components/components.rb
+++ b/lib/hanami/components/components.rb
@@ -29,7 +29,7 @@ module Hanami
 
       resolve do |configuration|
         if configuration.logger.is_a?(Array)
-          if configuration.logger.first.is_a?(::Logger)
+          if logger_interface?(configuration.logger.first)
             configuration.logger.first
           else
             Hanami::Logger.new(Hanami.environment.project_name, *configuration.logger)

--- a/spec/isolation/components/logger/with_custom_logger_spec.rb
+++ b/spec/isolation/components/logger/with_custom_logger_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "Components: logger", type: :integration do
     end
   end
 
-  it "allows loggers not base on ::Logger" do
+  it "allows loggers not based on ::Logger" do
     with_project do
-      replace 'config/environment.rb', 'logger ', "logger SemanticLogger['test']"
+      replace 'config/environment.rb', 'logger ', "logger SemanticLogger.new"
 
       require Pathname.new(Dir.pwd).join("config", "environment")
       Hanami::Components.resolve('logger')
 
-      expect(Hanami.logger.class).to eq(SemanticLogger::Logger)
+      expect(Hanami.logger.class).to eq(SemanticLogger)
     end
   end
 end

--- a/spec/isolation/components/logger/with_custom_logger_spec.rb
+++ b/spec/isolation/components/logger/with_custom_logger_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe "Components: logger", type: :integration do
       expect(Hanami.logger.class).to eq(::Logger)
     end
   end
+
+  it "allows loggers not base on ::Logger" do
+    with_project do
+      replace 'config/environment.rb', 'logger ', "logger SemanticLogger['test']"
+
+      require Pathname.new(Dir.pwd).join("config", "environment")
+      Hanami::Components.resolve('logger')
+
+      expect(Hanami.logger.class).to eq(SemanticLogger::Logger)
+    end
+  end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -14,3 +14,20 @@ module ApplicationConfigurationTesting
   class Application < Hanami::Application
   end
 end
+
+# Please use this mock logger only for:
+#
+#   * spec/isolation/components/logger/with_custom_logger_spec.rb
+class SemanticLogger
+  def initialize(*)
+  end
+
+  def info(*)
+  end
+
+  def warn(*)
+  end
+
+  def debug(*)
+  end
+end


### PR DESCRIPTION
## What
Allow to use loggers which not based on `::Logger` instance. For example [semantic_logger](https://github.com/rocketjob/semantic_logger)

## Why
Now we check only `::Logger` instance, I think it will be better check logger interface too, something like `#info`, `#debug` and `#warn` methods. In this case we can register any logger types without any problems.

## How
Just create a list of base logger methods and check that instance allow to call each method