### PR TITLE
Avoid zsh command error

### DIFF
--- a/lib/hanami/templates/welcome.html.erb
+++ b/lib/hanami/templates/welcome.html.erb
@@ -32,7 +32,7 @@
 
       <h3>Hanami is Open Source Software for MVC web development with Ruby.</h3>
 
-      <p>Please generate a new action with:<br><code>bundle exec hanami generate action <%= application_name %> home#index --url=/</code></p>
+      <p>Please generate a new action with:<br><code>bundle exec hanami generate action <%= application_name %> 'home#index' --url=/</code></p>
 
       <hr style="margin-top: 4em;"/>
       <div id="content">


### PR DESCRIPTION
If you are using **zsh**, a command like `bundle exec hanami generate action web home#index --url=/` would lead to an error.

```
zsh: no matches found: home#index
```

A simple fix for this issue is adding a single quote. Hence, the command should be like this.

```
bundle exec hanami generate action web 'home#index' --url=/
```

It is working on any shells as far as I know so it is better to display that command above instead IMO.
