### PR TITLE
Only allow "." as separator in the action identifier

### DIFF
--- a/lib/hanami/application/routing/resolver.rb
+++ b/lib/hanami/application/routing/resolver.rb
@@ -72,7 +72,7 @@ module Hanami
         def resolve_string_identifier(path, identifier)
           slice_name = slices_registry.find(path) or raise "missing slice for #{path.inspect} (#{identifier.inspect})"
           slice = slices[slice_name]
-          action_key = "actions.#{identifier.gsub(/[#\/]/, '.')}"
+          action_key = "actions.#{identifier}"
 
           slice[action_key]
         end

--- a/spec/new_integration/web_app_spec.rb
+++ b/spec/new_integration/web_app_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe "Hanami web app", :application_integration do
           class Routes < Hanami::Application::Routes
             define do
               slice :main, at: "/" do
-                root to: "home#index"
+                root to: "home.index"
               end
 
               slice :admin, at: "/admin" do
-                get "/dashboard", to: "dashboard#show"
+                get "/dashboard", to: "dashboard.show"
               end
             end
           end


### PR DESCRIPTION
It's better to enforce some consistency, so we're removing support for
"#" and "/".