### PR TITLE
Remove force_ssl from new app templates

### DIFF
--- a/lib/hanami/cli/commands/generate/app/application.erb
+++ b/lib/hanami/cli/commands/generate/app/application.erb
@@ -105,11 +105,6 @@ module <%= app.classify %>
       #
       # body_parsers :json
 
-      # When it's true and the router receives a non-encrypted request (http),
-      # it redirects to the secure equivalent (https). Disabled by default.
-      #
-      # force_ssl true
-
       ##
       # TEMPLATES
       #

--- a/spec/integration/cli/new_spec.rb
+++ b/spec/integration/cli/new_spec.rb
@@ -566,11 +566,6 @@ module Web
       #
       # body_parsers :json
 
-      # When it's true and the router receives a non-encrypted request (http),
-      # it redirects to the secure equivalent (https). Disabled by default.
-      #
-      # force_ssl true
-
       ##
       # TEMPLATES
       #

--- a/spec/integration/security/force_ssl_spec.rb
+++ b/spec/integration/security/force_ssl_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "force SSL", type: :integration do
     with_project(project, server: :puma) do
       generate "action web home#index --url=/"
 
-      replace "apps/web/application.rb", "# force_ssl true", "force_ssl true"
+      inject_line_after "apps/web/application.rb", "configure do", "force_ssl true"
 
       RSpec::Support::Env['HANAMI_ENV']   = 'production'
       RSpec::Support::Env['DATABASE_URL'] = "sqlite://#{Pathname.new('db').join('bookshelf.sqlite')}"

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -141,11 +141,6 @@ module #{app_name}
       #
       # body_parsers :json
 
-      # When it's true and the router receives a non-encrypted request (http),
-      # it redirects to the secure equivalent (https). Disabled by default.
-      #
-      # force_ssl true
-
       ##
       # TEMPLATES
       #


### PR DESCRIPTION
The use of this configuration is deprecated as of v1.3.0

Closes #971