### PR TITLE
Rename Hanami.application => application_class, and app => application

### DIFF
--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -13,36 +13,40 @@ module Hanami
 
   @_mutex = Mutex.new
 
+  def self.application_class
+    @_mutex.synchronize do
+      raise "Hanami.application_class not configured" unless defined?(@_application_class)
+
+      @_application_class
+    end
+  end
+
+  def self.application_class=(klass)
+    @_mutex.synchronize do
+      raise "Hanami.application_class already configured" if defined?(@_application_class)
+
+      @_application_class = klass unless klass.name.nil?
+    end
+  end
+
   def self.application
     @_mutex.synchronize do
-      raise "Hanami application not configured" unless defined?(@_application)
+      raise "Hanami.application not configured" unless defined?(@_application)
 
       @_application
     end
   end
 
-  def self.application=(app)
+  def self.application=(application)
     @_mutex.synchronize do
-      raise "Hanami application already configured" if defined?(@_application)
+      raise "Hanami.application already configured" if defined?(@_application)
 
-      @_application = app unless app.name.nil?
+      @_application = application
     end
   end
 
-  def self.app
-    @_mutex.synchronize do
-      raise "Hanami.app not configured" unless defined?(@_app)
-
-      @_app
-    end
-  end
-
-  def self.app=(app)
-    @_mutex.synchronize do
-      raise "Hanami.app already configured" if defined?(@_app)
-
-      @_app = app
-    end
+  class << self
+    alias_method :app, :application
   end
 
   def self.root
@@ -66,6 +70,6 @@ module Hanami
     end
 
     Container.finalize!
-    self.app = application.new
+    self.application = application_class.new
   end
 end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -11,9 +11,9 @@ module Hanami
   class Application
     @_mutex = Mutex.new
 
-    def self.inherited(app)
+    def self.inherited(app_class)
       @_mutex.synchronize do
-        app.class_eval do
+        app_class.class_eval do
           @_mutex         = Mutex.new
           @_configuration = Hanami::Configuration.new(env: Hanami.env)
 
@@ -21,7 +21,7 @@ module Hanami
           include InstanceMethods
         end
 
-        Hanami.application = app
+        Hanami.application_class = app_class
       end
     end
 
@@ -38,7 +38,7 @@ module Hanami
       def routes(&blk)
         @_mutex.synchronize do
           if blk.nil?
-            raise "Hanami.application.routes not configured" unless defined?(@_routes)
+            raise "Hanami.application_class.routes not configured" unless defined?(@_routes)
 
             @_routes
           else

--- a/lib/hanami/container.rb
+++ b/lib/hanami/container.rb
@@ -36,7 +36,7 @@ module Hanami
       end
 
       start do
-        register(:configuration, Hanami.application.configuration.finalize)
+        register(:configuration, Hanami.application_class.configuration.finalize)
       end
     end
 
@@ -57,7 +57,7 @@ module Hanami
       end
 
       start do
-        register(:routes, Hanami.application.routes)
+        register(:routes, Hanami.application_class.routes)
       end
     end
 

--- a/spec/isolation/hanami/application/inherit_anonymous_class_spec.rb
+++ b/spec/isolation/hanami/application/inherit_anonymous_class_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hanami do
   describe ".application" do
     it "it doesn't assign when anonymous class inherits Hanami::Application" do
       Class.new(Hanami::Application)
-      expect { Hanami.application }.to raise_error("Hanami application not configured")
+      expect { Hanami.application_class }.to raise_error("Hanami.application_class not configured")
     end
   end
 end

--- a/spec/isolation/hanami/application/inherit_concrete_class_spec.rb
+++ b/spec/isolation/hanami/application/inherit_concrete_class_spec.rb
@@ -8,7 +8,7 @@ end
 RSpec.describe Hanami do
   describe ".application" do
     it "it assign when concrete class inherits Hanami::Application" do
-      expect(Hanami.application).to eq(Bookshelf::Application)
+      expect(Hanami.application_class).to eq(Bookshelf::Application)
     end
   end
 end

--- a/spec/isolation/hanami/application/not_configured_spec.rb
+++ b/spec/isolation/hanami/application/not_configured_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Hanami do
   describe ".application" do
     it "it raises error when not configured" do
-      expect { Hanami.application }.to raise_error("Hanami application not configured")
+      expect { Hanami.application_class }.to raise_error("Hanami application not configured")
     end
   end
 end

--- a/spec/isolation/hanami/application/routes/configured_spec.rb
+++ b/spec/isolation/hanami/application/routes/configured_spec.rb
@@ -17,7 +17,7 @@ module Web
   end
 end
 
-Hanami.application.routes do
+Hanami.application_class.routes do
   mount :web, at: "/" do
     root to: "home#index"
   end
@@ -25,7 +25,7 @@ end
 
 RSpec.describe Hanami::Application do
   describe ".routes" do
-    subject { Hanami.application.routes }
+    subject { Hanami.application_class.routes }
 
     it "returns configured routes" do
       expect(subject).to be_kind_of(Hanami::Routes)

--- a/spec/isolation/hanami/application/routes/not_configured_spec.rb
+++ b/spec/isolation/hanami/application/routes/not_configured_spec.rb
@@ -7,10 +7,10 @@ end
 
 RSpec.describe Hanami::Application do
   describe ".routes" do
-    subject { Hanami.application.routes }
+    subject { Hanami.application_class.routes }
 
     it "raises error when not configured" do
-      expect { subject }.to raise_error("Hanami.application.routes not configured")
+      expect { subject }.to raise_error("Hanami.application_class.routes not configured")
     end
   end
 end

--- a/spec/isolation/hanami/boot/already_booted_spec.rb
+++ b/spec/isolation/hanami/boot/already_booted_spec.rb
@@ -5,7 +5,7 @@ module Bookshelf
   end
 end
 
-Hanami.application.routes do
+Hanami.application_class.routes do
 end
 
 RSpec.describe Hanami do

--- a/spec/isolation/hanami/boot/success_spec.rb
+++ b/spec/isolation/hanami/boot/success_spec.rb
@@ -7,7 +7,7 @@ module Bookshelf
   end
 end
 
-Hanami.application.routes do
+Hanami.application_class.routes do
   mount :web, at: "/" do
     root to: "home#index"
   end
@@ -27,7 +27,7 @@ end
 
 RSpec.describe Hanami do
   describe ".boot" do
-    it "assigns Hanami.app, .root, and .logger" do
+    it "assigns Hanami.application, .root, and .logger" do
       expect(Hanami::Container).to receive(:finalize!)
       expect(Hanami::Container).to receive(:[]).with("apps.web.actions.namespace").and_return(Web::Actions)
       expect(Hanami::Container).to receive(:[]).with("apps.web.actions.configuration").and_return(Hanami::Controller::Configuration.new)
@@ -35,6 +35,7 @@ RSpec.describe Hanami do
 
       Hanami.boot
       expect(Hanami.app).to be_kind_of(Hanami::Application)
+      expect(Hanami.application).to be_kind_of(Hanami::Application)
       expect(Hanami.root).to eq(Pathname.new(Dir.pwd))
       expect(Hanami.logger).to be_kind_of(Hanami::Logger)
     end


### PR DESCRIPTION
As discussed in #975, this PR renames the Hanami.application* accessors so its clearer what kind of object is held behind each.

Hanami.app is kept as a short-hand alias for application, since its frequently used within the setup of integration tests.