### PR TITLE
Require delegate library

### DIFF
--- a/lib/hanami/console/plugins/slice_readers.rb
+++ b/lib/hanami/console/plugins/slice_readers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "delegate"
+
 module Hanami
   module Console
     module Plugins


### PR DESCRIPTION
Testing out @timriley's example Hanami 2 app, I was unable to run the console / db tasks due to an uninitialized constant `SimpleDelegator`.

Reproducible in `unstable` with `ruby -rbundler/setup -rhanami/cli/application/cli -e Hanami::CLI::Application::CLI.new.call`

```
oot@7c71d7029846:/app# ruby -rbundler/setup -rhanami/cli/application/cli -e Hanami::CLI::Application::CLI.new.call
Traceback (most recent call last):
        17: from -e:in `require'
        16: from /app/lib/hanami/cli/application/cli.rb:4:in `<top (required)>'
        15: from /app/lib/hanami/cli/application/cli.rb:4:in `require_relative'
        14: from /app/lib/hanami/cli/application/commands.rb:5:in `<top (required)>'
        13: from /app/lib/hanami/cli/application/commands.rb:6:in `<module:Hanami>'
        12: from /app/lib/hanami/cli/application/commands.rb:7:in `<class:CLI>'
        11: from /app/lib/hanami/cli/application/commands.rb:9:in `<module:Application>'
        10: from /app/lib/hanami/cli/application/commands.rb:12:in `<module:Commands>'
         9: from /app/lib/hanami/cli/application/commands.rb:12:in `require_relative'
         8: from /app/lib/hanami/cli/application/commands/console.rb:5:in `<top (required)>'
         7: from /app/lib/hanami/cli/application/commands/console.rb:5:in `require'
         6: from /app/lib/hanami/console/context.rb:3:in `<top (required)>'
         5: from /app/lib/hanami/console/context.rb:3:in `require_relative'
         4: from /app/lib/hanami/console/plugins/slice_readers.rb:3:in `<top (required)>'
         3: from /app/lib/hanami/console/plugins/slice_readers.rb:4:in `<module:Hanami>'
         2: from /app/lib/hanami/console/plugins/slice_readers.rb:5:in `<module:Console>'
         1: from /app/lib/hanami/console/plugins/slice_readers.rb:8:in `<module:Plugins>'
/app/lib/hanami/console/plugins/slice_readers.rb:19:in `<class:SliceReaders>': uninitialized constant Hanami::Console::Plugins::SliceReaders::SimpleDelegator (NameError)
```
