### PR TITLE
Fix Rubocop in main branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,6 @@ gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.
 group :test do
   gem "dotenv"
   gem "dry-types"
+  gem "rubocop", "~> 0.86"
   gem "slim"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
-gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "unstable"
-gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "unstable"
-gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "unstable"
 gem "hanami-cli", "~> 1.0.alpha", require: false, git: "https://github.com/hanami/cli.git", branch: "unstable"
+gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "unstable"
+gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "unstable"
+gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "unstable"
 gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", branch: "master"
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -239,7 +239,7 @@ module Hanami
         namespace.const_set :Container, Class.new(Dry::System::Container)
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def configure_container(container)
         container.use :env, inferrer: -> { Hanami.env }
         container.use :notifications
@@ -283,7 +283,7 @@ module Hanami
 
         container
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def define_deps_module
         require "#{application_name}/deps"

--- a/lib/hanami/cli/commands/command.rb
+++ b/lib/hanami/cli/commands/command.rb
@@ -108,7 +108,7 @@ module Hanami
           # @since 1.1.0
           # @api private
           def call(template, context)
-            ::ERB.new(template, nil, TRIM_MODE).result(context)
+            ::ERB.new(template, trim_mode: TRIM_MODE).result(context)
           end
         end
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -42,11 +42,9 @@ module Hanami
       self
     end
 
-    # rubocop:disable Style/DoubleNegation
     def booted?
       !!@booted
     end
-    # rubocop:enable Style/DoubleNegation
 
     def container
       @container ||= define_container

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "hanami/devtools/unit/support/coverage"


### PR DESCRIPTION
This installs the most recent Rubocop locally and addresses any outstanding issues it raised. This should enable `script/ci` to work in full again (and will allow us to restore Rubocop as part of the GitHub actions).