### PR TITLE
Fix Ruby 2.7 keyword argument warnings

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -94,12 +94,12 @@ module Hanami
         slices[name.to_sym] = slice
       end
 
-      def register(*args, &block)
-        container.register(*args, &block)
+      def register(*args, **opts, &block)
+        container.register(*args, **opts, &block)
       end
 
-      def register_bootable(*args, &block)
-        container.boot(*args, &block)
+      def register_bootable(*args, **opts, &block)
+        container.boot(*args, **opts, &block)
       end
 
       def init_bootable(*args)
@@ -244,7 +244,7 @@ module Hanami
 
         unless container.key?(:logger)
           require "hanami/logger"
-          container.register :logger, Hanami::Logger.new(configuration.logger)
+          container.register :logger, Hanami::Logger.new(**configuration.logger)
         end
 
         unless container.key?(:rack_monitor)

--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -17,8 +17,8 @@ module Hanami
       end
 
       def attach(rack_monitor)
-        rack_monitor.on :stop do |env:, status:, time:|
-          log_request env, status, time
+        rack_monitor.on :stop do |event|
+          log_request event[:env], event[:status], event[:time]
         end
 
         rack_monitor.on :error do |event|


### PR DESCRIPTION
The kinds of warnings we were seeing:

```
/path/to/dry-monitor-0.3.2/lib/dry/monitor/notifications.rb:49: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/hanami-88aa9c9825e4/lib/hanami/web/rack_logger.rb:20: warning: The called method `call' is defined here
```

With these changes, these warnings are no longer emitted.