### PR TITLE
Expose url_helpers from router

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -331,6 +331,8 @@ module Hanami
 
     # Application instance interface
     module InstanceMethods
+      attr_reader :url_helpers
+
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def initialize(application = self.class)
         require_relative "application/router"
@@ -349,10 +351,12 @@ module Hanami
         ) do
           use application[:rack_monitor]
 
-          application.config.for_each_middleware do |m, *args, &block|
-            use(m, *args, &block)
+          application.config.for_each_middleware do |middleware, *args, &block|
+            use(middleware, *args, &block)
           end
         end
+
+        @url_helpers = router.url_helpers
 
         @app = router.to_rack_app
       end


### PR DESCRIPTION
(Note: This is for Hanami 2, which is on the `unstable` branch)

I don't think this is the right place for it, considering it would be the _only_ public method available on classes that inherit from `Hanami::Application`. But just wanted to open this PR to show the simplest way it could be done.

I wasn't able to find any other publicly accesible way to access the router's `url_helpers` from within an app.

I tried to register `router.url_helpers` on the application's container, but it's already finalized by this point so it can't be added. I wonder if the router will have to be created earlier, if that's possible, then we can put a `router.url_helpers` in the container registry at that time.

(The way I was able to work around this was `Hanami.app.instance_variable_get(:@app).app.instance_variable_get(:@app).url_helpers`, which is obviously not an acceptable solution, pulling the router out from private instance variables)