### PR TITLE
Make all Hanami::View settings available in Hanami.appliaction.config.views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/han
 gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "unstable"
 gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "unstable"
 gem "hanami-cli", "~> 1.0.alpha", require: false, git: "https://github.com/hanami/cli.git", branch: "unstable"
-gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", branch: "master"
+gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", branch: "enhancement/application-view-expanded-config"
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git"
 

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -22,6 +22,7 @@ module Hanami
     require_relative "configuration/views"
 
     attr_reader :actions
+    attr_reader :views
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def initialize(env:)
@@ -47,11 +48,11 @@ module Hanami
       self.router     = Router.new(base_url)
       self.middleware = Middleware.new
       self.security   = Security.new
-      self.views      = Views.new
 
       self.inflections = Dry::Inflector.new
 
       @actions = Actions.new
+      @views = Views.new
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -186,10 +187,6 @@ module Hanami
       settings.fetch(:middleware)
     end
 
-    def views
-      settings.fetch(:views)
-    end
-
     def security=(value)
       settings[:security] = value
     end
@@ -227,10 +224,6 @@ module Hanami
 
     def middleware=(value)
       settings[:middleware] = value
-    end
-
-    def views=(value)
-      settings[:views] = value
     end
 
     def inflections=(value)

--- a/spec/unit/hanami/configuration/views_spec.rb
+++ b/spec/unit/hanami/configuration/views_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "hanami/configuration"
+require "hanami/configuration/views"
+
+RSpec.describe Hanami::Configuration, "#views" do
+  let(:configuration) { described_class.new(env: :development) }
+  subject(:actions) { configuration.views }
+
+  it "returns an Hanami::Configuration::Views" do
+    is_expected.to be_an_instance_of(Hanami::Configuration::Views)
+  end
+end
+
+RSpec.describe Hanami::Configuration::Views do
+  subject(:configuration) { described_class.new }
+
+  context "Hanami::View available" do
+    it "exposes Hanami::View settings" do
+      expect(configuration).to respond_to(:paths)
+      expect(configuration).to respond_to(:paths=)
+    end
+  end
+
+  context "Hanami::View not available" do
+    before do
+      load_error = LoadError.new.tap do |error|
+        error.instance_variable_set :@path, "hanami/view"
+      end
+
+      allow_any_instance_of(described_class)
+        .to receive(:require)
+        .with("hanami/view")
+        .and_raise load_error
+    end
+
+    it "does not expose any settings" do
+      expect(configuration).not_to respond_to(:paths)
+      expect(configuration).not_to respond_to(:paths=)
+    end
+  end
+end


### PR DESCRIPTION
This PR follows the pattern we established in https://github.com/hanami/hanami/pull/1065. In this case, we import the full config from `Hanami::View` and make it available for application-level config at `Hanami.application.config.views`.

Alongside with the counterpart PR in https://github.com/hanami/view/pull/176, this makes every aspect of view configuration available on the application, which means we can keep view-specific config in the same place as the rest of the application config, and do not need to repeat common config across multiple base views (e.g. within different slices).