### PR TITLE
Fix warning on Hash#fetch

### DIFF
--- a/spec/unit/hanami/application/settings/dotenv_store_spec.rb
+++ b/spec/unit/hanami/application/settings/dotenv_store_spec.rb
@@ -110,12 +110,6 @@ RSpec.describe Hanami::Application::Settings::DotenvStore do
       expect(store.fetch("BAZ") { "qux" }).to eq("qux")
     end
 
-    it "returns the block execution when both default and block are given" do
-      store = described_class.new(store: { "FOO" => "bar" })
-
-      expect(store.fetch("BAZ", "corge") { "qux" }).to eq("qux")
-    end
-
     it "raises KeyError when value is not found and no default is given" do
       store = described_class.new(store: { "FOO" => "bar" })
 


### PR DESCRIPTION
Calling a block with a default argument and a block warns with:

> warning: block supersedes default value argument

There's no need to test Ruby default behavior.

The warning was introduced in #1114