### PR TITLE
Fix now-evaluation at Hanami::CommonLogger

### DIFF
--- a/lib/hanami/common_logger.rb
+++ b/lib/hanami/common_logger.rb
@@ -55,7 +55,7 @@ module Hanami
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def log(env, status, header, began_at)
-      now    = Time.now
+      now    = Rack::Utils.clock_time
       length = extract_content_length(header)
 
       msg = Hash[

--- a/lib/hanami/common_logger.rb
+++ b/lib/hanami/common_logger.rb
@@ -55,7 +55,7 @@ module Hanami
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def log(env, status, header, began_at)
-      now    = Rack::Utils.clock_time
+      now    = ElapsedTime.call
       length = extract_content_length(header)
 
       msg = Hash[
@@ -88,6 +88,22 @@ module Hanami
       result.merge!(env.fetch(FORM_HASH, {}))
       result.merge!(Utils::Hash.deep_stringify(env.fetch(ROUTER_PARAMS, {})))
       result
+    end
+
+    # Wrapper which uses Rack's monotonic class (used for began_at since Rack 2.1.0)
+    #
+    # @since 1.3.4
+    # @api private
+    class ElapsedTime
+      @clock = if Gem::Version.new(Rack::RELEASE) >= Gem::Version.new('2.1.0')
+                 -> { Rack::Utils.clock_time }
+               else
+                 -> { Time.now }
+               end.freeze
+
+      def self.call
+        @clock.call
+      end
     end
   end
 end

--- a/lib/hanami/common_logger.rb
+++ b/lib/hanami/common_logger.rb
@@ -90,7 +90,7 @@ module Hanami
       result
     end
 
-    # Wrapper which uses Rack's monotonic class (used for began_at since Rack 2.1.0)
+    # Wrapper which uses Rack's monotonic clock_time (used for began_at since Rack 2.1.0)
     #
     # @since 1.3.4
     # @api private

--- a/spec/unit/hanami/common_logger_spec.rb
+++ b/spec/unit/hanami/common_logger_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe Hanami::CommonLogger do
         get "/"
 
         device.rewind
-        expect(device.read).to include(%(:path=>"logo.png"))
+        read_device = device.read
+        expect(read_device).to include(%(:path=>"logo.png"))
+        expect(read_device).to include(%(:elapsed=>0.))
       end
     end
   end


### PR DESCRIPTION
This commit at Rack (rack/rack@743f29d) changed the evaluation of `began_at` at `Rack::CommonLogger`. With that change Hanami's `CommonLogger` cannot calculate `elapsed` properly.

The result are logging-entries like that: 
```txt
[bookshelf] [INFO] [2020-06-20 19:11:23 +0200] HTTP/1.1 GET 200 127.0.0.1 / 14915 {} 2020-06-20 16:10:40 +0200
``` 
with this fix, `elapsed` is calculated properly
```txt
[bookshelf] [INFO] [2020-06-20 19:11:23 +0200] HTTP/1.1 GET 200 127.0.0.1 / 14915 {} 0.0457000
``` 
WDYT?
best regards