### PR TITLE
Use bootable files for all standard components

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
+gem "dry-system", git: "https://github.com/dry-rb/dry-system.git", branch: "bootable-paths"
 gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "unstable"
 gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "unstable"
 gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "unstable"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
-gem "dry-system", git: "https://github.com/dry-rb/dry-system.git", branch: "bootable-paths"
 gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "unstable"
 gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "unstable"
 gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "unstable"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_dependency "dry-core",          "~> 0.4"
   spec.add_dependency "dry-inflector",     "~> 0.1", ">= 0.1.2"
   spec.add_dependency "dry-monitor"
-  spec.add_dependency "dry-system",        "~> 0.10"
+  spec.add_dependency "dry-system",        "~> 0.18", ">= 0.18.0"
   spec.add_dependency "hanami-cli",        "~> 1.0.alpha"
   spec.add_dependency "hanami-controller", "~> 2.0.alpha"
   spec.add_dependency "hanami-router",     "~> 2.0.alpha"

--- a/lib/hanami/application/container/boot/inflector.rb
+++ b/lib/hanami/application/container/boot/inflector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami.application.register_bootable :inflector do
   start do
     register :inflector, Hanami.application.inflector

--- a/lib/hanami/application/container/boot/inflector.rb
+++ b/lib/hanami/application/container/boot/inflector.rb
@@ -1,0 +1,5 @@
+Hanami.application.register_bootable :inflector do
+  start do
+    register :inflector, Hanami.application.inflector
+  end
+end

--- a/lib/hanami/application/container/boot/logger.rb
+++ b/lib/hanami/application/container/boot/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami.application.register_bootable :logger do
   start do
     require "hanami/logger"

--- a/lib/hanami/application/container/boot/logger.rb
+++ b/lib/hanami/application/container/boot/logger.rb
@@ -1,0 +1,6 @@
+Hanami.application.register_bootable :logger do
+  start do
+    require "hanami/logger"
+    register :logger, Hanami::Logger.new(**Hanami.application.configuration.logger)
+  end
+end

--- a/lib/hanami/application/container/boot/rack_logger.rb
+++ b/lib/hanami/application/container/boot/rack_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami.application.register_bootable :rack_logger do |container|
   start do
     require "hanami/web/rack_logger"

--- a/lib/hanami/application/container/boot/rack_logger.rb
+++ b/lib/hanami/application/container/boot/rack_logger.rb
@@ -1,0 +1,17 @@
+Hanami.application.register_bootable :rack_logger do |container|
+  start do
+    require "hanami/web/rack_logger"
+
+    use :logger
+    use :rack_monitor
+
+    rack_logger = Hanami::Web::RackLogger.new(
+      container[:logger],
+      filter_params: Hanami.application.configuration.rack_logger_filter_params
+    )
+
+    rack_logger.attach container[:rack_monitor]
+
+    register :rack_logger, rack_logger
+  end
+end

--- a/lib/hanami/application/container/boot/rack_monitor.rb
+++ b/lib/hanami/application/container/boot/rack_monitor.rb
@@ -1,0 +1,10 @@
+Hanami.application.register_bootable :rack_monitor do |container|
+  start do
+    require "dry/monitor"
+    require "dry/monitor/rack/middleware"
+
+    middleware = Dry::Monitor::Rack::Middleware.new(container[:notifications])
+
+    register :rack_monitor, middleware
+  end
+end

--- a/lib/hanami/application/container/boot/rack_monitor.rb
+++ b/lib/hanami/application/container/boot/rack_monitor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami.application.register_bootable :rack_monitor do |container|
   start do
     require "dry/monitor"

--- a/lib/hanami/application/container/boot/settings.rb
+++ b/lib/hanami/application/container/boot/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami.application.register_bootable :settings do
   start do
     register :settings, Hanami.application.settings

--- a/lib/hanami/application/container/boot/settings.rb
+++ b/lib/hanami/application/container/boot/settings.rb
@@ -1,0 +1,5 @@
+Hanami.application.register_bootable :settings do
+  start do
+    register :settings, Hanami.application.settings
+  end
+end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -104,6 +104,7 @@ module Hanami
 
       if root && File.directory?(root)
         container.config.root = root
+        container.config.bootable_dirs = ["config/boot"]
 
         container.config.auto_register = ["lib/#{namespace_path}"]
         container.config.default_namespace = namespace_path.tr("/", ".")

--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Application settings", :application_integration do
     end
   end
 
-  specify "Settings are altogether optional" do
+  specify "Settings are nil when not defined" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/application.rb", <<~RUBY
         require "hanami"
@@ -157,7 +157,7 @@ RSpec.describe "Application settings", :application_integration do
       require "hanami/init"
 
       expect(Hanami.application.settings).to be_nil
-      expect { Hanami.application.container[:settings] }.to raise_error Dry::System::ComponentLoadError
+      expect(Hanami.application.container[:settings]).to be_nil
     end
   end
 end

--- a/spec/new_integration/container/standard_bootable_components_spec.rb
+++ b/spec/new_integration/container/standard_bootable_components_spec.rb
@@ -1,0 +1,129 @@
+RSpec.describe "Container / Standard bootable components", :application_integration do
+  specify "Standard components are available on booted container" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "lib/test_app/.keep", ""
+
+      require "hanami/setup"
+      Hanami.boot web: false
+
+      expect(Hanami.application[:settings]).to be_nil
+      expect(Hanami.application[:inflector]).to eql Hanami.application.inflector
+      expect(Hanami.application[:logger]).to be_a_kind_of(Hanami::Logger)
+      expect(Hanami.application[:rack_logger]).to be_a_kind_of(Hanami::Web::RackLogger)
+    end
+  end
+
+  specify "Standard components are resolved lazily on non-booted container" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "lib/test_app/.keep", ""
+
+      require "hanami/setup"
+      Hanami.init
+
+      expect(Hanami.application[:settings]).to be_nil
+      expect(Hanami.application[:inflector]).to eql Hanami.application.inflector
+      expect(Hanami.application[:logger]).to be_a_kind_of(Hanami::Logger)
+      expect(Hanami.application[:rack_logger]).to be_a_kind_of(Hanami::Web::RackLogger)
+    end
+  end
+
+  specify "Settings component is available when settings are defined" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "config/settings.rb", <<~RUBY
+        Hanami.application.settings do
+          setting :session_secret
+        end
+      RUBY
+
+      write "lib/test_app/.keep", ""
+
+      require "hanami/setup"
+      Hanami.boot web: false
+
+      expect(Hanami.application[:settings]).to respond_to :session_secret
+    end
+  end
+
+  specify "Standard components can be replaced by custom bootable components (on booted container)" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "config/boot/logger.rb", <<~RUBY
+        Hanami.application.register_bootable :logger do
+          start do
+            register :logger, "custom logger"
+          end
+        end
+      RUBY
+
+      write "lib/test_app/.keep", ""
+
+      require "hanami/setup"
+      Hanami.boot web: false
+
+      expect(Hanami.application[:logger]).to eq "custom logger"
+    end
+  end
+
+  specify "Standard components can be replaced by custom bootable components resolved lazily (on non-booted container)" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "config/boot/logger.rb", <<~RUBY
+        Hanami.application.register_bootable :logger do
+          start do
+            register :logger, "custom logger"
+          end
+        end
+      RUBY
+
+      write "lib/test_app/.keep", ""
+
+      require "hanami/setup"
+      Hanami.init
+
+      expect(Hanami.application[:logger]).to eq "custom logger"
+    end
+  end
+end

--- a/spec/support/application_integration.rb
+++ b/spec/support/application_integration.rb
@@ -31,7 +31,7 @@ RSpec.configure do |config|
   config.after :each, :application_integration do
     $LOAD_PATH.replace(@load_paths)
     $LOADED_FEATURES.delete_if do |feature_path|
-      feature_path =~ %r{hanami/(setup|init|boot)}
+      feature_path =~ %r{hanami/(setup|init|boot|application/container/boot)}
     end
 
     application_modules.each do |app_module|


### PR DESCRIPTION
This uses the new `bootable_dirs` setting just released in dry-system 0.18 (see https://github.com/dry-rb/dry-system/pull/151 for details) and configures 2 bootable dirs for the main application container:

- A new `lib/hanami/application/container/boot` directory, shipped as part of the gem
- The `config/boot` directory within the application's root (n.b. this is a change from the previous default of `system/boot`)

It then moves the registration of our application's standard components into bootable component files inside `lib/hanami/application/container/boot`.

This arrangement allows the application's standard components to be replaced by custom components within applications (e.g. providing a custom logger, which was the use case that drove this change), just by the application providing a same-named boot file in its own `config/boot` directory. Previously, this level of customisation was not possible, because it was impossible to arrange any application to run before the `configure_container` method inside `Hanami::Application`.

This change also makes the `configure_container` method more rational – it applies some config settings _only_, and leaves the component boot process to this new dry-system behavior.