### PR TITLE
Make a routes helper class available in the container

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -8,6 +8,7 @@ require "rack"
 require "zeitwerk"
 require_relative "slice"
 require_relative "application/autoloader/inflector_adapter"
+require_relative "application/router"
 require_relative "application/routes"
 require_relative "application/settings"
 
@@ -70,8 +71,6 @@ module Hanami
         slices.freeze
 
         autoloader.setup
-
-        load_routes
 
         @inited = true
         self
@@ -148,6 +147,8 @@ module Hanami
 
         init
 
+        load_router
+
         container.finalize!(&block)
 
         slices.values.each(&:boot)
@@ -166,12 +167,6 @@ module Hanami
 
       def settings
         @_settings ||= load_settings
-      end
-
-      def routes
-        @_mutex.synchronize do
-          @_routes ||= load_routes
-        end
       end
 
       MODULE_DELIMITER = "::"
@@ -214,6 +209,41 @@ module Hanami
         return unless component_name
 
         providers.detect { |provider| component_name.include?(provider.namespace.to_s) }
+      end
+
+      def router
+        @_mutex.synchronize do
+          @_router ||= load_router
+        end
+      end
+
+      def load_router
+        Router.new(
+          routes: routes,
+          resolver: resolver,
+          **configuration.router.options,
+        ) do
+          use Hanami.application[:rack_monitor]
+
+          Hanami.application.config.for_each_middleware do |m, *args, &block|
+            use(m, *args, &block)
+          end
+        end
+      end
+
+      def routes
+        require File.join(configuration.root, configuration.router.routes_path)
+        routes_class = autodiscover_application_constant(configuration.router.routes_class_name)
+        routes_class.routes
+      rescue LoadError
+        proc {}
+      end
+
+      def resolver
+        config.router.resolver.new(
+          slices: slices,
+          inflector: inflector
+        )
       end
 
       private
@@ -312,13 +342,6 @@ module Hanami
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-      def load_routes
-        require File.join(configuration.root, configuration.router.routes_path)
-        routes_class = autodiscover_application_constant(configuration.router.routes_class_name)
-        routes_class.routes
-      rescue LoadError # rubocop:disable Lint/SuppressedException
-      end
-
       def load_settings
         prepare_base_load_path
         require File.join(configuration.root, configuration.settings_path)
@@ -342,24 +365,7 @@ module Hanami
 
         application.boot
 
-        resolver = application.config.router.resolver.new(
-          slices: application.slices,
-          inflector: application.inflector
-        )
-
-        router = Application::Router.new(
-          routes: application.routes,
-          resolver: resolver,
-          **application.configuration.router.options,
-        ) do
-          use application[:rack_monitor]
-
-          application.config.for_each_middleware do |m, *args, &block|
-            use(m, *args, &block)
-          end
-        end
-
-        @app = router.to_rack_app
+        @app = application.router.to_rack_app
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 

--- a/lib/hanami/application/container/boot/routes_helper.rb
+++ b/lib/hanami/application/container/boot/routes_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Hanami.application.register_bootable :routes_helper do
+  start do
+    require "hanami/application/routes_helper"
+
+    register :routes_helper, Hanami::Application::RoutesHelper.new(Hanami.application.router)
+  end
+end

--- a/lib/hanami/application/routes_helper.rb
+++ b/lib/hanami/application/routes_helper.rb
@@ -9,7 +9,7 @@ module Hanami
     # it to get the route helpers for your application.
     #
     # @example
-    #   MyApp::Aplication["routes_helper"].path(:root) # => "/"
+    #   MyApp::Application["routes_helper"].path(:root) # => "/"
     #
     # @see Hanami::Router::UrlHelpers
     # @since 2.0.0

--- a/lib/hanami/application/routes_helper.rb
+++ b/lib/hanami/application/routes_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Application
+    # Hanami application routes helpers
+    #
+    # An instance of this class gets registered in the container
+    # (`routes_helper` key) once the Hanami application is booted. You can use
+    # it to get the route helpers for your application.
+    #
+    # @example
+    #   MyApp::Aplication["routes_helper"].path(:root) # => "/"
+    #
+    # @see Hanami::Router::UrlHelpers
+    # @since 2.0.0
+    class RoutesHelper
+      # @since 2.0.0
+      # @api private
+      def initialize(router)
+        @router = router
+      end
+
+      # @see Hanami::Router::UrlHelpers#path
+      def path(*args, **kwargs, &block)
+        @router.path(*args, **kwargs, &block)
+      end
+
+      # @see Hanami::Router::UrlHelpers#url
+      def url(*args, **kwargs, &block)
+        @router.url(*args, **kwargs, &block)
+      end
+    end
+  end
+end

--- a/spec/new_integration/container/application_routes_helper_spec.rb
+++ b/spec/new_integration/container/application_routes_helper_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe "Application routes helper", :application_integration do
+  specify "Routing to actions based on their container identifiers" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+            config.logger.options[:stream] = File.new("/dev/null", "w")
+          end
+        end
+      RUBY
+
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Application::Routes
+            define do
+              slice :main, at: "/" do
+                root to: "home.index"
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/actions/home/index.rb", <<~RUBY
+        require "hanami/action"
+
+        module Main
+          module Actions
+            module Home
+              class Index < Hanami::Action
+                def handle(*, res)
+                  res.body = "Hello world"
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+
+      expect(TestApp::Application["routes_helper"].path(:root)).to eq "/"
+      expect(TestApp::Application["routes_helper"].url(:root).to_s).to match /http:\/\/.*\//
+    end
+  end
+end


### PR DESCRIPTION
We add a new `Hanami::Application::RoutesHelper` class which delegates
`path` & `url` methods into the router's URL helpers. The intention is
for it to be made available to whichever view system in use (i.e.,
dry-view).

We have slightly rearranged the boot process. Instead of explicitly
creating the router when the application instance is initialized, we add
it to the `boot` phase of the application (which is effectively the
same). This way, we can register the helpers in the container just
afterward, still on the boot phase, when the container is finalized.
There's no need to load the routes beforehand as the router will already
do that.