### PR TITLE
Use dry-configurable for hanami settings

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -153,18 +153,17 @@ module Hanami
 
       def settings(&block) # rubocop:disable Metrics/MethodLength
         if block
-          @_settings = Application::Settings.build(
+          Application::Settings.build(
             configuration.settings_loader,
             configuration.settings_loader_options,
             &block
           )
-        elsif instance_variable_defined?(:@_settings)
-          @_settings
+        elsif Settings.config.values.any?
+          Settings.config
         else
           # Load settings lazily so they can be used to configure the
           # Hanami::Application subclass (before the application has inited)
           load_settings
-          @_settings ||= nil
         end
       end
 

--- a/lib/hanami/application/settings.rb
+++ b/lib/hanami/application/settings.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/core/constants"
+require "dry/configurable"
 require_relative "settings/definition"
 require_relative "settings/struct"
 
@@ -10,6 +11,8 @@ module Hanami
     #
     # @since 2.0.0
     module Settings
+      extend Dry::Configurable
+
       Undefined = Dry::Core::Constants::Undefined
 
       def self.build(loader, loader_options, &definition_block)


### PR DESCRIPTION
This is a baby step towards the to-be-defined level of integration we
want between hanami settings and dry-configurable.

This commit introduces the minimal changes to keep the very same
features we're supporting on the hanami settings side while still
delegating to dry-configurable what it's already capable of handling:

- dry-configurable is responsible for the setter/getter methods.
- Hanami settings resolve the value through a type constructor, when
  present, before delegating it to dry-configurable.
- Hanami settings wrap the definition of all the settings to detect all
  errors at once instead of failing on a one-by-one basis.

Further integration can include delegating the type constructor to a
processor keyword argument (we could already delegate it to the block,
but probably we want to do the former) and provide an error handler to
the whole definition.