### PR TITLE
Use a class for the application routes

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -6,6 +6,7 @@ require "pathname"
 require "rack"
 require_relative "slice"
 require_relative "application/autoloader/inflector_adapter"
+require_relative "application/routes"
 require_relative "application/settings"
 
 module Hanami
@@ -155,15 +156,9 @@ module Hanami
         @_settings ||= load_settings
       end
 
-      def routes(&block)
+      def routes
         @_mutex.synchronize do
-          if block.nil?
-            raise "Hanami.application.routes not configured" unless defined?(@_routes)
-
-            @_routes
-          else
-            @_routes = block
-          end
+          @_routes ||= load_routes
         end
       end
 
@@ -308,17 +303,23 @@ module Hanami
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def load_routes
-        require File.join(configuration.root, configuration.router.routes)
+        require File.join(configuration.root, configuration.routes_path)
+        routes_class = autodiscover_application_constant(configuration.routes_class_name)
+        routes_class.routes
       rescue LoadError # rubocop:disable Lint/SuppressedException
       end
 
       def load_settings
         prepare_base_load_path
         require File.join(configuration.root, configuration.settings_path)
-        settings_class = inflector.constantize([namespace_name, configuration.settings_class_name].join(MODULE_DELIMITER))
+        settings_class = autodiscover_application_constant(configuration.settings_class_name)
         settings_class.new(configuration.settings_store)
       rescue LoadError
         Settings.new
+      end
+
+      def autodiscover_application_constant(constants)
+        inflector.constantize([namespace_name, *constants].join(MODULE_DELIMITER))
       end
     end
     # rubocop:enable Metrics/ModuleLength

--- a/lib/hanami/application/routes.rb
+++ b/lib/hanami/application/routes.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Application
+    # Application routes
+    #
+    # Users are expected to inherit from this class to define their application
+    # routes.
+    #
+    # @example
+    #   # config/routes.rb
+    #   # frozen_string_literal: true
+    #
+    #   require "hanami/application/routes"
+    #
+    #   module MyApp
+    #     class Routes < Hanami::Application::Routes
+    #       define do
+    #         slice :main, at: "/" do
+    #           root to: "home.show"
+    #         end
+    #       end
+    #     end
+    #   end
+    #
+    #   See {Hanami::Application::Router} for the syntax allowed within the
+    #   `define` block.
+    #
+    # @see Hanami::Application::Router
+    # @since 2.0.0
+    class Routes
+      # Defines application routes
+      #
+      # @yield DSL syntax to define application routes executed in the context
+      # of {Hanami::Application::Router}
+      # @returns [Proc]
+      def self.define(&block)
+        @_routes = block
+      end
+
+      # @api private
+      def self.routes
+        @_routes || raise(<<~MSG)
+          Routes need to be defined before being able to fetch them. E.g.,
+            define do
+              slice :main, at: "/" do
+                root to: "home.show"
+              end
+            end
+        MSG
+      end
+    end
+  end
+end

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -35,6 +35,7 @@ module Hanami
       settings[:slices] = {}
 
       self.settings_path = DEFAULT_SETTINGS_PATH
+      self.routes_path = DEFAULT_ROUTES_PATH
 
       self.base_url = DEFAULT_BASE_URL
 
@@ -132,6 +133,22 @@ module Hanami
 
     def slices
       settings[:slices]
+    end
+
+    def routes_path=(value)
+      settings[:routes_path] = value
+    end
+
+    def routes_path
+      settings.fetch(:routes_path)
+    end
+
+    def routes_class_name=(name)
+      settings[:routes_class_name] = name
+    end
+
+    def routes_class_name
+      settings.fetch(:routes_class_name, "Routes")
     end
 
     def settings_path=(value)
@@ -256,6 +273,9 @@ module Hanami
 
     DEFAULT_RACK_LOGGER_FILTER_PARAMS = %w[_csrf password password_confirmation].freeze
     private_constant :DEFAULT_RACK_LOGGER_FILTER_PARAMS
+
+    DEFAULT_ROUTES_PATH = File.join("config", "routes")
+    private_constant :DEFAULT_ROUTES_PATH
 
     DEFAULT_SETTINGS_PATH = File.join("config", "settings")
     private_constant :DEFAULT_SETTINGS_PATH

--- a/lib/hanami/configuration/router.rb
+++ b/lib/hanami/configuration/router.rb
@@ -9,21 +9,12 @@ module Hanami
     class Router
       # @api private
       # @since 2.0.0
-      attr_writer :routes
-
-      # @api private
-      # @since 2.0.0
-      attr_reader :routes
-
-      # @api private
-      # @since 2.0.0
       attr_writer :resolver
 
       # @api private
       # @since 2.0.0
-      def initialize(base_url, routes: DEFAULT_ROUTES)
+      def initialize(base_url)
         @base_url = base_url
-        @routes = routes
       end
 
       # @api private
@@ -40,11 +31,6 @@ module Hanami
       def options
         { base_url: @base_url }
       end
-
-      # @api private
-      # @since 2.0.0
-      DEFAULT_ROUTES = File.join("config", "routes")
-      private_constant :DEFAULT_ROUTES
     end
   end
 end

--- a/spec/new_integration/web_app_spec.rb
+++ b/spec/new_integration/web_app_spec.rb
@@ -20,13 +20,17 @@ RSpec.describe "Hanami web app", :application_integration do
       RUBY
 
       write "config/routes.rb", <<~RUBY
-        Hanami.application.routes do
-          slice :main, at: "/" do
-            root to: "home#index"
-          end
+        module TestApp
+          class Routes < Hanami::Application::Routes
+            define do
+              slice :main, at: "/" do
+                root to: "home#index"
+              end
 
-          slice :admin, at: "/admin" do
-            get "/dashboard", to: "dashboard#show"
+              slice :admin, at: "/admin" do
+                get "/dashboard", to: "dashboard#show"
+              end
+            end
           end
         end
       RUBY

--- a/spec/unit/hanami/application/routes_spec.rb
+++ b/spec/unit/hanami/application/routes_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "hanami/application/routes"
+
+RSpec.describe Hanami::Application::Routes do
+  describe ".define" do
+    it "sets routes block" do
+      routes_class = Class.new(described_class)
+
+      routes_class.define { "Dummy routes" }
+
+      expect(routes_class.routes.call).to eq("Dummy routes")
+    end
+  end
+
+  describe ".routes" do
+    context "when called before the routes have been defined" do
+      it "raises an error" do
+        routes_class = Class.new(described_class)
+
+        expect { routes_class.routes }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We move the definition of routes as a block provided to
`Hanami::Application.routes` to its own class
`Hanami::Application::Routes`.

Users need to create a subclass and define the routes through a block
applied to the `.routes` class method. As before, the hanami application
captures the context of the block and forwards it to
`Hanami::Application::Router` for its evaluation.

E.g.:

```ruby

require "hanami/application/routes"

module MyApp
  class Routes < Hanami::Application::Routes
    routes do
      slice :main, at: "/" do
        root to: "home.show"
      end
    end
  end
end
```

For consistency with settings, we move the routes path configuration to
the main `Hanami::Configuration` class.