### PR TITLE
Drop `git` in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,3 +51,8 @@ gem 'hanami-webconsole', require: false, git: 'https://github.com/hanami/webcons
 
 # https://github.com/hanami/hanami/issues/893
 gem 'builder'
+
+# for hanami's downstream maintenance
+if RUBY_VERSION.to_f >= 2.4
+  gem 'rubocop-packaging', '~> 0.5'
+end

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -2,6 +2,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hanami/version'
+require 'rake/file_list'
 
 Gem::Specification.new do |spec|
   spec.name          = 'hanami'
@@ -13,9 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://hanamirb.org'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -c -o --exclude-standard -z -- lib/* bin/* LICENSE.md README.md CODE_OF_CONDUCT.md CHANGELOG.md FEATURES.md hanami.gemspec`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test)/})
+  spec.files         = Rake::FileList['{lib,bin}/**/{*,.*}'].exclude(*File.read('.gitignore').split)
+                                                            .reject { |f| File.directory?(f) } +
+                       %w(LICENSE.md README.md CODE_OF_CONDUCT.md CHANGELOG.md FEATURES.md hanami.gemspec)
+  spec.executables   = ['hanami']
+  spec.test_files    = Rake::FileList['spec/**/*']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 


### PR DESCRIPTION
Hi @jodosha 👋🏻 

As discussed in #1075, here's the PR that drops `git` in gemspec! 😄 

Using git in gemspec, in general, a bit troublesome and it's best if avoided.
The rationale about this can be found here: https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#gemspec-git-rationale

Closes: #1075 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>