### PR TITLE
Only pass app body parsers options to internal router if user enables them

### DIFF
--- a/lib/hanami/components/app/routes.rb
+++ b/lib/hanami/components/app/routes.rb
@@ -39,17 +39,19 @@ module Hanami
           resolver    = Hanami::Routing::EndpointResolver.new(pattern: config.controller_pattern, namespace: namespace)
           default_app = Hanami::Routing::Default.new
 
-          Hanami::Router.new(
+          options = {
             resolver:    resolver,
             default_app: default_app,
-            parsers:     config.body_parsers,
             scheme:      config.scheme,
             host:        config.host,
             port:        config.port,
             prefix:      config.path_prefix,
-            force_ssl:   config.force_ssl,
-            &config.routes
-          )
+            force_ssl:   config.force_ssl
+          }
+
+          options[:parsers] = config.body_parsers if config.body_parsers.any?
+
+          Hanami::Router.new(options, &config.routes)
         end
       end
     end


### PR DESCRIPTION
@jodosha 

I decided to close the old PR since the title and the commit history did not make much sense.

After your explanation the reason for the code change seems pretty obvious, next time I will use more the rational part of the brain 😆 

Hope this helps ❤️ 💎 