### PR TITLE
Fix concatenation of Pathname and String in CommonLogger

### DIFF
--- a/lib/hanami/common_logger.rb
+++ b/lib/hanami/common_logger.rb
@@ -58,7 +58,7 @@ module Hanami
         verb:    env[REQUEST_METHOD],
         status:  status.to_s[0..3],
         ip:      env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR],
-        path:    env[SCRIPT_NAME] + env[PATH_INFO],
+        path:    env[SCRIPT_NAME] + env[PATH_INFO].to_s,
         length:  length,
         params:  extract_params(env),
         elapsed: now - began_at


### PR DESCRIPTION
If `env[PATH_INFO]` is not converted to string, it always logs following error to stdout every request:

```
Read error: #<TypeError: no implicit conversion of Pathname into String>
```