### PR TITLE
hanami/cli -> dry/cli for main branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,4 @@ end
 gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "unstable"
 gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "unstable"
 gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "unstable"
-gem "hanami-cli", "~> 1.0.alpha", require: false, git: "https://github.com/hanami/cli.git", branch: "unstable"
-
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ which provides the glue that ties all the parts together:
 * [**Hanami::Helpers**](https://github.com/hanami/helpers) - View helpers for Ruby applications
 * [**Hanami::Mailer**](https://github.com/hanami/mailer) - Mail for Ruby applications
 * [**Hanami::Assets**](https://github.com/hanami/assets) - Assets management for Ruby
-* [**Hanami::CLI**](https://github.com/hanami/cli) - Ruby command line interface
 * [**Hanami::Utils**](https://github.com/hanami/utils) - Ruby core extensions and class utilities
 
 These components are designed to be used independently or together in a Hanami application.

--- a/bin/hanami
+++ b/bin/hanami
@@ -5,4 +5,4 @@ require "bundler"
 require "hanami/cli/commands"
 
 Bundler.require(*Hanami.bundler_groups) if File.exist?(ENV["BUNDLE_GEMFILE"] || "Gemfile")
-Hanami::CLI.new(Hanami::CLI::Commands).call
+Dry::CLI.new(Hanami::CLI::Commands).call

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hanami-utils",      "~> 2.0.alpha"
   spec.add_dependency "hanami-router",     "~> 2.0.alpha"
   spec.add_dependency "hanami-controller", "~> 2.0.alpha"
-  spec.add_dependency "hanami-cli",        "~> 1.0.alpha"
+  spec.add_dependency "dry-cli",           "~> 0.5"
   spec.add_dependency "dry-monitor"
   spec.add_dependency "dry-system",        "~> 0.10"
   spec.add_dependency "dry-inflector",     "~> 0.1", ">= 0.1.2"

--- a/lib/hanami/cli/application/cli.rb
+++ b/lib/hanami/cli/application/cli.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "hanami/cli"
+require "dry/cli"
 require_relative "commands"
 
 module Hanami
   class CLI
     module Application
       # Hanami application CLI
-      class CLI < Hanami::CLI
+      class CLI < Dry::CLI
         attr_reader :application
 
         def initialize(application: Hanami.application, commands: Commands)

--- a/lib/hanami/cli/application/commands.rb
+++ b/lib/hanami/cli/application/commands.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "hanami/cli/registry"
+require "dry/cli/registry"
 
 module Hanami
   class CLI
     module Application
       # Hanami application CLI commands registry
       module Commands
-        extend Hanami::CLI::Registry
+        extend Dry::CLI::Registry
 
         require_relative "commands/console"
       end

--- a/lib/hanami/cli/application/commands/console.rb
+++ b/lib/hanami/cli/application/commands/console.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/cli"
+require "dry/cli"
 require "hanami/cli/application/command"
 require "hanami/console/context"
 

--- a/lib/hanami/cli/base_command.rb
+++ b/lib/hanami/cli/base_command.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require "dry/inflector"
-require "hanami/cli/command"
+require "dry/cli/command"
 require "hanami/utils/files"
 
 module Hanami
   class CLI
     # Base class for Hanami application CLI commands
-    class BaseCommand < Hanami::CLI::Command
+    class BaseCommand < Dry::CLI::Command
       attr_reader :out
       attr_reader :inflector
       attr_reader :files

--- a/lib/hanami/cli/commands.rb
+++ b/lib/hanami/cli/commands.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/cli"
+require "dry/cli"
 
 module Hanami
   # Hanami CLI
@@ -55,7 +55,7 @@ module Hanami
     # @since 1.1.0
     # @api private
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
       require "hanami/cli/commands/command"
       require "hanami/cli/commands/server"

--- a/lib/hanami/cli/commands/command.rb
+++ b/lib/hanami/cli/commands/command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "hanami"
-require "hanami/cli/command"
+require "dry/cli/command"
 require "concurrent"
 require "hanami/utils/files"
 require "erb"
@@ -15,7 +15,7 @@ module Hanami
       # Abstract command
       #
       # @since 1.1.0
-      class Command < Hanami::CLI::Command
+      class Command < Dry::CLI::Command
         # @since 1.1.0
         # @api private
         def self.inherited(component)

--- a/script/setup
+++ b/script/setup
@@ -20,7 +20,7 @@ bundle_package() {
 }
 
 install_hanami_frameworks() {
-  declare -a frameworks=(utils validations router helpers model view controller mailer assets cli webconsole)
+  declare -a frameworks=(utils validations router helpers model view controller mailer assets webconsole)
 
   for framework in "${frameworks[@]}"
   do

--- a/script/teardown
+++ b/script/teardown
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 uninstall_hanami_gems() {
-  declare -a frameworks=(hanami hanami-assets hanami-mailer hanami-controller hanami-view hanami-model hanami-helpers hanami-router hanami-validations hanami-cli hanami-webconsole hanami-utils)
+  declare -a frameworks=(hanami hanami-assets hanami-mailer hanami-controller hanami-view hanami-model hanami-helpers hanami-router hanami-validations hanami-webconsole hanami-utils)
 
   for framework in "${frameworks[@]}"
   do

--- a/spec/integration/cli/new/hanami_head_spec.rb
+++ b/spec/integration/cli/new/hanami_head_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "hanami new", type: :integration do
         expect("Gemfile").to have_file_content(%r{gem 'hanami-view',        require: false, git: 'https://github.com/hanami/view.git',        branch: 'develop'})
         expect("Gemfile").to have_file_content(%r{gem 'hanami-helpers',     require: false, git: 'https://github.com/hanami/helpers.git',     branch: 'develop'})
         expect("Gemfile").to have_file_content(%r{gem 'hanami-mailer',      require: false, git: 'https://github.com/hanami/mailer.git',      branch: 'develop'})
-        expect("Gemfile").to have_file_content(%r{gem 'hanami-cli',         require: false, git: 'https://github.com/hanami/cli.git',         branch: 'develop'})
         expect("Gemfile").to have_file_content(%r{gem 'hanami-assets',      require: false, git: 'https://github.com/hanami/assets.git',      branch: 'develop'})
         expect("Gemfile").to have_file_content(%r{gem 'hanami-model',       require: false, git: 'https://github.com/hanami/model.git',       branch: 'develop'})
         expect("Gemfile").to have_file_content(%r{gem 'hanami',                             git: 'https://github.com/hanami/hanami.git',      branch: 'develop'})


### PR DESCRIPTION
This is the way how to switch to the usage of dry-cli (former hanami-cli) gem.