### PR TITLE
Add simple Zeitwerk integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", br
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git", branch: "unstable"
 
+gem "dry-system", git: "https://github.com/dry-rb/dry-system.git", branch: "default-settings-for-component-dirs"
 gem "dry-configurable", git: "https://github.com/dry-rb/dry-configurable.git", branch: "master"
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", br
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git", branch: "unstable"
 
-gem "dry-system", git: "https://github.com/dry-rb/dry-system.git", branch: "default-settings-for-component-dirs"
 gem "dry-configurable", git: "https://github.com/dry-rb/dry-configurable.git", branch: "master"
 
 group :test do

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_dependency "hanami-router",     "~> 2.0.alpha"
   spec.add_dependency "hanami-utils",      "~> 2.0.alpha"
   spec.add_dependency "hanami-view",       "~> 2.0.alpha"
+  spec.add_dependency "zeitwerk",          "~> 2.4"
 
   spec.add_development_dependency "rspec",     "~>  3.8"
   spec.add_development_dependency "rack-test", "~> 1.1"

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -6,6 +6,7 @@ require "hanami/configuration"
 require "pathname"
 require "rack"
 require_relative "slice"
+require_relative "application/autoloader/inflector_adapter"
 require_relative "application/settings"
 
 module Hanami
@@ -63,18 +64,7 @@ module Hanami
         slices.values.each(&:init)
         slices.freeze
 
-        # TODO: put this shim somewhere useful
-        configuration.autoloader.inflector = Class.new {
-          def initialize(inflector)
-            @inflector = inflector
-          end
-
-          def camelize(basename, _abspath)
-            # Discard unused `_abspath` argument before calling our own inflector's
-            # `#camelize` (which takes only one argument)
-            @inflector.camelize(basename)
-          end
-        }.new(inflector)
+        configuration.autoloader.inflector = Autoloader::InflectorAdapter.new(inflector)
         configuration.autoloader.setup
 
         load_routes

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "dry/system/container"
-require "dry/system/loader/autoloading"
 require "hanami/configuration"
 require "pathname"
 require "rack"
@@ -258,7 +257,9 @@ module Hanami
           ]
 
           if configuration.autoloader
+            require "dry/system/loader/autoloading"
             config.component_dirs.loader = Dry::System::Loader::Autoloading
+            config.component_dirs.add_to_load_path = false
           end
 
           if root.join("lib").directory?

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -63,6 +63,18 @@ module Hanami
         slices.values.each(&:init)
         slices.freeze
 
+        # TODO: put this shim somewhere useful
+        configuration.autoloader.inflector = Class.new {
+          def initialize(inflector)
+            @inflector = inflector
+          end
+
+          def camelize(basename, _abspath)
+            # Discard unused `_abspath` argument before calling our own inflector's
+            # `#camelize` (which takes only one argument)
+            @inflector.camelize(basename)
+          end
+        }.new(inflector)
         configuration.autoloader.setup
 
         load_routes

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/system/container"
+require "dry/system/loader/autoloading"
 require "hanami/configuration"
 require "pathname"
 require "rack"
@@ -61,6 +62,8 @@ module Hanami
         load_slices
         slices.values.each(&:init)
         slices.freeze
+
+        configuration.autoloader.setup
 
         load_routes
 
@@ -250,10 +253,14 @@ module Hanami
             Pathname(__dir__).join("application/container/boot").realpath,
           ]
 
+          config.component_dirs.loader = Dry::System::Loader::Autoloading
+
           if root.join("lib").directory?
             config.component_dirs.add "lib" do |dir|
               dir.default_namespace = application_name.to_s
             end
+
+            configuration.autoloader.push_dir(root.join("lib"))
           end
         end
 

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -257,7 +257,9 @@ module Hanami
             Pathname(__dir__).join("application/container/boot").realpath,
           ]
 
-          config.component_dirs.loader = Dry::System::Loader::Autoloading
+          if configuration.autoloader
+            config.component_dirs.loader = Dry::System::Loader::Autoloading
+          end
 
           if root.join("lib").directory?
             config.component_dirs.add "lib" do |dir|

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -64,8 +64,10 @@ module Hanami
         slices.values.each(&:init)
         slices.freeze
 
-        configuration.autoloader.inflector = Autoloader::InflectorAdapter.new(inflector)
-        configuration.autoloader.setup
+        if configuration.autoloader
+          configuration.autoloader.inflector = Autoloader::InflectorAdapter.new(inflector)
+          configuration.autoloader.setup
+        end
 
         load_routes
 
@@ -262,7 +264,7 @@ module Hanami
               dir.default_namespace = application_name.to_s
             end
 
-            configuration.autoloader.push_dir(root.join("lib"))
+            configuration.autoloader&.push_dir(root.join("lib"))
           end
         end
 

--- a/lib/hanami/application/autoloader/inflector_adapter.rb
+++ b/lib/hanami/application/autoloader/inflector_adapter.rb
@@ -1,0 +1,22 @@
+module Hanami
+  class Application
+    module Autoloader
+      # Allows the Hanami standard inflector (from dry-inflector) to be used with Zeitwerk
+      class InflectorAdapter
+        def initialize(inflector)
+          @inflector = inflector
+        end
+
+        def camelize(basename, _abspath)
+          # Discard unused `_abspath` argument before calling our own inflector's
+          # `#camelize` (which takes only one argument)
+          inflector.camelize(basename)
+        end
+
+        private
+
+        attr_reader :inflector
+      end
+    end
+  end
+end

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -85,7 +85,7 @@ module Hanami
     end
 
     def autoloader=(loader)
-      settings[:autoloader] = loader
+      settings[:autoloader] = loader || nil
     end
 
     def autoloader

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -5,6 +5,7 @@ require "concurrent/hash"
 require "concurrent/array"
 require "dry/inflector"
 require "pathname"
+require "zeitwerk"
 
 module Hanami
   # Hanami application configuration
@@ -23,6 +24,8 @@ module Hanami
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def initialize(env:)
       @settings = Concurrent::Hash.new
+
+      self.autoloader = Zeitwerk::Loader.new
 
       self.env = env
       self.environments = DEFAULT_ENVIRONMENTS.clone
@@ -79,6 +82,14 @@ module Hanami
 
     def environment(name, &blk)
       environment_for(name).push(blk)
+    end
+
+    def autoloader=(loader)
+      settings[:autoloader] = loader
+    end
+
+    def autoloader
+      settings.fetch(:autoloader)
     end
 
     def env=(value)

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -115,7 +115,7 @@ module Hanami
               dir.default_namespace = namespace_path.tr(File::SEPARATOR, config.namespace_separator)
             end
 
-            application.configuration.autoloader.push_dir(root.join("lib"))
+            application.configuration.autoloader&.push_dir(root.join("lib"))
           end
         end
       end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/system/container"
+require "dry/system/loader/autoloading"
 require "pathname"
 
 module Hanami
@@ -103,6 +104,8 @@ module Hanami
         config.name = name
         config.inflector = application.configuration.inflector
 
+        config.component_dirs.loader = Dry::System::Loader::Autoloading
+
         if root&.directory?
           config.root = root
           config.bootable_dirs = ["config/boot"]
@@ -111,6 +114,8 @@ module Hanami
             config.component_dirs.add "lib" do |dir|
               dir.default_namespace = namespace_path.tr(File::SEPARATOR, config.namespace_separator)
             end
+
+            application.configuration.autoloader.push_dir(root.join("lib"))
           end
         end
       end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "dry/system/container"
-require "dry/system/loader/autoloading"
 require "pathname"
 
 module Hanami
@@ -105,7 +104,9 @@ module Hanami
         config.inflector = application.configuration.inflector
 
         if application.configuration.autoloader
+          require "dry/system/loader/autoloading"
           config.component_dirs.loader = Dry::System::Loader::Autoloading
+          config.component_dirs.add_to_load_path = false
         end
 
         if root&.directory?

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -104,7 +104,9 @@ module Hanami
         config.name = name
         config.inflector = application.configuration.inflector
 
-        config.component_dirs.loader = Dry::System::Loader::Autoloading
+        if application.configuration.autoloader
+          config.component_dirs.loader = Dry::System::Loader::Autoloading
+        end
 
         if root&.directory?
           config.root = root

--- a/spec/integration/cli/destroy/migration_spec.rb
+++ b/spec/integration/cli/destroy/migration_spec.rb
@@ -21,35 +21,20 @@ RSpec.describe "hanami destroy", type: :integration do
 
     it "fails with missing argument" do
       with_project do
-<<<<<<< HEAD
         output = <<~OUT
           ERROR: "hanami destroy migration" was called with no arguments
           Usage: "hanami destroy migration MIGRATION"
         OUT
         run_command "hanami destroy migration", output, exit_status: 1
-=======
-        output = <<-OUT
-ERROR: "hanami destroy migration" was called with no arguments
-Usage: "hanami destroy migration MIGRATION"
-OUT
-        run_cmd "hanami destroy migration", output, exit_status: 1
->>>>>>> develop
       end
     end
 
     it "fails with unknown migration" do
       with_project do
-<<<<<<< HEAD
         output = <<~OUT
           cannot find `create_unknowns'. Please have a look at `db/migrations' directory to find an existing migration
         OUT
         run_command "hanami destroy migration create_unknowns", output, exit_status: 1
-=======
-        output = <<-OUT
-cannot find `create_unknowns'. Please have a look at `db/migrations' directory to find an existing migration
-OUT
-        run_cmd "hanami destroy migration create_unknowns", output, exit_status: 1
->>>>>>> develop
       end
     end
 
@@ -78,11 +63,7 @@ OUT
           %r{  hanami destroy migration create_users # Destroy `db/migrations/[\d]{14}_create_users.rb`}
         ]
 
-<<<<<<< HEAD
         run_command "hanami destroy migration --help", output
-=======
-        run_cmd 'hanami destroy migration --help', output
->>>>>>> develop
       end
     end
   end # migration

--- a/spec/new_integration/container/autoloader_spec.rb
+++ b/spec/new_integration/container/autoloader_spec.rb
@@ -1,0 +1,140 @@
+RSpec.describe "Application autoloader", :application_integration do
+  specify "Classes are autoloaded through direct reference, including through components resolved from the container" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+            # Use a custom inflection to ensure this is respected by the autoloader
+            config.inflector do |inflections|
+              inflections.acronym "NBA"
+            end
+          end
+        end
+      RUBY
+
+      write "lib/test_app/nba_jam/get_that_outta_here.rb", <<~RUBY
+        module TestApp
+          module NBAJam
+            class GetThatOuttaHere
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/lib/admin/operations/create_game.rb", <<~RUBY
+        module Admin
+          module Operations
+            class CreateGame
+              def call
+                Entities::Game.new
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/lib/admin/entities/game.rb", <<~RUBY
+        # auto_register: false
+
+        module Admin
+          module Entities
+            class Game
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/lib/admin/entities/quarter.rb", <<~RUBY
+        # auto_register: false
+
+        module Admin
+          module Entities
+            class Quarter
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+
+      expect(TestApp::NBAJam::GetThatOuttaHere).to be
+      expect(Admin::Slice["operations.create_game"]).to be_an_instance_of(Admin::Operations::CreateGame)
+      expect(Admin::Slice["operations.create_game"].call).to be_an_instance_of(Admin::Entities::Game)
+      expect(Admin::Entities::Quarter).to be
+    end
+  end
+
+  specify "Autoloading can be disabled" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+            config.autoloader = false
+          end
+        end
+      RUBY
+
+      write "lib/test_app/nba_jam/get_that_outta_here.rb", <<~RUBY
+        module TestApp
+          module NBAJam
+            class GetThatOuttaHere
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/lib/admin/operations/create_game.rb", <<~RUBY
+        require "admin/entities/game"
+
+        module Admin
+          module Operations
+            class CreateGame
+              def call
+                Entities::Game.new
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/lib/admin/entities/game.rb", <<~RUBY
+        # auto_register: false
+
+        module Admin
+          module Entities
+            class Game
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/lib/admin/entities/quarter.rb", <<~RUBY
+        # auto_register: false
+
+        module Admin
+          module Entities
+            class Quarter
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+
+      expect { TestApp::NBAJam::GetThatOuttaHere }.to raise_error NameError
+      require "test_app/nba_jam/get_that_outta_here"
+      expect(TestApp::NBAJam::GetThatOuttaHere).to be
+
+      expect(Admin::Slice["operations.create_game"]).to be_an_instance_of(Admin::Operations::CreateGame)
+      expect(Admin::Slice["operations.create_game"].call).to be_an_instance_of(Admin::Entities::Game)
+
+      expect { Admin::Entities::Quarter }.to raise_error NameError
+      require "admin/entities/quarter"
+      expect(Admin::Entities::Quarter).to be
+    end
+  end
+end

--- a/spec/new_integration/view/views_spec.rb
+++ b/spec/new_integration/view/views_spec.rb
@@ -71,8 +71,6 @@ RSpec.describe "Hanami view integration", :application_integration do
       RUBY
 
       write "lib/test_app/views/test_view.rb", <<~RUBY
-        require "test_app/view"
-
         module TestApp
           module Views
             class TestView < TestApp::View

--- a/spec/new_integration/view/views_spec.rb
+++ b/spec/new_integration/view/views_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe "Hanami view integration", :application_integration do
       RUBY
 
       write "slices/main/lib/main/views/test_view.rb", <<~RUBY
-        require "main/view"
-
         module Main
           module Views
             class TestView < Main::View

--- a/spec/support/application_integration.rb
+++ b/spec/support/application_integration.rb
@@ -2,6 +2,7 @@
 
 require "hanami/devtools/integration/files"
 require "hanami/devtools/integration/with_tmp_directory"
+require "zeitwerk"
 
 module TestNamespace
   def remove_constants
@@ -29,6 +30,13 @@ RSpec.configure do |config|
   end
 
   config.after :each, :application_integration do
+    # Tear down Zeitwerk (from zeitwerk's own test/support/loader_test)
+    Zeitwerk::Registry.loaders.each(&:unload)
+    Zeitwerk::Registry.loaders.clear
+    Zeitwerk::Registry.loaders_managing_gems.clear
+    Zeitwerk::ExplicitNamespace.cpaths.clear
+    Zeitwerk::ExplicitNamespace.tracer.disable
+
     $LOAD_PATH.replace(@load_paths)
     $LOADED_FEATURES.delete_if do |feature_path|
       feature_path =~ %r{hanami/(setup|init|boot|application/container/boot)}


### PR DESCRIPTION
Set up autoloading by default for Hanami 2 applications.

This uses Zeitwerk and dry-system's autoloading support.

To support this, we do the following:

- Set up a Zeitwerk loader by default at `Hanami.application.configuration.autoloader`
- When the application and slice containers are prepared:
  - Add their directories to the Zeitwerk loader
  - Enable the dry-system `Loader::Autoloading` and disable the containers' component dirs from being added to the load path
- Then later in the Hanami app init process
  - Configure the autoloader with the app's inflector (via an adapter, since the expected API is slightly different)
  - Then call `#setup` on the loader, effectively finalizing its config

We also support opting out of autoloading entirely by setting `Hanami.application.configuration.autoloader` to `nil` or `false`.