### PR TITLE
Point to 1.x-master branch of hanami-view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'hanami-utils',       '~> 1.3', require: false, git: 'https://github.com/han
 gem 'hanami-validations', '~> 1.3', require: false, git: 'https://github.com/hanami/validations.git', branch: 'master'
 gem 'hanami-router',      '~> 1.3', require: false, git: 'https://github.com/hanami/router.git',      branch: 'master'
 gem 'hanami-controller',  '~> 1.3', require: false, git: 'https://github.com/hanami/controller.git',  branch: 'master'
-gem 'hanami-view',        '~> 1.3', require: false, git: 'https://github.com/hanami/view.git',        branch: 'master'
+gem 'hanami-view',        '~> 1.3', require: false, git: 'https://github.com/hanami/view.git',        branch: '1.x-master'
 gem 'hanami-model',       '~> 1.3', require: false, git: 'https://github.com/hanami/model.git',       branch: 'master'
 gem 'hanami-helpers',     '~> 1.3', require: false, git: 'https://github.com/hanami/helpers.git',     branch: 'master'
 gem 'hanami-mailer',      '~> 1.3', require: false, git: 'https://github.com/hanami/mailer.git',      branch: 'master'


### PR DESCRIPTION
This is the new default branch for the 1.x series of hanami-view releases (the master branch now contains the full history of dry-view, now renamed to hanami-view).

Fixes #1036