### PR TITLE
Add support for local .env files

### DIFF
--- a/lib/hanami/cli/commands/new/gitignore.erb
+++ b/lib/hanami/cli/commands/new/gitignore.erb
@@ -1,2 +1,3 @@
 /public/assets*
 /tmp
+.env.*.local

--- a/lib/hanami/cli/commands/new/gitignore_with_sqlite.erb
+++ b/lib/hanami/cli/commands/new/gitignore_with_sqlite.erb
@@ -1,3 +1,4 @@
 /db/*.sqlite
 /public/assets*
 /tmp
+.env.*.local

--- a/lib/hanami/env.rb
+++ b/lib/hanami/env.rb
@@ -59,7 +59,7 @@ module Hanami
       parsed   = Dotenv::Parser.call(contents)
 
       parsed.each do |k, v|
-        next if @env.has_key?(k)
+        next if @env.key?(k)
 
         @env[k] = v
       end

--- a/lib/hanami/environment.rb
+++ b/lib/hanami/environment.rb
@@ -487,10 +487,17 @@ module Hanami
     # @since 0.2.0
     # @api private
     def set_application_env_vars!
-      dotenv = root.join(DEFAULT_DOTENV_ENV % environment)
-      return unless dotenv.exist?
+      default = root.join(DEFAULT_DOTENV_ENV % environment)
 
-      env.load!(dotenv)
+      dotenvs = [root.join("#{default}.local"), default].compact
+
+      dotenvs.each do |dotenv|
+        next unless dotenv.exist?
+
+        env.load!(dotenv)
+      end
+
+      nil
     end
 
     # @since 0.1.0

--- a/spec/integration/cli/new/database_spec.rb
+++ b/spec/integration/cli/new/database_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe "hanami new", type: :integration do
           expect(".gitignore").to have_file_content <<-END
 /public/assets*
 /tmp
+.env.*.local
           END
         end
       end

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -357,6 +357,7 @@ END
 /db/*.sqlite
 /public/assets*
 /tmp
+.env.*.local
 END
 
       #

--- a/spec/support/fixtures/dotenv-local/.env.development
+++ b/spec/support/fixtures/dotenv-local/.env.development
@@ -1,0 +1,3 @@
+HANAMI_PORT=42
+BAZ="yes"
+WAT="true"

--- a/spec/support/fixtures/dotenv-local/.env.development.local
+++ b/spec/support/fixtures/dotenv-local/.env.development.local
@@ -1,0 +1,1 @@
+HANAMI_PORT=43

--- a/spec/support/shared_examples/cli/new.rb
+++ b/spec/support/shared_examples/cli/new.rb
@@ -87,6 +87,7 @@ END
 /db/*.sqlite
 /public/assets*
 /tmp
+.env.*.local
 END
     end
   end

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -60,7 +60,32 @@ RSpec.describe Hanami::Environment do
       end
 
       context 'with same ENV variable set in ENV and .env.development' do
-        let(:env) { {'WAT' => 'false'} }
+        let(:env) { { 'WAT' => 'false' } }
+
+        it 'sets manual set ENV vars over .env.development set' do
+          with_directory('spec/support/fixtures/dotenv') do
+            described_class.new(env: env)
+
+            expect(env['HANAMI_PORT']).to eq('42')
+
+            expect(env['BAZ']).to eq('yes')
+            expect(env['WAT']).to eq('false')
+          end
+        end
+
+        context "with a local env file" do
+          it "prefers variables from the .env.development.local" do
+            with_directory('spec/support/fixtures/dotenv-local') do
+              described_class.new(env: env)
+
+              expect(env['HANAMI_PORT']).to eq('43')
+            end
+          end
+        end
+      end
+
+      context 'with same ENV variable set in ENV and .env.development' do
+        let(:env) { { 'WAT' => 'false' } }
 
         it 'sets manual set ENV vars over .env.development set' do
           with_directory('spec/support/fixtures/dotenv') do


### PR DESCRIPTION
One feature that I love from `dotenv-rails` is the ability to create a `.env.development.local` file which will take precedence over the `.env.development` file.

The main use case I have for this right now is being able to specify a custom `CAPYBARA_DRIVER` so I can run the specs on my machine without starting a browser. Since my window manager is works differently than my other co-workers, specs fail on my machine since the window resizing works differently. Thus, specifying a local env configuration is the perfect solution for me.

Let me know if you would like anything changed, I would love to see this merged!

- Ian