### PR TITLE
Remove ruby 2.4 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
           - "2.7"
           - "2.6"
           - "2.5"
-          - "2.4"
     steps:
       - uses: actions/checkout@v1
       - name: Install package dependencies


### PR DESCRIPTION
Hi @jodosha,

As **ruby** `2.4` os reached end of life on march 2020, I think it's meaningless to keep running CI for it.

Regards,