### PR TITLE
Pass base config to actions; finalize all configs

### DIFF
--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -53,7 +53,7 @@ module Hanami
       @actions = begin
         require_path = "hanami/action/application_configuration"
         require require_path
-        Hanami::Action::ApplicationConfiguration.new
+        Hanami::Action::ApplicationConfiguration.new(self)
       rescue LoadError => e
         raise e unless e.path == require_path
         Object.new
@@ -67,6 +67,10 @@ module Hanami
       environment_for(env).each do |blk|
         instance_eval(&blk)
       end
+
+      # Finalize nested configuration objects
+      actions.finalize!
+      views.finalize!
 
       self
     end


### PR DESCRIPTION
This allows the actions configuration to adapt to various top-level configs, e.g. to enable CSRF protections automatically in the case of `config.sessions.enabled?` being true.

We handle this by passing the base application config to the nested actions config, and then call `finalize!` on the nested actions config when the base config is finalized.

This means the nested actions config can adapt its own configuration at the last moment, which ensures we support the user specifying their configs in whatever order they like prior to this.

This PR enables the automatic enabling of action CSRF protection in https://github.com/hanami/controller/pull/329