### PR TITLE
Restore passing tests for dry-configurable changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.
 
 gem "dry-files", git: "https://github.com/dry-rb/dry-files.git", branch: "master"
 gem "dry-configurable", git: "https://github.com/dry-rb/dry-configurable.git", branch: "master"
+gem "dry-system", git: "https://github.com/dry-rb/dry-system.git", branch: "master"
 
 group :test do
   gem "dotenv"


### PR DESCRIPTION
We need to use dry-system master until the dry-configurable changes have filtered through as releases for the various dry-rb gems (later this month!)