### PR TITLE
Fix middleware config so blocks are accepted without error

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -331,7 +331,7 @@ module Hanami
         ) do
           use application[:rack_monitor]
 
-          application.config.for_each_middleware do |m, *args, &block|
+          application.config.for_each_middleware do |m, args, block|
             use(m, *args, &block)
           end
         end

--- a/lib/hanami/configuration/middleware.rb
+++ b/lib/hanami/configuration/middleware.rb
@@ -11,7 +11,7 @@ module Hanami
       end
 
       def use(middleware, *args, &block)
-        stack.push([middleware, *args, block].compact)
+        stack.push([middleware, args, block].compact)
       end
 
       attr_reader :stack


### PR DESCRIPTION
Hey, came across this issue when trying to use middleware with a block. 

```
module Service
  class Application < Hanami::Application
    # ...
    config.middleware.use OmniAuth::Builder do
      provider :developer unless Hanami.env?("production")
    end
    # ...
  end
end

```


The supplied block was being treated as an argument when the middleware was being initialised, leading to a mismatch in the number of required/supplied arguments.

The main issue seems to be the `&` in `application.config.for_each_middleware do |m, *args, &block|`. In that, `&block` won't match the `Proc` in the stack. Instead, the `Proc` will be the last value in `args`. 

I also removed the splat for the args to match how the middleware stack is handled in the router.

I've added a case to the integration spec that would test this path, but I haven't been able to get the integration specs to run successfully, so can't guarantee that it passes.