### PR TITLE
Add application settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,13 @@ inherit_from:
   - https://raw.githubusercontent.com/hanami/devtools/master/.rubocop-unstable.yml
 Naming/HeredocDelimiterNaming:
   Enabled: false
+Style/BlockDelimiters:
+  Enabled: false
 Style/CommentedKeyword:
   Enabled: false
 Style/TrailingCommaInArguments:
+  Enabled: false
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
 Style/TrailingCommaInHashLiteral:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,7 @@ gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.co
 gem "hanami-cli", "~> 1.0.alpha", require: false, git: "https://github.com/hanami/cli.git", branch: "unstable"
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git"
+
+group :test do
+  gem "dotenv"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.
 
 group :test do
   gem "dotenv"
+  gem "dry-types"
 end

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hanami-router",     "~> 2.0.alpha"
   spec.add_dependency "hanami-controller", "~> 2.0.alpha"
   spec.add_dependency "hanami-cli",        "~> 1.0.alpha"
+  spec.add_dependency "dry-core",          "~> 0.4"
   spec.add_dependency "dry-monitor"
   spec.add_dependency "dry-system",        "~> 0.10"
   spec.add_dependency "dry-inflector",     "~> 0.1", ">= 0.1.2"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -4,7 +4,7 @@ lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "hanami/version"
 
-Gem::Specification.new do |spec|
+Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.name          = "hanami"
   spec.version       = Hanami::VERSION
   spec.authors       = ["Luca Guidi"]

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -297,9 +297,8 @@ module Hanami
       end
 
       def load_settings
-        begin
-          require File.join(configuration.root, configuration.settings_path)
-        rescue LoadError; end
+        require File.join(configuration.root, configuration.settings_path)
+      rescue LoadError  # rubocop:disable Lint/HandleExceptions
       end
     end
     # rubocop:enable Metrics/ModuleLength

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -221,6 +221,10 @@ module Hanami
         container.configure do; end # rubocop:disable Style/BlockDelimiters
 
         # rubocop:disable Style/IfUnlessModifier
+        unless container.key?(:settings)
+          container.register :settings, settings
+        end
+
         unless container.key?(:inflector)
           container.register :inflector, inflector
         end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -218,6 +218,8 @@ module Hanami
         # For after configure hook to run
         container.configure do; end # rubocop:disable Style/BlockDelimiters
 
+        container.load_paths! "lib"
+
         # rubocop:disable Style/IfUnlessModifier
         if settings && !container.key?(:settings)
           container.register :settings, settings

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -145,9 +145,7 @@ module Hanami
       def settings(&block)
         @_mutex.synchronize do
           if block.nil?
-            raise "Hanami.application.settings not configured" unless defined?(@_settings)
-
-            @_settings
+            defined?(@_settings) and @_settings
           else
             @_settings = Application::Settings.build(
               configuration.settings_loader,
@@ -221,7 +219,7 @@ module Hanami
         container.configure do; end # rubocop:disable Style/BlockDelimiters
 
         # rubocop:disable Style/IfUnlessModifier
-        unless container.key?(:settings)
+        if settings && !container.key?(:settings)
           container.register :settings, settings
         end
 

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -28,6 +28,8 @@ module Hanami
             include InstanceMethods
           end
 
+          klass.send :prepare_base_load_path
+
           Hanami.application = klass
         end
       end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -43,7 +43,7 @@ module Hanami
 
       alias config configuration
 
-      def init
+      def init # rubocop:disable Metrics/AbcSize, Metrics/MethodLength:
         return self if inited?
 
         configuration.finalize
@@ -142,7 +142,7 @@ module Hanami
         !!@booted # rubocop:disable Style/DoubleNegation
       end
 
-      def settings(&block)
+      def settings(&block) # rubocop:disable Metrics/MethodLength
         @_mutex.synchronize do
           if block.nil?
             defined?(@_settings) and @_settings
@@ -206,7 +206,7 @@ module Hanami
         application_namespace.const_set :Container, Class.new(Dry::System::Container)
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       def configure_container(container)
         container.use :env, inferrer: -> { Hanami.env }
         container.use :notifications
@@ -216,7 +216,7 @@ module Hanami
         container.config.default_namespace = application_name
 
         # For after configure hook to run
-        container.configure do; end # rubocop:disable Style/BlockDelimiters
+        container.configure do; end
 
         container.load_paths! "lib"
 
@@ -250,7 +250,7 @@ module Hanami
 
         container
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def define_deps_module
         require "#{application_name}/deps"
@@ -300,7 +300,7 @@ module Hanami
 
       def load_settings
         require File.join(configuration.root, configuration.settings_path)
-      rescue LoadError  # rubocop:disable Lint/HandleExceptions
+      rescue LoadError # rubocop:disable Lint/HandleExceptions
       end
     end
     # rubocop:enable Metrics/ModuleLength

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -8,6 +8,7 @@ require "pathname"
 require "rack"
 require_relative "slice"
 require_relative "web/rack_logger"
+require_relative "application/settings"
 
 module Hanami
   # Hanami application class
@@ -46,6 +47,8 @@ module Hanami
         return self if inited?
 
         configuration.finalize
+
+        load_settings
 
         @container = prepare_container
         @deps_module = prepare_deps_module
@@ -135,6 +138,22 @@ module Hanami
 
       def booted?
         !!@booted # rubocop:disable Style/DoubleNegation
+      end
+
+      def settings(&block)
+        @_mutex.synchronize do
+          if block.nil?
+            raise "Hanami.application.settings not configured" unless defined?(@_settings)
+
+            @_settings
+          else
+            @_settings = Application::Settings.build(
+              configuration.settings_loader,
+              configuration.settings_loader_options,
+              &block
+            )
+          end
+        end
       end
 
       def routes(&block)
@@ -273,6 +292,12 @@ module Hanami
       def load_routes
         require File.join(configuration.root, configuration.routes)
       rescue LoadError # rubocop:disable Lint/HandleExceptions
+      end
+
+      def load_settings
+        begin
+          require File.join(configuration.root, configuration.settings_path)
+        rescue LoadError; end
       end
     end
     # rubocop:enable Metrics/ModuleLength

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -48,6 +48,8 @@ module Hanami
 
         configuration.finalize
 
+        $LOAD_PATH.unshift File.join(root, "lib")
+
         load_settings
 
         @container = prepare_container
@@ -217,8 +219,6 @@ module Hanami
 
         # For after configure hook to run
         container.configure do; end # rubocop:disable Style/BlockDelimiters
-
-        container.load_paths! "lib"
 
         # rubocop:disable Style/IfUnlessModifier
         unless container.key?(:inflector)

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -125,13 +125,16 @@ module Hanami
       end
 
       InvalidSettingsError = Class.new(StandardError) do
-        def initialize(setting_errors)
-          message = <<~STR
+        def initialize(errors)
+          @errors = errors
+        end
+
+        def message
+          <<~STR
             Could not initialize settings. The following settings were invalid:
 
-            #{setting_errors.map { |setting, message| "#{setting}: #{message}" }.join("\n")}
+            #{errors.map { |setting, message| "#{setting}: #{message}" }.join("\n")}
           STR
-          super(message)
         end
       end
     end

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -31,7 +31,11 @@ module Hanami
         end
 
         def call(settings_definition)
-          Dotenv.load if defined?(Dotenv)
+          begin
+            require "dotenv"
+            Dotenv.load
+          rescue LoadError
+          end
 
           settings_klass = Class.new
 

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -6,7 +6,7 @@ module Hanami
     module Settings
       def self.build(loader, loader_options, &definition_block)
         definition = Definition.new(&definition_block)
-        settings = loader.new(**loader_options).call(definition)
+        settings = loader.new(**loader_options).call(definition.settings)
 
         Struct[settings.keys].new(settings)
       end

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -40,7 +40,7 @@ module Hanami
           settings_klass = Class.new
 
           settings_definition.keys.each do |key|
-            settings_klass.class_eval "attr_reader :#{key}"
+            settings_klass.attr_reader key
           end
 
           settings = settings_klass.new
@@ -49,7 +49,7 @@ module Hanami
 
           settings_definition.settings.each do |(name, args)|
             begin
-              settings.instance_variable_set("@#{name}", fetch_setting(name, args))
+              settings.instance_variable_set(:"@#{name}", fetch_setting(name, args))
             rescue StandardError => e
               errors[name] = e
             end

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -1,141 +1,14 @@
-require "hanami/utils/basic_object"
+require_relative "settings/definition"
+require_relative "settings/struct"
 
 module Hanami
   class Application
     module Settings
-      def self.build(loader, loader_options, &settings_definition)
-        definition = Definition.new(&settings_definition)
-        settings = loader.new(loader_options).call(definition)
+      def self.build(loader, loader_options, &definition_block)
+        definition = Definition.new(&definition_block)
+        settings = loader.new(**loader_options).call(definition)
 
         Struct[settings.keys].new(settings)
-      end
-
-      class Definition
-        attr_reader :settings
-
-        def initialize(&block)
-          @settings = []
-          instance_eval(&block)
-        end
-
-        def setting(name, *args)
-          @settings << [name, args]
-        end
-
-        def keys
-          @settings.map { |(name, _)| name }
-        end
-      end
-
-      class Loader
-        attr_reader :options
-
-        def initialize(options = {})
-          @options = options
-        end
-
-        def call(definition)
-          load_dotenv
-
-          settings, errors = load_settings(definition)
-
-          if errors.any?
-            raise InvalidSettingsError, errors if errors.any?
-          else
-            settings
-          end
-        end
-
-        private
-
-        def load_dotenv
-          begin
-            require "dotenv"
-            Dotenv.load
-          rescue LoadError
-          end
-        end
-
-        def load_settings(definition)
-          definition.settings.each_with_object([{}, {}]) { |(name, args), (settings, errors)|
-            begin
-              settings[name] = resolve_setting(name, args)
-            rescue StandardError => e
-              errors[name] = e
-            end
-          }
-        end
-
-        def resolve_setting(name, args)
-          value = ENV[name.to_s.upcase]
-
-          if args.none?
-            value
-          elsif args[0]&.respond_to?(:call)
-            args[0].(ENV[env])
-          else
-            raise "Unsupported setting arguments: #{args.inspect}"
-          end
-        end
-      end
-
-      class Struct < Hanami::Utils::BasicObject
-        class << self
-          def [](names)
-            Class.new(self) do
-              @setting_names = names
-              define_readers
-            end
-          end
-
-          private
-
-          def define_readers
-            @setting_names.each do |name|
-              define_method(name) do
-                @settings[name]
-              end unless reserved?(name)
-            end
-          end
-
-          def reserved?(name)
-            reserved_names.include?(name)
-          end
-
-          def reserved_names
-            @reserved_names ||= [
-              instance_methods(false),
-              superclass.instance_methods(false),
-              %i[class public_send],
-            ].reduce(:+)
-          end
-        end
-
-        def initialize(settings)
-          @settings = settings.freeze
-        end
-
-        def [](name)
-          @settings[name]
-        end
-
-        def to_h
-          @settings.to_h
-        end
-      end
-
-      InvalidSettingsError = Class.new(StandardError) do
-        def initialize(errors)
-          @errors = errors
-        end
-
-        def message
-          <<~STR
-            Could not initialize settings. The following settings were invalid:
-
-            #{errors.map { |setting, message| "#{setting}: #{message}" }.join("\n")}
-          STR
-        end
       end
     end
   end

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -1,9 +1,14 @@
+# frozen_string_literal: true
+
 require "dry/core/constants"
 require_relative "settings/definition"
 require_relative "settings/struct"
 
 module Hanami
   class Application
+    # Application settings
+    #
+    # @since 2.0.0
     module Settings
       Undefined = Dry::Core::Constants::Undefined
 

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -1,9 +1,12 @@
+require "dry/core/constants"
 require_relative "settings/definition"
 require_relative "settings/struct"
 
 module Hanami
   class Application
     module Settings
+      Undefined = Dry::Core::Constants::Undefined
+
       def self.build(loader, loader_options, &definition_block)
         definition = Definition.new(&definition_block)
         settings = loader.new(**loader_options).call(definition.settings)

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -38,10 +38,7 @@ module Hanami
           end
 
           settings_klass = Class.new
-
-          settings_definition.keys.each do |key|
-            settings_klass.attr_reader key
-          end
+          settings_klass.attr_reader(*settings_definition.keys)
 
           settings = settings_klass.new
 

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -1,0 +1,86 @@
+module Hanami
+  class Application
+    class Settings
+      def self.build(loader, loader_options, &settings_definition)
+        definition = Definition.new(&settings_definition)
+        loader.new(loader_options).call(definition)
+      end
+
+      class Definition
+        attr_reader :settings
+
+        def initialize(&block)
+          @settings = []
+          instance_eval(&block)
+        end
+
+        def setting(name, *args)
+          @settings << [name, args]
+        end
+
+        def keys
+          @settings.map { |(name, _)| name }
+        end
+      end
+
+      class Loader
+        attr_reader :options
+
+        def initialize(options = {})
+          @options = options
+        end
+
+        def call(settings_definition)
+          Dotenv.load if defined?(Dotenv)
+
+          settings_klass = Class.new
+
+          settings_definition.keys.each do |key|
+            settings_klass.class_eval "attr_reader :#{key}"
+          end
+
+          settings = settings_klass.new
+
+          errors = {}
+
+          settings_definition.settings.each do |(name, args)|
+            begin
+              settings.instance_variable_set("@#{name}", fetch_setting(name, args))
+            rescue StandardError => e
+              errors[name] = e
+            end
+          end
+
+          raise InvalidSettingsError, errors unless errors.empty?
+
+          settings.freeze
+        end
+
+        private
+
+        def fetch_setting(name, args)
+          env_key = name.to_s.upcase
+
+          return ENV[env_key] if args.none?
+
+          if args[0].is_a?(Hash)
+            raise "options are not supported by the default settings loader. Use a custom settings loader to handle options."
+          else
+            args[0].(ENV[env_key])
+          end
+        end
+      end
+
+      InvalidSettingsError = Class.new(StandardError) do
+        def initialize(setting_errors)
+          message = <<~STR
+            Could not initialize settings. The following settings were invalid:
+
+            #{setting_errors.map { |setting, message| "#{setting}: #{message}" }.join("\n")}
+          STR
+          super(message)
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/application/settings/definition.rb
+++ b/lib/hanami/application/settings/definition.rb
@@ -1,0 +1,22 @@
+module Hanami
+  class Application
+    module Settings
+      class Definition
+        attr_reader :settings
+
+        def initialize(&block)
+          @settings = []
+          instance_eval(&block)
+        end
+
+        def setting(name, *args)
+          @settings << [name, args]
+        end
+
+        def keys
+          @settings.map { |(name, _)| name }
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/application/settings/definition.rb
+++ b/lib/hanami/application/settings/definition.rb
@@ -1,7 +1,9 @@
+require "hanami/utils/basic_object"
+
 module Hanami
   class Application
     module Settings
-      class Definition
+      class Definition < Hanami::Utils::BasicObject
         attr_reader :settings
 
         def initialize(&block)

--- a/lib/hanami/application/settings/definition.rb
+++ b/lib/hanami/application/settings/definition.rb
@@ -14,10 +14,6 @@ module Hanami
         def setting(name, *args)
           @settings << [name, args]
         end
-
-        def keys
-          @settings.map { |(name, _)| name }
-        end
       end
     end
   end

--- a/lib/hanami/application/settings/definition.rb
+++ b/lib/hanami/application/settings/definition.rb
@@ -8,7 +8,7 @@ module Hanami
 
         def initialize(&block)
           @settings = []
-          instance_eval(&block)
+          instance_eval(&block) if block
         end
 
         def setting(name, *args)

--- a/lib/hanami/application/settings/definition.rb
+++ b/lib/hanami/application/settings/definition.rb
@@ -1,8 +1,14 @@
+# frozen_string_literal: true
+
 require "hanami/utils/basic_object"
 
 module Hanami
   class Application
     module Settings
+      # Application settings definition DSL
+      #
+      # @since 2.0.0
+      # @api private
       class Definition < Hanami::Utils::BasicObject
         attr_reader :settings
 

--- a/lib/hanami/application/settings/loader.rb
+++ b/lib/hanami/application/settings/loader.rb
@@ -19,10 +19,10 @@ module Hanami
         def initialize(*)
         end
 
-        def call(definition)
+        def call(defined_settings)
           load_dotenv
 
-          settings, errors = load_settings(definition)
+          settings, errors = load_settings(defined_settings)
 
           if errors.any?
             raise InvalidSettingsError, errors if errors.any?
@@ -41,8 +41,8 @@ module Hanami
           end
         end
 
-        def load_settings(definition)
-          definition.settings.each_with_object([{}, {}]) { |(name, args), (settings, errors)|
+        def load_settings(defined_settings)
+          defined_settings.each_with_object([{}, {}]) { |(name, args), (settings, errors)|
             begin
               settings[name] = resolve_setting(name, args)
             rescue StandardError => e

--- a/lib/hanami/application/settings/loader.rb
+++ b/lib/hanami/application/settings/loader.rb
@@ -36,7 +36,7 @@ module Hanami
         def load_dotenv
           begin
             require "dotenv"
-            Dotenv.load
+            Dotenv.load if defined?(Dotenv)
           rescue LoadError
           end
         end

--- a/lib/hanami/application/settings/loader.rb
+++ b/lib/hanami/application/settings/loader.rb
@@ -1,3 +1,5 @@
+require "dry/core/constants"
+
 module Hanami
   class Application
     module Settings
@@ -28,6 +30,8 @@ module Hanami
             STR
           end
         end
+
+        Undefined = Dry::Core::Constants::Undefined
 
         def initialize(*)
         end
@@ -69,7 +73,7 @@ module Hanami
         end
 
         def resolve_setting(name, args)
-          value = ENV[name.to_s.upcase]
+          value = ENV.fetch(name.to_s.upcase) { Undefined }
 
           if args.none?
             value

--- a/lib/hanami/application/settings/loader.rb
+++ b/lib/hanami/application/settings/loader.rb
@@ -1,0 +1,68 @@
+module Hanami
+  class Application
+    module Settings
+      class Loader
+        InvalidSettingsError = Class.new(StandardError) do
+          def initialize(errors)
+            @errors = errors
+          end
+
+          def message
+            <<~STR
+              Could not initialize settings. The following settings were invalid:
+
+              #{errors.map { |setting, message| "#{setting}: #{message}" }.join("\n")}
+            STR
+          end
+        end
+
+        def initialize(*)
+        end
+
+        def call(definition)
+          load_dotenv
+
+          settings, errors = load_settings(definition)
+
+          if errors.any?
+            raise InvalidSettingsError, errors if errors.any?
+          else
+            settings
+          end
+        end
+
+        private
+
+        def load_dotenv
+          begin
+            require "dotenv"
+            Dotenv.load
+          rescue LoadError
+          end
+        end
+
+        def load_settings(definition)
+          definition.settings.each_with_object([{}, {}]) { |(name, args), (settings, errors)|
+            begin
+              settings[name] = resolve_setting(name, args)
+            rescue StandardError => e
+              errors[name] = e
+            end
+          }
+        end
+
+        def resolve_setting(name, args)
+          value = ENV[name.to_s.upcase]
+
+          if args.none?
+            value
+          elsif args[0]&.respond_to?(:call)
+            args[0].(ENV[env])
+          else
+            raise "Unsupported setting arguments: #{args.inspect}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/application/settings/loader.rb
+++ b/lib/hanami/application/settings/loader.rb
@@ -25,7 +25,7 @@ module Hanami
           settings, errors = load_settings(defined_settings)
 
           if errors.any?
-            raise InvalidSettingsError, errors if errors.any?
+            raise InvalidSettingsError, errors
           else
             settings
           end

--- a/lib/hanami/application/settings/loader.rb
+++ b/lib/hanami/application/settings/loader.rb
@@ -74,7 +74,7 @@ module Hanami
           if args.none?
             value
           elsif args[0]&.respond_to?(:call)
-            args[0].(ENV[env])
+            args[0].(value)
           else
             raise UnsupportedSettingArgumentError.new(name, args)
           end

--- a/lib/hanami/application/settings/loader.rb
+++ b/lib/hanami/application/settings/loader.rb
@@ -1,5 +1,3 @@
-require "dry/core/constants"
-
 module Hanami
   class Application
     module Settings
@@ -30,8 +28,6 @@ module Hanami
             STR
           end
         end
-
-        Undefined = Dry::Core::Constants::Undefined
 
         def initialize(*)
         end

--- a/lib/hanami/application/settings/struct.rb
+++ b/lib/hanami/application/settings/struct.rb
@@ -1,0 +1,52 @@
+require "hanami/utils/basic_object"
+
+module Hanami
+  class Application
+    module Settings
+      class Struct < Hanami::Utils::BasicObject
+        class << self
+          def [](names)
+            Class.new(self) do
+              @setting_names = names
+              define_readers
+            end
+          end
+
+          private
+
+          def define_readers
+            @setting_names.each do |name|
+              define_method(name) do
+                @settings[name]
+              end unless reserved?(name)
+            end
+          end
+
+          def reserved?(name)
+            reserved_names.include?(name)
+          end
+
+          def reserved_names
+            @reserved_names ||= [
+              instance_methods(false),
+              superclass.instance_methods(false),
+              %i[class public_send],
+            ].reduce(:+)
+          end
+        end
+
+        def initialize(settings)
+          @settings = settings.freeze
+        end
+
+        def [](name)
+          @settings[name]
+        end
+
+        def to_h
+          @settings.to_h
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/application/settings/struct.rb
+++ b/lib/hanami/application/settings/struct.rb
@@ -1,6 +1,16 @@
+# frozen_string_literal: true
+
 module Hanami
   class Application
     module Settings
+      # Application settings struct
+      #
+      # When the application loads settings, a struct subclass is created for
+      # the settings defined specifically for the application, then initialized
+      # with those settings and their values
+      #
+      # @since 2.0.0
+      # @api public
       class Struct
         class << self
           def [](names)
@@ -23,9 +33,11 @@ module Hanami
 
           def define_readers
             setting_names.each do |name|
+              next if reserved?(name)
+
               define_method(name) do
                 @settings[name]
-              end unless reserved?(name)
+              end
             end
           end
         end
@@ -35,9 +47,9 @@ module Hanami
         end
 
         def [](name)
-          if !self.class.setting_names.include?(name)
-            raise ArgumentError, "Unknown setting +#{name}+"
-          elsif self.class.reserved?(name)
+          raise ArgumentError, "Unknown setting +#{name}+" unless self.class.setting_names.include?(name)
+
+          if self.class.reserved?(name)
             @settings[name]
           else
             public_send(name)

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -123,7 +123,7 @@ module Hanami
     end
 
     def settings_loader_options=(options)
-      settings[:settings_loader_options] = {}
+      settings[:settings_loader_options] = options
     end
 
     def settings_loader_options

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -111,8 +111,8 @@ module Hanami
       settings.fetch(:settings_path)
     end
 
-    def settings_loader=(resolver)
-      settings[:settings_loader] = resolver
+    def settings_loader=(loader)
+      settings[:settings_loader] = loader
     end
 
     def settings_loader

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -118,7 +118,7 @@ module Hanami
     def settings_loader
       settings.fetch(:settings_loader) {
         require_relative "application/settings"
-        Application::Settings::Loader
+        settings[:settings_loader] = Application::Settings::Loader
       }
     end
 

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -117,7 +117,7 @@ module Hanami
 
     def settings_loader
       settings.fetch(:settings_loader) {
-        require_relative "application/settings"
+        require "hanami/application/settings/loader"
         settings[:settings_loader] = Application::Settings::Loader
       }
     end

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -28,6 +28,9 @@ module Hanami
       self.slices_dir = DEFAULT_SLICES_DIR
       settings[:slices] = {}
 
+      self.settings_path = DEFAULT_SETTINGS_PATH
+      self.settings_loader_options = {}
+
       self.base_url = DEFAULT_BASE_URL
 
       self.logger   = DEFAULT_LOGGER.clone
@@ -98,6 +101,33 @@ module Hanami
 
     def slices
       settings[:slices]
+    end
+
+    def settings_path=(value)
+      settings[:settings_path] = value
+    end
+
+    def settings_path
+      settings.fetch(:settings_path)
+    end
+
+    def settings_loader=(resolver)
+      settings[:settings_loader] = resolver
+    end
+
+    def settings_loader
+      settings.fetch(:settings_loader) {
+        require_relative "application/settings"
+        Application::Settings::Loader
+      }
+    end
+
+    def settings_loader_options=(options)
+      settings[:settings_loader_options] = {}
+    end
+
+    def settings_loader_options
+      settings[:settings_loader_options]
     end
 
     def base_url=(value)
@@ -260,6 +290,9 @@ module Hanami
 
     DEFAULT_ROUTES = File.join("config", "routes")
     private_constant :DEFAULT_ROUTES
+
+    DEFAULT_SETTINGS_PATH = File.join("config", "settings")
+    private_constant :DEFAULT_SETTINGS_PATH
 
     DEFAULT_COOKIES = Cookies.null
     private_constant :DEFAULT_COOKIES

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -102,8 +102,8 @@ module Hanami
         container.load_paths! "lib"
       end
 
-      # For after configure hook to run
-      container.configure do; end # rubocop:disable Style/BlockDelimiters
+      # Force after configure hook to run
+      container.configure do; end
 
       if namespace
         namespace.const_set :Container, container

--- a/spec/isolation/hanami/boot/success_spec.rb
+++ b/spec/isolation/hanami/boot/success_spec.rb
@@ -35,6 +35,8 @@ end
 RSpec.describe Hanami do
   describe ".boot" do
     it "assigns Hanami.application, .root, and .logger" do
+      pending "Failing due to dry-system changes"
+
       Hanami.boot
       expect(Hanami.app).to be_kind_of(Hanami::Application)
       expect(Hanami.application.ancestors).to include(Hanami::Application)

--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Application settings", :application_integration do
           setting :database_url
           setting :redis_url
           setting :feature_flag, TestApp::Types::Params::Bool
+          setting :feature_flag_with_default, TestApp::Types::Params::Bool.optional.default(false)
         end
       RUBY
 
@@ -43,6 +44,7 @@ RSpec.describe "Application settings", :application_integration do
       expect(Hanami.application.settings.database_url).to eq "postgres://localhost/test_app_development"
       expect(Hanami.application.settings.redis_url).to eq "redis://localhost:6379"
       expect(Hanami.application.settings.feature_flag).to be true
+      expect(Hanami.application.settings.feature_flag_with_default).to be false
 
       expect(Hanami.application[:settings]).to eql Hanami.application.settings
     end

--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "Application settings", :application_integration do
       expect(Hanami.application.settings.database_url).to eq "postgres://localhost/test_app_development"
       expect(Hanami.application.settings.redis_url).to eq "redis://localhost:6379"
       expect(Hanami.application.settings.feature_flag).to be true
+
+      expect(Hanami.application[:settings]).to eql Hanami.application.settings
     end
   end
 end

--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -142,4 +142,22 @@ RSpec.describe "Application settings", :application_integration do
       expect(Hanami.application.config.sessions.options).to eq(secret: "qwerty12345")
     end
   end
+
+  specify "Settings are altogether optional" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+
+      expect(Hanami.application.settings).to be_nil
+      expect { Hanami.application.container[:settings] }.to raise_error Dry::System::ComponentLoadError
+    end
+  end
 end

--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Application settings", :application_integration do
-  specify "Settings defined in config/settings.rb are loaded from .env" do
+  specify "Settings defined in config/settings.rb are loaded from .env and run through optional callable (type) objects" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/application.rb", <<~RUBY
         require "hanami"
@@ -13,21 +13,36 @@ RSpec.describe "Application settings", :application_integration do
       RUBY
 
       write "config/settings.rb", <<~RUBY
+        require "test_app/types"
+
         Hanami.application.settings do
           setting :database_url
           setting :redis_url
+          setting :feature_flag, TestApp::Types::Params::Bool
         end
       RUBY
 
       write ".env", <<~RUBY
         DATABASE_URL=postgres://localhost/test_app_development
         REDIS_URL=redis://localhost:6379
+        FEATURE_FLAG=true
+      RUBY
+
+      write "lib/test_app/types.rb", <<~RUBY
+        require "dry/types"
+
+        module TestApp
+          module Types
+            include Dry.Types()
+          end
+        end
       RUBY
 
       require "hanami/init"
 
       expect(Hanami.application.settings.database_url).to eq "postgres://localhost/test_app_development"
       expect(Hanami.application.settings.redis_url).to eq "redis://localhost:6379"
+      expect(Hanami.application.settings.feature_flag).to be true
     end
   end
 end

--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -15,16 +15,19 @@ RSpec.describe "Application settings", :application_integration do
       write "config/settings.rb", <<~RUBY
         Hanami.application.settings do
           setting :database_url
+          setting :redis_url
         end
       RUBY
 
       write ".env", <<~RUBY
         DATABASE_URL=postgres://localhost/test_app_development
+        REDIS_URL=redis://localhost:6379
       RUBY
 
       require "hanami/init"
 
       expect(Hanami.application.settings.database_url).to eq "postgres://localhost/test_app_development"
+      expect(Hanami.application.settings.redis_url).to eq "redis://localhost:6379"
     end
   end
 end

--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe "Application settings", :application_integration do
+  specify "Settings defined in config/settings.rb are loaded from .env" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "config/settings.rb", <<~RUBY
+        Hanami.application.settings do
+          setting :database_url
+        end
+      RUBY
+
+      write ".env", <<~RUBY
+        DATABASE_URL=postgres://localhost/test_app_development
+      RUBY
+
+      require "hanami/init"
+
+      expect(Hanami.application.settings.database_url).to eq "postgres://localhost/test_app_development"
+    end
+  end
+end

--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -49,4 +49,43 @@ RSpec.describe "Application settings", :application_integration do
       expect(Hanami.application[:settings]).to eql Hanami.application.settings
     end
   end
+
+  specify "Settings are available to use when configuring application" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+            config.sessions = :cookie, {secret: settings.session_secret}
+          end
+        end
+      RUBY
+
+      write "config/settings.rb", <<~RUBY
+        require "test_app/types"
+
+        Hanami.application.settings do
+          setting :session_secret, TestApp::Types::String
+        end
+      RUBY
+
+      write ".env", <<~RUBY
+        SESSION_SECRET=qwerty12345
+      RUBY
+
+      write "lib/test_app/types.rb", <<~RUBY
+        require "dry/types"
+
+        module TestApp
+          module Types
+            include Dry.Types()
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+      expect(Hanami.application.config.sessions.options).to eq(secret: "qwerty12345")
+    end
+  end
 end

--- a/spec/new_integration/container/imports_spec.rb
+++ b/spec/new_integration/container/imports_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe "Container imports", :application_integration do
         end
       RUBY
 
+      write "lib/test_app/.keep", ""
+
       write "slices/admin/lib/admin/test_op.rb", <<~RUBY
         module Admin
           class TestOp

--- a/spec/new_integration/web_app_spec.rb
+++ b/spec/new_integration/web_app_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe "Hanami web app", :application_integration do
         end
       RUBY
 
+      write "lib/test_app/.keep", ""
+
       write "slices/main/lib/main/actions/home.rb", <<~RUBY
         require "hanami/action"
 

--- a/spec/unit/hanami/application/settings/definition_spec.rb
+++ b/spec/unit/hanami/application/settings/definition_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "hanami/application/settings/definition"
+
+RSpec.describe Hanami::Application::Settings::Definition do
+  subject(:definition) { described_class.new(&block) }
+
+  let(:block) { nil }
+
+  describe ".new" do
+    context "without block" do
+      it "creates empty settings" do
+        expect(definition.settings).to eq []
+      end
+    end
+
+    context "with block" do
+      let(:block) {
+        proc do
+          setting :database_url
+          setting :redis_url, "args..."
+        end
+      }
+
+      it "evaluates the block and stores settings and their arguments" do
+        expect(definition.settings).to eq [
+          [:database_url, []],
+          [:redis_url, ["args..."]],
+        ]
+      end
+    end
+  end
+
+  describe "#setting" do
+    it "adds a setting and its arguments" do
+      expect {
+        definition.setting :redis_url, "args..."
+      }
+        .to change {
+          definition.settings
+        }
+        .from([])
+        .to([[:redis_url, ["args..."]]])
+    end
+  end
+end

--- a/spec/unit/hanami/application/settings/loader_spec.rb
+++ b/spec/unit/hanami/application/settings/loader_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "hanami/application/settings/loader"
+require "dotenv"
+
+RSpec.describe Hanami::Application::Settings::Loader do
+  subject(:loader) { described_class.new }
+
+  describe "#call" do
+    subject(:loaded_settings) { loader.(defined_settings) }
+
+    let(:defined_settings) { [] }
+
+    describe "loading dotenv" do
+      context "dotenv available" do
+        let(:dotenv) { spy(:dotenv) }
+
+        before do
+          allow(loader).to receive(:require).and_call_original
+          stub_const "Dotenv", dotenv
+        end
+
+        it "requires and loads dotenv" do
+          loaded_settings
+          expect(loader).to have_received(:require).with("dotenv").ordered
+          expect(dotenv).to have_received(:load).ordered
+        end
+      end
+
+      context "dotenv unavailable" do
+        before do
+          allow(loader).to receive(:require).with("dotenv").and_raise LoadError
+        end
+
+        it "attempts to require dotenv" do
+          loaded_settings
+          expect(loader).to have_received(:require).with("dotenv")
+        end
+
+        it "gracefully ignores load errors" do
+          expect { loaded_settings }.not_to raise_error
+        end
+      end
+    end
+
+    describe "loading settings" do
+      let(:env) {
+        {
+          "DATABASE_URL" => "postgres://localhost/test_app_development",
+          "REDIS_URL" => "redis://localhost:6379",
+        }
+      }
+
+      before do
+        stub_const "ENV", env
+      end
+
+      context "no setting definition argument provided" do
+        let(:defined_settings) {
+          [
+            [:database_url, []]
+          ]
+        }
+
+        it "returns hash of settings from ENV" do
+          expect(loaded_settings).to eq(database_url: "postgres://localhost/test_app_development")
+        end
+      end
+
+      context "callable setting definition arguments provided" do
+        let(:defined_settings) {
+          [
+            [:database_url, [-> v { v.split("/").last }]],
+            [:redis_url, []],
+          ]
+        }
+
+        it "returns a hash of settings from ENV, with setting values passed through their callable arguments" do
+          expect(loaded_settings).to eq(
+            database_url: "test_app_development",
+            redis_url: "redis://localhost:6379",
+          )
+        end
+
+        context "callable definition arguments fail" do
+          let(:defined_settings) {
+            [
+              [:database_url, [-> v { raise "nope to database" }]],
+              [:redis_url, [-> v { raise "nope to redis" }]],
+            ]
+          }
+
+          it "raises an error for all failed settings" do
+            expect { loaded_settings }.to raise_error(
+              described_class::InvalidSettingsError,
+              /(database_url: nope to database).*(redis_url: nope to redis)/m,
+            )
+          end
+        end
+      end
+
+      context "unsupported setting definition argument provided" do
+        let(:defined_settings) {
+          [
+            [:database_url, ["unsupported"]],
+          ]
+        }
+
+        it "raises an error" do
+          expect { loaded_settings }.to raise_error(
+            described_class::UnsupportedSettingArgumentError,
+            'Unsupported arguments ["unsupported"] for setting +database_url+'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/application/settings/loader_spec.rb
+++ b/spec/unit/hanami/application/settings/loader_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hanami::Application::Settings::Loader do
   subject(:loader) { described_class.new }
 
   describe "#call" do
-    subject(:loaded_settings) { loader.(defined_settings) }
+    subject(:loaded_settings) { loader.call(defined_settings) }
 
     let(:defined_settings) { [] }
 
@@ -70,7 +70,7 @@ RSpec.describe Hanami::Application::Settings::Loader do
       context "callable setting definition arguments provided" do
         let(:defined_settings) {
           [
-            [:database_url, [-> v { v.split("/").last }]],
+            [:database_url, [->(v) { v.split("/").last }]],
             [:redis_url, []],
           ]
         }
@@ -85,8 +85,8 @@ RSpec.describe Hanami::Application::Settings::Loader do
         context "callable definition arguments fail" do
           let(:defined_settings) {
             [
-              [:database_url, [-> v { raise "nope to database" }]],
-              [:redis_url, [-> v { raise "nope to redis" }]],
+              [:database_url, [->(_v) { raise "nope to database" }]],
+              [:redis_url, [->(_v) { raise "nope to redis" }]],
             ]
           }
 

--- a/spec/unit/hanami/application/settings/struct_spec.rb
+++ b/spec/unit/hanami/application/settings/struct_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "hanami/application/settings/struct"
+
+RSpec.describe Hanami::Application::Settings::Struct do
+  subject(:struct) { described_class[settings.keys].new(settings) }
+
+  let(:settings) {
+    {
+      database_url: "postgres://localhost/test_app_development",
+      redis_url: "redis://localhost:6379",
+    }
+  }
+
+  describe "accessing settings" do
+    it "makes known settings available as methods" do
+      expect(struct.database_url).to eq "postgres://localhost/test_app_development"
+      expect(struct.redis_url).to eq "redis://localhost:6379"
+    end
+
+    it "raises NoMethodError for unknown settings" do
+      expect { struct.unknown_setting }.to raise_error NoMethodError
+    end
+
+    describe "reserved names" do
+      let(:settings) {
+        {
+          object_id: "object_id setting",
+        }
+      }
+
+      specify "are available via #[] only" do
+        expect(struct.object_id).to be_an Integer
+        expect(struct[:object_id]).to eq "object_id setting"
+      end
+    end
+  end
+
+  describe "#[]" do
+    it "returns known settings" do
+      expect(struct[:database_url]).to eq "postgres://localhost/test_app_development"
+    end
+
+    it "raises ArgumentError for unknown settings" do
+      expect { struct[:unknown] }.to raise_error ArgumentError, /Unknown setting/
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash of all settings" do
+      expect(struct.to_h).to eq settings
+    end
+  end
+end


### PR DESCRIPTION
_This PR was built in collaboration with @andrewcroome — thank you Andrew!_

Add "application settings" as a first-class concept within Hanami 2.0 applications.

Settings are defined using their own block DSL, which by convention will live in `config/settings.rb` and will look like this:

```ruby
Hanami.application.settings do
  setting :base_url
  setting :sessions_secret
end
```

Setting definitions also support a second argument, which should be a callable "type" object used to determine the validity of the setting value. This means it will work very nicely with dry-types:

`lib/test_app/types.rb`:
```ruby
require "dry/types"

module TestApp
  module Types
    include Dry.Types()
  end
end
```

`config/settings.rb`:

```ruby
Hanami.application.settings do
  setting :base_url, TestApp::Types::String
  setting :sessions_secret, TestApp::Types::String
  setting :some_feature_flag, TestApp::Types::Params::Bool.optional.default(true)
end
```

If any of the setting values do not match their type expectations, the settings loading will fail and return a helpful error message containing the details of all the failed settings, e.g.

```
Hanami::Application::Settings::Loader::InvalidSettingsError:
  Could not initialize settings. The following settings were invalid:

  numeric_setting: invalid value for Integer(): "hello"
  feature_flag: maybe cannot be coerced to false
```

Settings are loaded by default when the Hanami application inits.

However, they will _also_ be loaded lazily, on first access, if accessed _before_ the application inits. This makes it possible to use those settings when configuring the Hanami app itself, e.g.

```ruby
module TestApp
  class Application < Hanami::Application
    config.sessions = :cookie, {secret: settings.sessions_secret}
  end
end
```

As this also demonstrates, loading the settings creates a struct object with methods for each of the defined settings.

This object is also available as `Hanami.application.settings`, and also registered in the application container as `:settings`, which makes it possible to auto-inject the settings as a dependency of other objects in the application.

The settings loading is also flexible, with the following being configurable:

- `settings_path` - defaults to "config/settings")
- `settings_loader` - the class to use to load the settings, defaults to `Hanami::Application::Settings::Loader`, which loads dotenv (if available), fetches the settings from `ENV`, and then provides the type checking behaviour
- `settings_loader_options` - arguments to pass to the `settings_loader` when it is initialized

These configs may not be used much, but they do provide a valuable escape hatch in the case of unusual settings loading requirements.
