### PR TITLE
use <= instead of ancestors.include? for performance reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cd bookshelf && bundle
 bundle exec hanami server # visit http://localhost:2300
 ```
 
-Please follow along with the [Getting Started guide](http://hanamirb.org/guides/getting-started).
+Please follow along with the [Getting Started guide](http://hanamirb.org/guides/1.2/getting-started/).
 
 ## Donations
 

--- a/lib/hanami/components/routes_inspector.rb
+++ b/lib/hanami/components/routes_inspector.rb
@@ -51,7 +51,7 @@ module Hanami
       # @since 0.9.0
       # @api private
       def hanami_app?(klass)
-        klass.ancestors.include?(Hanami::Application)
+        klass <= Hanami::Application
       end
 
       # @since 0.9.0

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -138,7 +138,7 @@ module Hanami
     # @api private
     def apps
       mounted.each_pair do |klass, app|
-        yield(app) if klass.ancestors.include?(Hanami::Application)
+        yield(app) if klass <= Hanami::Application
       end
     end
 


### PR DESCRIPTION
@jodosha 

I was reading https://github.com/JuanitoFatas/fast-ruby I notice an interesting comment https://github.com/JuanitoFatas/fast-ruby/blob/master/code/general/inheritance-check.rb#L12-L14

I get to check and they were still there, so I decided to change it ❤️ 💎 

