### PR TITLE
Fix isolation specs for recent "Application action" changes

### DIFF
--- a/spec/isolation/hanami/application/routes/configured_spec.rb
+++ b/spec/isolation/hanami/application/routes/configured_spec.rb
@@ -8,6 +8,12 @@ module Bookshelf
 end
 
 module Web
+end
+Hanami.application.register_slice :web, namespace: Web
+
+Hanami.init
+
+module Web
   class Action < Hanami::Action
   end
 

--- a/spec/isolation/hanami/boot/success_spec.rb
+++ b/spec/isolation/hanami/boot/success_spec.rb
@@ -8,6 +8,12 @@ module Bookshelf
   end
 end
 
+module Web
+end
+slice = Hanami.application.register_slice :web, namespace: Web
+
+Hanami.init
+
 Hanami.application.routes do
   mount :web, at: "/" do
     root to: "home#index"
@@ -25,8 +31,6 @@ module Web
     end
   end
 end
-
-slice = Hanami.application.register_slice :web, namespace: Web
 
 slice.register "actions.home.index" do
   Web::Actions::Home::Index.new


### PR DESCRIPTION
These broke when inheriting from Hanami::Action resulted in a call to Hanami.application.component_provider, which wants the slices to be registered already.

Explicitly registering the slices earlier and init’ing the app is the fix here, but I’d also like to explore making single file Hanami apps a little more ergonomic in the future.

FWIW, I still plan on converting all of the isolation specs into the "new style" integration tests, which can be run as part of a single test suite.