### PR TITLE
Excluding .env* files from git by default

### DIFF
--- a/lib/hanami/cli/commands/new/gitignore.erb
+++ b/lib/hanami/cli/commands/new/gitignore.erb
@@ -1,2 +1,3 @@
 /public/assets*
 /tmp
+.env.*

--- a/lib/hanami/cli/commands/new/gitignore_with_sqlite.erb
+++ b/lib/hanami/cli/commands/new/gitignore_with_sqlite.erb
@@ -1,3 +1,4 @@
 /db/*.sqlite
 /public/assets*
 /tmp
+.env.*


### PR DESCRIPTION
A tiny contribution, but excluding sensitive data from the repo is generally considered good practice.

Even better would be encoding `.env` files with a master key, à la Rails, using the cli. If that's something you would consider merging, I'd be happy to contribute it for Hanami 2.0.0.