### PR TITLE
Use monotonic time in common_logger

### DIFF
--- a/lib/hanami/common_logger.rb
+++ b/lib/hanami/common_logger.rb
@@ -55,7 +55,7 @@ module Hanami
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def log(env, status, header, began_at)
-      now    = Time.now
+      now    = Concurrent.monotonic_time
       length = extract_content_length(header)
 
       msg = Hash[
@@ -66,7 +66,7 @@ module Hanami
         path:    env[SCRIPT_NAME] + env[PATH_INFO].to_s,
         length:  length,
         params:  extract_params(env),
-        elapsed: now - began_at
+        elapsed: '%.4f' % (now - began_at)
       ]
 
       logger = @logger || env[RACK_ERRORS]

--- a/spec/unit/hanami/common_logger_spec.rb
+++ b/spec/unit/hanami/common_logger_spec.rb
@@ -26,5 +26,36 @@ RSpec.describe Hanami::CommonLogger do
         expect(device.read).to include(%(:path=>"logo.png"))
       end
     end
+
+    context "when ELAPSED time is present" do
+      it "returns the elapsed time" do
+        freeze_clock_time_at(Time.at(0), Time.at(1)) do
+          get "/"
+        end
+
+        device.rewind
+        expect(device.read).to include(%(:elapsed=>"1.0000"))
+      end
+    end
+  end
+
+  # For the sake of simplicity this method receives only the parameters
+  # it needs to provide data for the calculation of elapsed time, which
+  # means basically, two times:
+  #
+  # begin_at..now
+  def freeze_clock_time_at(first, second)
+    times = [first, second].map(&:to_f)
+
+    clazz = class << Process; self; end
+    clazz.send :alias_method, :xyz, :clock_gettime
+    clazz.send :define_method, :clock_gettime do |_|
+      times.shift
+    end
+
+    yield
+  ensure
+    clazz.send :undef_method, :clock_gettime
+    clazz.send :alias_method, :clock_gettime, :xyz
   end
 end


### PR DESCRIPTION
Relates to: https://github.com/hanami/hanami/issues/1088

### Changes

- Use monotonic time from `concurrent-ruby` to keep consistency with Rack gem
- Fix the milliseconds/seconds in the logline

### Rational

In order to keep consistency between the Rack timestamp and the Hanami one, and based on the point suggested in the same issue #1088 I decided to take a look at the Rack implementation of the elapsed time and why we were using `Time.now` instead of the monotonic version. So, I couldn't find the reasons behind that decision but It seems to make sense to me to use a monotonic time to compare with that one coming from Rack (considering it follows that time counter).

### References

The `rack` implementation:
https://github.com/rack/rack/blob/03b4b9708f375db46ee214b219f709d08ed6eeb0/lib/rack/utils.rb#L82

The `concurrent-ruby` implemetation:
https://github.com/ruby-concurrency/concurrent-ruby/blob/a5076bf9e977b290cce5a65b7b72810562bca295/lib/concurrent-ruby/concurrent/utility/monotonic_time.rb#L11

### Update

The changes this PR contains are also available at [this PR](https://github.com/hanami/hanami/pull/1061) opened 8 months ago, there are slight differences among them but feel free to close it if you guys prefer.