### PR TITLE
Replace sass -> sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ if RUBY_DESCRIPTION =~ /linux/
 end
 
 # `hanami assets` integration tests
-gem 'sass',          require: false
+gem 'sassc',         require: false
 gem 'coffee-script', require: false
 
 gem 'dotenv',    '~> 2.4', require: false

--- a/spec/integration/assets/serve_spec.rb
+++ b/spec/integration/assets/serve_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "assets", type: :integration do
     it "compiles and serves assets in development mode" do
       project = "bookshelf_serve_assets"
 
-      with_project(project, gems: ['sass']) do
+      with_project(project, gems: ['sassc']) do
         generate "action web home#index --url=/"
 
         write "apps/web/assets/javascripts/application.css.sass", <<-EOF

--- a/spec/integration/cli/assets/precompile_spec.rb
+++ b/spec/integration/cli/assets/precompile_spec.rb
@@ -3,7 +3,7 @@ require 'json'
 RSpec.describe 'hanami assets', type: :integration do
   describe 'precompile' do
     it "precompiles assets" do
-      gems = ['sass', 'coffee-script']
+      gems = ['sassc', 'coffee-script']
 
       Platform.match do
         os(:linux).engine(:ruby)  { gems.push('therubyracer') }


### PR DESCRIPTION
This PR replaces `sass` -> `sassc` as the former is deprecated and will go unmaintained later this year.

Closes #955 once merged.