### PR TITLE
Gracefully handle unnamed classes given to Application.component_provider

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -210,6 +210,8 @@ module Hanami
         component_class = component.is_a?(Class) ? component : component.class
         component_name = component_class.name
 
+        return unless component_name
+
         providers.detect { |provider| component_name.include?(provider.namespace.to_s) }
       end
 

--- a/spec/new_integration/application/component_provider_spec.rb
+++ b/spec/new_integration/application/component_provider_spec.rb
@@ -4,6 +4,7 @@ require "hanami/application"
 
 RSpec.describe Hanami::Application, "#component_provider", :application_integration do
   let(:application) { Hanami.application }
+  let(:application_modules) { %i[TestApp Main External] }
 
   before do
     module TestApp
@@ -32,6 +33,22 @@ RSpec.describe Hanami::Application, "#component_provider", :application_integrat
 
     it "returns the application" do
       expect(application.component_provider(component)).to eq application
+    end
+  end
+
+  context "component from external (non-app/slice) namespace" do
+    let(:component) { External::Component = Class.new }
+
+    it "returns nil" do
+      expect(application.component_provider(component)).to be_nil
+    end
+  end
+
+  context "unnamed component" do
+    let(:component) { Class.new }
+
+    it "returns nil" do
+      expect(application.component_provider(component)).to be_nil
     end
   end
 end


### PR DESCRIPTION
This is a small robustness fix for this method – in a real test suite for an Hanami 2 codebase, we had some tests that used anonymous classes inheriting from `Hanami::Action`, which before this fix, would result in a crash. This is obviously not what we want, and IMO there is a clear behaviour that should be exhibited for anonymous classes - they clearly are not attached to any given component provider, so the method should gracefully return nil.