### PR TITLE
Correcting 7 typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -386,7 +386,7 @@ The web, with simplicity.
 ## v0.3.0 - 2015-03-23
 ### Added
 - [Luca Guidi] Introduced action generator. Eg. `bundle exec lotus generate action web dashboard#index`
-- [Alfonso Uceda Pompa] Allow to specify default coookies options in application configuration. Eg. `cookies true, { domain: 'lotusrb.org' }`
+- [Alfonso Uceda Pompa] Allow to specify default cookies options in application configuration. Eg. `cookies true, { domain: 'lotusrb.org' }`
 - [Tom Kadwill] Include `Lotus::Helpers` in views.
 - [Linus Pettersson] Allow to specify `--database` CLI option when generate a new project. Eg. `lotus new bookshelf --database=postgresql`
 - [Linus Pettersson] Initialize a Git repository when generating a new project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,11 +247,11 @@ The web, with simplicity.
 
 ## v0.7.2 - 2016-02-09
 ### Fixed
-- [Alfonso Uceda Pompa] Fixed routing issue when static assets server tried to hijiack paths that are matching directories in public directory
+- [Alfonso Uceda Pompa] Fixed routing issue when static assets server tried to hijack paths that are matching directories in public directory
 
 ## v0.7.1 - 2016-02-05
 ### Fixed
-- [Anton Davydov] Fixed routing issue when static assets server tried to hijiack requests belonging to dynamic endpoints
+- [Anton Davydov] Fixed routing issue when static assets server tried to hijack requests belonging to dynamic endpoints
 - [Anatolii Didukh] Ensure to fallback to default engine for `hanami console`
 
 ## v0.7.0 - 2016-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The web, with simplicity.
 ### Fixed
 - [Aidan Coyle] Remove from app generator support for deprecated `force_ssl` setting
 - [Alessandro Caporrini] Remove from app generator support for deprecated `body_parsers` setting
-- [Daphne Rouw & Sean Collins] Make app generator to work when code in `config/enviroment.rb` uses double quotes
+- [Daphne Rouw & Sean Collins] Make app generator to work when code in `config/environment.rb` uses double quotes
 
 ## v1.3.0 - 2018-10-24
 ### Added
@@ -41,7 +41,7 @@ The web, with simplicity.
 
 ### Fixed
 - [Anton Davydov] Make possible to pass extra settings for custom logger instances (eg. `logger SemanticLogger.new, :foo, :bar`)
-- [graywolf] Ensure `hanami generate app` to work without `require_relative` entries in `config/enviroment.rb`
+- [graywolf] Ensure `hanami generate app` to work without `require_relative` entries in `config/environment.rb`
 - [Makoto Tajitsu & Luca Guidi] Fixed regression for `hanami new .` that used to generate a broken project
 
 ### Fixed
@@ -158,7 +158,7 @@ The web, with simplicity.
 - [Luca Guidi] Make compatible with Rack 2.0 only
 - [Luca Guidi] Removed `logger` settings from Hanami applications
 - [Luca Guidi] Removed logger for Hanami applications (eg `Web.logger`)
-- [Luca Guidi] Changed mailer syntax in `config/enviroment.rb`
+- [Luca Guidi] Changed mailer syntax in `config/environment.rb`
 
 ## v0.9.2 - 2016-12-19
 ## Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,7 +26,7 @@
 - Unobtrusive JavaScript (UJS) (via `hanami-ujs` gem)
 - Interactive console for development error page (via `hanami-webconsole` gem)
 - CLI: register callbacks for `hanami` commands (`Hanami::CLI.after("db migrate", MyCallback.new)` or `Hanami::CLI.after("db migrate") { ... }`)
-- Project level Rack middleware stack (`Hanami.configure { middleware.use MyRackMiddlewre }`)
+- Project level Rack middleware stack (`Hanami.configure { middleware.use MyRackMiddleware }`)
 - Plugins can hook into project configuration (`Hanami.plugin { middleware.use AnotherRackMiddleware }`)
 - Custom repository commands
 - Coloured logging

--- a/lib/hanami/components/app/assets.rb
+++ b/lib/hanami/components/app/assets.rb
@@ -5,7 +5,7 @@ module Hanami
     # @since 0.9.0
     # @api private
     module App
-      # hanami-assets configuration for a sigle Hanami application in the project.
+      # hanami-assets configuration for a single Hanami application in the project.
       #
       # @since 0.9.0
       # @api private

--- a/lib/hanami/components/app/controller.rb
+++ b/lib/hanami/components/app/controller.rb
@@ -8,7 +8,7 @@ module Hanami
     # @since 0.9.0
     # @api private
     module App
-      # hanami-controller configuration for a sigle Hanami application in the project.
+      # hanami-controller configuration for a single Hanami application in the project.
       #
       # @since 0.9.0
       # @api private

--- a/lib/hanami/components/app/routes.rb
+++ b/lib/hanami/components/app/routes.rb
@@ -8,7 +8,7 @@ module Hanami
     # @since 0.9.0
     # @api private
     module App
-      # hanami-router configuration for a sigle Hanami application in the project.
+      # hanami-router configuration for a single Hanami application in the project.
       #
       # @since 0.9.0
       # @api private

--- a/lib/hanami/components/app/view.rb
+++ b/lib/hanami/components/app/view.rb
@@ -5,7 +5,7 @@ module Hanami
     # @since 0.9.0
     # @api private
     module App
-      # hanami-view configuration for a sigle Hanami application in the project.
+      # hanami-view configuration for a single Hanami application in the project.
       #
       # @since 0.9.0
       # @api private

--- a/lib/hanami/early_hints.rb
+++ b/lib/hanami/early_hints.rb
@@ -3,7 +3,7 @@
 module Hanami
   # HTTP/2 Early Hints Rack middleware
   #
-  # It sends extra responses **before** the main reponse is sent.
+  # It sends extra responses **before** the main response is sent.
   # These extra responses are HTTP/2 Early Hints (103).
   # They specify the web assets (javascripts, stylesheets, etc..) to be "pushed",
   # so modern browsers pre-fetch them in parallel with the main HTTP response.

--- a/spec/integration/cli/generate/action_spec.rb
+++ b/spec/integration/cli/generate/action_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "hanami generate", type: :integration do
       end
 
       it "fails with unknown argument" do
-        with_project('bookshelf_generate_action_uknown_method') do
+        with_project('bookshelf_generate_action_unknown_method') do
           output = "`FOO' is not a valid HTTP method. Please use one of: `GET' `POST' `PUT' `DELETE' `HEAD' `OPTIONS' `TRACE' `PATCH' `OPTIONS' `LINK' `UNLINK'"
           run_cmd "hanami generate action web books#create --method=FOO", output, exit_status: 1
         end


### PR DESCRIPTION
I put the codebase through a spellchecker & spotted 7 typos that looked pretty easy to update.

Primary these changes were in the changelog & comments.