### PR TITLE
Remove unnecessary spaces

### DIFF
--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'concurrent-ruby',    '~> 1.0'
   spec.add_dependency 'bundler',            '>= 1.6', '< 3'
 
-  spec.add_development_dependency 'rspec',     '~>  3.7'
+  spec.add_development_dependency 'rspec',     '~> 3.7'
   spec.add_development_dependency 'rack-test', '~> 1.1'
-  spec.add_development_dependency 'aruba',     '~>  0.14'
+  spec.add_development_dependency 'aruba',     '~> 0.14'
   spec.add_development_dependency 'rake',      '~> 12.0'
 end


### PR DESCRIPTION
I think one space after `~>` would be better