### PR TITLE
Change Hanami::Middleware to Hanami::MiddlewareStack

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -191,12 +191,12 @@ module Hanami
 
     # Rack middleware stack
     #
-    # @return [Hanami::Middleware] the middleware stack
+    # @return [Hanami::MiddlewareStack] the middleware stack
     #
     # @since 0.1.0
     # @api private
     #
-    # @see Hanami::Middleware
+    # @see Hanami::MiddlewareStack
     attr_reader :middleware
   end
 end

--- a/lib/hanami/application_configuration.rb
+++ b/lib/hanami/application_configuration.rb
@@ -1,6 +1,6 @@
 require 'hanami/utils/kernel'
 require 'hanami/environment'
-require 'hanami/middleware'
+require 'hanami/middleware_stack'
 require 'hanami/config/cookies'
 require 'hanami/config/framework_configuration'
 require 'hanami/config/load_paths'
@@ -670,7 +670,7 @@ module Hanami
     # @since 0.2.0
     #
     # @see http://rdoc.info/gems/rack/Rack/Static
-    # @see Hanami::Middleware#use
+    # @see Hanami::MiddlewareStack#use
     #
     # @example
     #   require 'hanami'
@@ -684,7 +684,7 @@ module Hanami
     #     end
     #   end
     def middleware
-      @middleware ||= Hanami::Middleware.new(self)
+      @middleware ||= Hanami::MiddlewareStack.new(self)
     end
 
     # Adapter configuration.

--- a/lib/hanami/middleware_stack.rb
+++ b/lib/hanami/middleware_stack.rb
@@ -6,12 +6,12 @@ module Hanami
   #
   # @since 0.1.0
   # @api private
-  class Middleware
+  class MiddlewareStack
     # Instantiate a middleware stack
     #
     # @param configuration [Hanami::ApplicationConfiguration] the application's configuration
     #
-    # @return [Hanami::Middleware] the new stack
+    # @return [Hanami::MiddlewareStack] the new stack
     #
     # @since 0.1.0
     # @api private
@@ -25,7 +25,7 @@ module Hanami
 
     # Load the middleware stack
     #
-    # @return [Hanami::Middleware] the loaded middleware stack
+    # @return [Hanami::MiddlewareStack] the loaded middleware stack
     #
     # @since 0.2.0
     # @api private
@@ -62,7 +62,7 @@ module Hanami
     #
     # @since 0.2.0
     #
-    # @see Hanami::Middleware#prepend
+    # @see Hanami::MiddlewareStack#prepend
     #
     # @example
     #   # apps/web/application.rb
@@ -89,7 +89,7 @@ module Hanami
     #
     # @since 0.6.0
     #
-    # @see Hanami::Middleware#use
+    # @see Hanami::MiddlewareStack#use
     #
     # @example
     #   # apps/web/application.rb

--- a/spec/isolation/middleware/ensure_unique_stack_spec.rb
+++ b/spec/isolation/middleware/ensure_unique_stack_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Hanami::Middleware, type: :integration do
+RSpec.describe Hanami::MiddlewareStack, type: :integration do
   describe "#load!" do
     it "loads the middleware stack without duplicates" do
       with_project do


### PR DESCRIPTION
@jodosha

Following your suggestion on https://github.com/hanami/router/pull/178#pullrequestreview-155811188 I changed the name from `Hanami::Middleware` to `Hanami::MiddlewareStack`

I did not go with your initial suggestion of `Hanami::Config::Middleware` because we already have `Hanami::Configuration::Middleware` and I think it would create more confusion.

BTW to be sure I understood the reason why there are two different `Middleware` classes. `Hanami::Configuration::Middleware` is responsible for handing middleware that applies to all applications and `Hanami::Middleware` is just responsible for each application middleware stack.

If that last statement is correct, do you see useful to have just one `Hanami::Configuration::Middleware` class that would handle all the logic and depending on where you call it stores the middleware for the whole application or each application?
