### PR TITLE
CLI application env handling and dotenv improvements

### DIFF
--- a/lib/hanami/application/settings/loader.rb
+++ b/lib/hanami/application/settings/loader.rb
@@ -53,8 +53,17 @@ module Hanami
 
         def load_dotenv
           require "dotenv"
-          Dotenv.load if defined?(Dotenv)
+          Dotenv.load(*dotenv_files) if defined?(Dotenv)
         rescue LoadError # rubocop:disable Lint/SuppressedException
+        end
+
+        def dotenv_files
+          [
+            ".env.#{Hanami.env}.local",
+            (".env.local" unless Hanami.env?(:test)),
+            ".env.#{Hanami.env}",
+            ".env"
+          ].compact
         end
 
         def load_settings(defined_settings) # rubocop:disable Metrics/MethodLength

--- a/lib/hanami/cli/application/cli.rb
+++ b/lib/hanami/cli/application/cli.rb
@@ -10,11 +10,9 @@ module Hanami
       class CLI < Hanami::CLI
         attr_reader :application
 
-        def initialize(application: Hanami.application, commands: Commands)
+        def initialize(application: nil, commands: Commands)
           super(commands)
           @application = application
-
-          application.init
         end
 
         private
@@ -24,7 +22,13 @@ module Hanami
           command, arguments = super
 
           if command.respond_to?(:with_application)
-            application.config.env = arguments[:env] if arguments[:env]
+            # Set HANAMI_ENV before the application inits to ensure all aspects
+            # of the boot process respect the provided env
+            ENV["HANAMI_ENV"] = arguments[:env] if arguments[:env]
+
+            require "hanami/init"
+            application = Hanami.application
+
             [command.with_application(application), arguments]
           else
             [command, arguments]

--- a/spec/unit/hanami/application/settings/loader_spec.rb
+++ b/spec/unit/hanami/application/settings/loader_spec.rb
@@ -20,10 +20,37 @@ RSpec.describe Hanami::Application::Settings::Loader do
           stub_const "Dotenv", dotenv
         end
 
-        it "requires and loads dotenv" do
+        it "requires and loads a range of dotenv files, specific to the current HANAMI_ENV" do
           loaded_settings
+
           expect(loader).to have_received(:require).with("dotenv").ordered
-          expect(dotenv).to have_received(:load).ordered
+          expect(dotenv).to have_received(:load).ordered.with(
+            ".env.development.local",
+            ".env.local",
+            ".env.development",
+            ".env"
+          )
+        end
+
+        context "HANAMI_ENV is 'test'" do
+          before do
+            @hanami_env = ENV["HANAMI_ENV"]
+            ENV["HANAMI_ENV"] = "test"
+          end
+
+          after do
+            ENV["HANAMI_ENV"] = @hanami_env
+          end
+
+          it "does not load .env.local (which is intended for non-test settings only)" do
+            loaded_settings
+
+            expect(dotenv).to have_received(:load).ordered.with(
+              ".env.test.local",
+              ".env.test",
+              ".env"
+            )
+          end
         end
       end
 


### PR DESCRIPTION
We had a problem with our Hanami 2 app where the HANAMI_ENV, when passed by the `-e` flag to the CLI, was being set too late for some processing of application settings based on the env.

This PR defers the init of the app as late as possible, which means the correct env is in place for the entirety of the application boot (which fixes our issue and should also help with ensuring more predictable behavior overall).

Along with this, I've expanded the number of files loaded by Dotenv by default. This brings it inline with the behavior of dotenv-rails, which I think is a good model to follow. This change is bundled in here because it means that e.g. `.env.test` can finally be respected when using the `-e test` flag to CLI commands (we had to hack this into our app until I could fix it properly here).