### PR TITLE
Introduce `Hanami.shutdown`

### DIFF
--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -73,6 +73,10 @@ module Hanami
     end
   end
 
+  def self.shutdown
+    application.shutdown
+  end
+
   def self.bundler_groups
     [:plugins]
   end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -151,6 +151,10 @@ module Hanami
         @booted
       end
 
+      def shutdown
+        container.shutdown!
+      end
+
       def settings
         @_settings ||= load_settings
       end

--- a/spec/new_integration/container/shutdown_spec.rb
+++ b/spec/new_integration/container/shutdown_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe "Container shutdown", :application_integration do
+  specify "Application container shuts down components" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "config/boot/persistence.rb", <<~RUBY
+        Hanami.application.register_bootable :persistence do
+          init do
+            module TestApp
+              class Persistence
+                attr_reader :connected
+
+                def initialize
+                  @connected = true
+                end
+
+                def disconnect
+                  @connected = false
+                end
+              end
+            end
+          end
+
+          start do
+            register(:persistence, TestApp::Persistence.new)
+          end
+
+          stop do
+            container[:persistence].disconnect
+          end
+        end
+      RUBY
+
+      write "lib/test_app/.keep", ""
+
+      require "hanami/setup"
+      Hanami.boot web: false
+
+      persistence = Hanami.application[:persistence]
+
+      expect(persistence).to be_kind_of(TestApp::Persistence)
+      expect(persistence.connected).to be(true)
+
+      Hanami.shutdown
+
+      expect(persistence.connected).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Proposal

It's a single entry point to be used to shutdown an application. The ideal context is Puma's `before_fork` block.

## Problem

Right now all the app components that need to be shutdown must be manually referenced to trigger custom shutdown logic.

This is inconvenient and it leaks details of the single components outside of their definition.

## Solution

Given `dry-system` supports the definition of the shutdown logic via `stop` block, we can suggest users to utilize this API.

`dry-system` also exposes a private API to iterate all the registered components and trigger their shutdown logic (`stop` blocks).

The idea is to expose a new public API for Hanami which can safely, conveniently shutdown an application: `Hanami.shutdown`. This new method will hook into the `dry-system` mechanism described above.

## Example

Imagine to have a component that needs to be cleaned up when the application shuts down. In our example, we want to close the connection with Redis database.

```ruby
# config/boot/redis.rb

Hanami.application.register_bootable :redis do
  init do
    require "redis"
  end

  start do
    register(:redis, Redis.new)
  end

  stop do |container|
    container[:redis].close
  end
end
```

Puma server has a set of hooks to allow application developers to plug in their own cleanup logic:

```ruby
# config/puma.rb

## BEFORE THIS FEATURE
before_fork do
  Hanami.application[:redis].close
  # repeat for each component that needs to be shutdown
end

## AFTER THIS FEATURE
before_fork do
  Hanami.shutdown
end
```

---

https://trello.com/c/vJ4AQMlV
https://discourse.hanamirb.org/t/hanami-v2-0-0-alpha2-app-template-feedback/606/37?u=jodosha