### PR TITLE
Prohibit Ruby 3 for Hanami v1.x

### DIFF
--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.3.0', '< 3'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 


### PR DESCRIPTION
See #1101 and #1108.

We probably should've done this as soon as it was released. Doing this now won't be as effective, since all existing gems already cut without it will get installed from `gem install hanami` with Ruby 3. The other option would be to yank `1.3.x` and backport this to all the gems and cut `1.3.x.1` versions, but that's likely overkill.
