### PR TITLE
Give visibility to the endpoint namespace key

### DIFF
--- a/lib/hanami/application/routing/resolver.rb
+++ b/lib/hanami/application/routing/resolver.rb
@@ -7,6 +7,8 @@ module Hanami
       #
       # @since 2.0.0
       class Resolver
+        ENDPOINT_KEY_NAMESPACE = "actions"
+
         require_relative "resolver/trie"
 
         # @since 2.0.0
@@ -21,7 +23,7 @@ module Hanami
         def initialize(slices:, inflector:)
           @slices = slices
           @inflector = inflector
-          @slices_registry = Trie.new
+          @slice_registry = Trie.new
         end
 
         # @api private
@@ -50,7 +52,7 @@ module Hanami
         # @api private
         # @since 2.0.0
         def register_slice_at_path(name, path)
-          slices_registry.add(path, name)
+          slice_registry.add(path, name)
         end
 
         private
@@ -65,16 +67,16 @@ module Hanami
 
         # @api private
         # @since 2.0.0
-        attr_reader :slices_registry
+        attr_reader :slice_registry
 
         # @api private
         # @since 2.0.0
         def resolve_string_identifier(path, identifier)
-          slice_name = slices_registry.find(path) or raise "missing slice for #{path.inspect} (#{identifier.inspect})"
+          slice_name = slice_registry.find(path) or raise "missing slice for #{path.inspect} (#{identifier.inspect})"
           slice = slices[slice_name]
-          action_key = "actions.#{identifier}"
+          endpoint_key = "#{ENDPOINT_KEY_NAMESPACE}.#{identifier}"
 
-          slice[action_key]
+          slice[endpoint_key]
         end
       end
     end


### PR DESCRIPTION
Instead of having it buried within the implementation of a private method, we give it the prominence it deserves by having it as a class constant.
    
We took the occasion to rename `slices_registry` to `slice_registry` to make the naming (singular) consistent with the new constant name.

This is not intended to be user-configurable and will not be marked as public API.

We're structuring this like so to make an important (but internal) detail of the resolver much clearer than just an incidental string deep inside a private method.