### PR TITLE
Issue #998 - Update URL to Hanami Guides in default welcome template

### DIFF
--- a/lib/hanami/templates/welcome.html.erb
+++ b/lib/hanami/templates/welcome.html.erb
@@ -38,7 +38,7 @@
       <div id="content">
         <ul>
           <li><a href="http://hanamirb.org">Website</a></li>
-          <li><a href="http://hanamirb.org/guides">Guides</a></li>
+          <li><a href="https://guides.hanamirb.org/">Guides</a></li>
           <li><a href="http://www.rubydoc.info/gems/hanami">API docs</a></li>
           <li><a href="https://github.com/hanami/hanami">Source code</a></li>
           <li><a href="https://gitter.im/hanami/chat">Chat</a></li>


### PR DESCRIPTION
Default template used to send to http://hanamirb.org/guides. This PR updates link to be https://guides.hanamirb.org/.

Closes #998 when merged.