### PR TITLE
Ensure to generate project with 'hanami new .'

### DIFF
--- a/lib/hanami/cli/commands/new.rb
+++ b/lib/hanami/cli/commands/new.rb
@@ -282,7 +282,9 @@ module Hanami
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
         def call(project:, **options)
-          project         = Utils::String.underscore(project)
+          project_name = project
+          pwd = ::File.basename(Dir.pwd) if project == "."
+          project         = Utils::String.underscore(pwd || project)
           database_config = DatabaseConfig.new(options[:database], project)
           test_framework  = TestFramework.new(hanamirc, options[:test])
           template_engine = TemplateEngine.new(hanamirc, options[:template])
@@ -308,7 +310,7 @@ module Hanami
 
           assert_project_name!(context)
 
-          directory = project_directory(project)
+          directory = project_directory(project_name, project)
           files.mkdir(directory)
 
           Dir.chdir(directory) do
@@ -532,8 +534,9 @@ module Hanami
 
         # @since 1.1.0
         # @api private
-        def project_directory(project)
-          @name == '.' ? '.' : project
+        def project_directory(project_name, project)
+          return Dir.pwd if project_name == '.'
+          project
         end
 
         # @since 1.1.0

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -786,6 +786,42 @@ END
     end
   end
 
+  context "with dot as project name" do
+    before do
+      root.mkpath
+    end
+
+    let(:root) { Pathname.new(Dir.pwd).join("tmp", "aruba", dir) }
+    let(:project) { "terrific_product" }
+    let(:dir) { "terrific product" }
+
+    it "generates project" do
+      cd(dir) do
+        run_command "hanami new ."
+      end
+
+      [
+        "create  lib/#{project}.rb",
+        "create  lib/#{project}/entities/.gitkeep",
+        "create  lib/#{project}/repositories/.gitkeep",
+        "create  lib/#{project}/mailers/.gitkeep",
+        "create  lib/#{project}/mailers/templates/.gitkeep",
+        "create  spec/#{project}/entities/.gitkeep",
+        "create  spec/#{project}/repositories/.gitkeep",
+        "create  spec/#{project}/mailers/.gitkeep"
+      ].each do |output|
+        expect(all_output).to match(/#{output}/)
+      end
+
+      within_project_directory(dir) do
+        #
+        # .hanamirc
+        #
+        expect('.hanamirc').to have_file_content %r{project=#{project}}
+      end
+    end
+  end
+
   context "with missing name" do
     it "fails" do
       output = <<-OUT


### PR DESCRIPTION
## Fix

Fixes #936 
Resumes #939 

## Manual testing

  1. Checkout this branch
  1. `mkdir -p "awesome project" && cd $_`
  1. `bundle exec hanami new .`
  1. Verify that `.hanamirc` has `project=awesome_project`
  1. Verify that `lib/awesome_project.rb` defines `AwesomeProject` module
  1. Verify that the specs of the _awesome project_ are passing with `bundle exec rake`