### PR TITLE
When used the body_parses configuration, we will mount the new BodyParser middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'i18n'
 
 gem 'hanami-utils',       '~> 1.3.beta', require: false, git: 'https://github.com/hanami/utils.git',       branch: 'develop'
 gem 'hanami-validations', '~> 1.3.beta', require: false, git: 'https://github.com/hanami/validations.git', branch: 'develop'
-gem 'hanami-router',      '~> 1.3.beta', require: false, git: 'https://github.com/hanami/router.git',      branch: 'develop'
+gem 'hanami-router',      '~> 1.3.beta', require: false, git: 'https://github.com/hanami/router.git',      branch: 'change-middleware-to-be-a-class'
 gem 'hanami-controller',  '~> 1.3.beta', require: false, git: 'https://github.com/hanami/controller.git',  branch: 'develop'
 gem 'hanami-view',        '~> 1.3.beta', require: false, git: 'https://github.com/hanami/view.git',        branch: 'develop'
 gem 'hanami-model',       '~> 1.3.beta', require: false, git: 'https://github.com/hanami/model.git',       branch: 'develop'

--- a/lib/hanami/components/app/routes.rb
+++ b/lib/hanami/components/app/routes.rb
@@ -1,5 +1,6 @@
 require 'hanami/routes'
 require 'hanami/routing/default'
+require 'hanami/middleware/body_parser'
 
 module Hanami
   # @since 0.9.0
@@ -34,6 +35,7 @@ module Hanami
         # @api private
         def self.application_routes(app) # rubocop:disable Metrics/MethodLength
           config      = app.configuration
+          set_body_parser_middleware(config)
           namespace   = app.namespace
 
           resolver    = Hanami::Routing::EndpointResolver.new(pattern: config.controller_pattern, namespace: namespace)
@@ -42,7 +44,6 @@ module Hanami
           Hanami::Router.new(
             resolver:    resolver,
             default_app: default_app,
-            parsers:     config.body_parsers,
             scheme:      config.scheme,
             host:        config.host,
             port:        config.port,
@@ -50,6 +51,14 @@ module Hanami
             force_ssl:   config.force_ssl,
             &config.routes
           )
+        end
+
+        # @since x.x.x
+        # @api private
+        def self.set_body_parser_middleware(config) # rubocop:disable Metrics/MethodLength
+          return unless config.body_parsers.any?
+          body_parsers = config.body_parsers
+          config.middleware.use Hanami::Middleware::BodyParser, body_parsers
         end
       end
     end

--- a/spec/isolation/middleware/include_body_parser_middleware_spec.rb
+++ b/spec/isolation/middleware/include_body_parser_middleware_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Hanami::Middleware, type: :integration do
+  describe "#load!" do
+    it "include the BodyParser Middleware when using the body_parses configuration" do
+      with_project do
+        generate "action web home#index"
+
+        replace "apps/web/application.rb", "configure do", <<-END
+configure do
+  body_parsers :json
+END
+
+        require Pathname.new(Dir.pwd).join("config", "environment")
+        Hanami::Components.resolve('all')
+
+        middleware = Web::Application.new.__send__(:middleware)
+
+        expect(middleware.__send__(:stack)).to include([Hanami::Middleware::BodyParser, [[:json]], nil])
+      end
+    end
+  end
+end


### PR DESCRIPTION
@jodosha here is the PR that remove the pass of `parsers` to the router, removing the warning in the last beta release.

Also, it replaces the parsers with the new `BodyParser` middleware, there is a dependency on another PR in the router repo https://github.com/hanami/router/pull/178

This is my first PR in the project, so any comments will be highly appreciated 🎉 🎉 