### PR TITLE
Introduce hanami version CLI command

### DIFF
--- a/lib/hanami/cli/commands.rb
+++ b/lib/hanami/cli/commands.rb
@@ -57,6 +57,7 @@ module Hanami
     module Commands
       extend Hanami::CLI::Registry
 
+      require "hanami/cli/commands/version"
       require "hanami/cli/commands/command"
       require "hanami/cli/commands/server"
     end

--- a/lib/hanami/cli/commands/version.rb
+++ b/lib/hanami/cli/commands/version.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Hanami
+  class CLI
+    module Commands
+      # @since 1.1.0
+      # @api private
+      class Version < Command
+        desc "Print Hanami version"
+
+        # @since 1.1.0
+        # @api private
+        def call(*)
+          puts "v#{Hanami::VERSION}"
+        end
+      end
+    end
+
+    register "version", Commands::Version, aliases: ["v", "-v", "--version"]
+  end
+end

--- a/spec/integration/cli/version_spec.rb
+++ b/spec/integration/cli/version_spec.rb
@@ -4,25 +4,25 @@ RSpec.describe "hanami version", type: :integration do
   context "within a project" do
     it "prints current version" do
       with_project do
-        run_command "hanami version", "v#{Hanami::VERSION}"
+        run_cmd "hanami version", "v#{Hanami::VERSION}"
       end
     end
 
     it "prints current version with v alias" do
       with_project do
-        run_command "hanami v", "v#{Hanami::VERSION}"
+        run_cmd "hanami v", "v#{Hanami::VERSION}"
       end
     end
 
     it "prints current version with -v alias" do
       with_project do
-        run_command "hanami -v", "v#{Hanami::VERSION}"
+        run_cmd "hanami -v", "v#{Hanami::VERSION}"
       end
     end
 
     it "prints current version with --version alias" do
       with_project do
-        run_command "hanami --version", "v#{Hanami::VERSION}"
+        run_cmd "hanami --version", "v#{Hanami::VERSION}"
       end
     end
 
@@ -42,26 +42,26 @@ RSpec.describe "hanami version", type: :integration do
             --help, -h                      	# Print this help
         OUT
 
-        run_command "hanami version --help", output
+        run_cmd "hanami version --help", output
       end
     end
   end
 
   context "outside of a project" do
     it "prints current version" do
-      run_command "hanami version", "v#{Hanami::VERSION}"
+      run_cmd "hanami version", "v#{Hanami::VERSION}"
     end
 
     it "prints current version with v alias" do
-      run_command "hanami v", "v#{Hanami::VERSION}"
+      run_cmd "hanami v", "v#{Hanami::VERSION}"
     end
 
     it "prints current version with -v alias" do
-      run_command "hanami -v", "v#{Hanami::VERSION}"
+      run_cmd "hanami -v", "v#{Hanami::VERSION}"
     end
 
     it "prints current version with --version alias" do
-      run_command "hanami --version", "v#{Hanami::VERSION}"
+      run_cmd "hanami --version", "v#{Hanami::VERSION}"
     end
 
     it "prints help message" do
@@ -79,7 +79,7 @@ RSpec.describe "hanami version", type: :integration do
           --help, -h                      	# Print this help
       OUT
 
-      run_command "hanami version --help", output
+      run_cmd "hanami version --help", output
     end
   end
 end


### PR DESCRIPTION
Hey

I added `hanami version` CLI command and also fix specs. We used `run_command` but it conflicted with aruba helpers (you can find revert commit from @jodosha  here: https://github.com/hanami/devtools/commit/afc2341578408af0581e5003888bdc59f4d476db)