### PR TITLE
Allow `hanami` to be started from non-root directory

### DIFF
--- a/lib/hanami/cli/commands/new/config.ru.erb
+++ b/lib/hanami/cli/commands/new/config.ru.erb
@@ -1,3 +1,3 @@
-require './config/environment'
+require_relative 'config/environment'
 
 run Hanami.app


### PR DESCRIPTION
I've tried to use hanami app as a dummy for another gem testing & run it via `Rack::Builder.parse_file('./dummy/config.ru').first`, but it fails to find `config/environment` in that case. 
This change allows application to be started and actually serve some pages. More complex usage still fails due to `Hanami::Environment#root` assuming that we're running from app root, but at least it works for my usecase without models/mailers.