### PR TITLE
Configure new dry-system component_dirs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
+
 gemspec
 
 unless ENV["CI"]
@@ -15,6 +16,9 @@ gem "hanami-cli", "~> 1.0.alpha", require: false, git: "https://github.com/hanam
 gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", branch: "master"
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git", branch: "unstable"
+
+gem "dry-system", git: "https://github.com/dry-rb/dry-system.git", branch: "master"
+gem "dry-configurable", git: "https://github.com/dry-rb/dry-configurable.git", branch: "master"
 
 group :test do
   gem "dotenv"

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", br
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git", branch: "unstable"
 
-gem "dry-system", git: "https://github.com/dry-rb/dry-system.git", branch: "master"
 gem "dry-configurable", git: "https://github.com/dry-rb/dry-configurable.git", branch: "master"
 
 group :test do

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_dependency "dry-core",          "~> 0.4"
   spec.add_dependency "dry-inflector",     "~> 0.1", ">= 0.1.2"
   spec.add_dependency "dry-monitor"
-  spec.add_dependency "dry-system",        "~> 0.18", ">= 0.18.0"
+  spec.add_dependency "dry-system",        "~> 0.19", ">= 0.19.0"
   spec.add_dependency "hanami-cli",        "~> 1.0.alpha"
   spec.add_dependency "hanami-controller", "~> 2.0.alpha"
   spec.add_dependency "hanami-router",     "~> 2.0.alpha"

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -241,17 +241,21 @@ module Hanami
         container.use :env, inferrer: -> { Hanami.env }
         container.use :notifications
 
-        container.config.inflector = configuration.inflector
+        container.configure do |config|
+          config.inflector = configuration.inflector
 
-        container.config.root = configuration.root
-        container.config.bootable_dirs = ["config/boot", Pathname(__dir__).join("application/container/boot").realpath]
-        container.config.auto_register = "lib/#{application_name}"
-        container.config.default_namespace = application_name
+          config.root = configuration.root
+          config.bootable_dirs = [
+            "config/boot",
+            Pathname(__dir__).join("application/container/boot").realpath,
+          ]
 
-        # Force after configure hook to run
-        container.configure do; end
-
-        container.load_paths! "lib"
+          if root.join("lib").directory?
+            config.component_dirs.add "lib" do |dir|
+              dir.default_namespace = application_name.to_s
+            end
+          end
+        end
 
         container
       end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -99,17 +99,20 @@ module Hanami
       container = Class.new(Dry::System::Container)
       container.use :env
 
-      container.config.name = name
-      container.config.inflector = application.configuration.inflector
+      container.configure do |config|
+        config.name = name
+        config.inflector = application.configuration.inflector
 
-      if root && File.directory?(root)
-        container.config.root = root
-        container.config.bootable_dirs = ["config/boot"]
+        if root&.directory?
+          config.root = root
+          config.bootable_dirs = ["config/boot"]
 
-        container.config.auto_register = ["lib/#{namespace_path}"]
-        container.config.default_namespace = namespace_path.tr("/", ".")
-
-        container.load_paths! "lib"
+          if root.join("lib").directory?
+            config.component_dirs.add "lib" do |dir|
+              dir.default_namespace = namespace_path.tr(File::SEPARATOR, config.namespace_separator)
+            end
+          end
+        end
       end
 
       # Force after configure hook to run


### PR DESCRIPTION
This PR updates the dry-system container setup to use the new `component_dirs` setting introduced in https://github.com/dry-rb/dry-system/pull/155 and https://github.com/dry-rb/dry-system/pull/157