### PR TITLE
Update CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             coverage: "true"
     env:
       COVERAGE: ${{matrix.coverage}}
+      CI: true
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby
@@ -45,3 +46,8 @@ jobs:
         run: bundle install --jobs 4 --retry 3
       - name: Run all tests
         run: bundle exec rake
+      - name: Send test coverage report to codecov.io
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{secrets.COVERAGE_TOKEN}}
+          file: ./coverage/.resultset.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Bundle install
         run: bundle install --jobs 4 --retry 3
       - name: Run all tests
-        run: script/ci
+        run: bundle exec rake

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "support/coverage" if ENV["COVERAGE"].eql?("true")
+
 require "hanami"
 require "hanami/utils/file_list"
 require "hanami/devtools/unit"

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,0 +1,1 @@
+require "hanami/devtools/unit/support/coverage"


### PR DESCRIPTION
## TODO

- [x] use the official codecov action
- [x] ~disable travis hooks~ I realized this shouldn't be done because master still depends on travis builds (I think)
- [x] use the default rake task instead of `scripts/ci`
- [x] ~add a rubocop step~ I gave up, too many offenses. This can be done later.