### PR TITLE
Ensure rack middleware args remain properly splattable

### DIFF
--- a/lib/hanami/application/router.rb
+++ b/lib/hanami/application/router.rb
@@ -28,7 +28,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def use(middleware, *args, &blk)
-        @stack.use(middleware, args, &blk)
+        @stack.use(middleware, *args, &blk)
       end
 
       # @since 2.0.0


### PR DESCRIPTION
The problem here was that we weren’t passing along splatted middleware args from the application router's outside `use` to the stack's `use`, which meant that an initial args of `[]` became `[[]]` when they were put on the stack, which _then_ meant we would end up seeing errors like “ArgumentError: wrong number of arguments (given 2, expected 1)” when trying to mount rack middleware with `#initialize` params signatures of just `(app)`. This was because we were effectively passing `(app, *[[]])` arguments, which meant an effective second argument of `[]` instead of no second argument at all (for the case of a simple `use` statement with no args).

This fix should ensure we have compatibility again with all rack middlewares, regardless of their initialize params signatures.