### PR TITLE
Generate correct syntax for layout unit tests

### DIFF
--- a/lib/hanami/cli/commands/generate/app/layout_spec.minitest.erb
+++ b/lib/hanami/cli/commands/generate/app/layout_spec.minitest.erb
@@ -1,9 +1,8 @@
 require "spec_helper"
 
 describe <%= app.classify %>::Views::ApplicationLayout do
-  let(:layout)   { <%= app.classify %>::Views::ApplicationLayout.new(template, {}) }
+  let(:layout)   { <%= app.classify %>::Views::ApplicationLayout.new({ format: :html }, "contents") }
   let(:rendered) { layout.render }
-  let(:template) { Hanami::View::Template.new('apps/<%= app %>/templates/application.html.<%= template %>') }
 
   it 'contains application name' do
     rendered.must_include('<%= app.classify %>')

--- a/lib/hanami/cli/commands/generate/app/layout_spec.rspec.erb
+++ b/lib/hanami/cli/commands/generate/app/layout_spec.rspec.erb
@@ -1,9 +1,8 @@
 require "spec_helper"
 
 RSpec.describe <%= app.classify %>::Views::ApplicationLayout, type: :view do
-  let(:layout)   { <%= app.classify %>::Views::ApplicationLayout.new(template, {}) }
+  let(:layout)   { <%= app.classify %>::Views::ApplicationLayout.new({ format: :html }, "contents") }
   let(:rendered) { layout.render }
-  let(:template) { Hanami::View::Template.new('apps/<%= app %>/templates/application.html.<%= template %>') }
 
   it 'contains application name' do
     expect(rendered).to include('<%= app.classify %>')

--- a/spec/integration/cli/generate/app_spec.rb
+++ b/spec/integration/cli/generate/app_spec.rb
@@ -112,7 +112,7 @@ END
           #
           # spec/admin/views/application_layout_spec.rb
           #
-          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{apps/admin/templates/application.html.erb})
+          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{Admin::Views::ApplicationLayout})
         end
       end
     end # erb
@@ -144,7 +144,7 @@ END
           #
           # spec/admin/views/application_layout_spec.rb
           #
-          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{apps/admin/templates/application.html.haml})
+          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{Admin::Views::ApplicationLayout})
         end
       end
     end # haml
@@ -177,7 +177,7 @@ END
           #
           # spec/admin/views/application_layout_spec.rb
           #
-          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{apps/admin/templates/application.html.slim})
+          expect("spec/admin/views/application_layout_spec.rb").to have_file_content(%r{Admin::Views::ApplicationLayout})
         end
       end
     end # slim

--- a/spec/integration/cli/new/test_spec.rb
+++ b/spec/integration/cli/new/test_spec.rb
@@ -54,9 +54,8 @@ END
 require "spec_helper"
 
 describe Web::Views::ApplicationLayout do
-  let(:layout)   { Web::Views::ApplicationLayout.new(template, {}) }
+  let(:layout)   { Web::Views::ApplicationLayout.new({ format: :html }, "contents") }
   let(:rendered) { layout.render }
-  let(:template) { Hanami::View::Template.new('apps/web/templates/application.html.erb') }
 
   it 'contains application name' do
     rendered.must_include('Web')
@@ -242,9 +241,8 @@ END
 require "spec_helper"
 
 RSpec.describe Web::Views::ApplicationLayout, type: :view do
-  let(:layout)   { Web::Views::ApplicationLayout.new(template, {}) }
+  let(:layout)   { Web::Views::ApplicationLayout.new({ format: :html }, "contents") }
   let(:rendered) { layout.render }
-  let(:template) { Hanami::View::Template.new('apps/web/templates/application.html.erb') }
 
   it 'contains application name' do
     expect(rendered).to include('Web')


### PR DESCRIPTION
## Problem

**TL;DR:** Until Hanami v1.2.0 we generate a wrong spec for layout unit tests.

This is a followup for https://github.com/hanami/view/pull/156, please read the complete problem description over there.

## Fix

This PR fixes the problem, by generating a new syntax for layout unit tests:

```ruby
require "spec_helper"

RSpec.describe Web::Views::ApplicationLayout, type: :view do
  let(:layout)   { Web::Views::ApplicationLayout.new({ format: :html }, "contents") }
  let(:rendered) { layout.render }

  it "contains application name" do
    expect(rendered).to include("Web")
  end
end
```

It's worth noting that the old, wrong, syntax will still work for backward compatibility. This backward compatible strategy has been implemented by https://github.com/hanami/view/pull/156.