### PR TITLE
Fix dry-inflector to 0.2.1 or greater

### DIFF
--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.add_dependency "bundler",           ">= 1.16", "< 3"
   spec.add_dependency "dry-core",          "~> 0.4"
-  spec.add_dependency "dry-inflector",     "~> 0.1", ">= 0.1.2"
+  spec.add_dependency "dry-inflector",     "~> 0.2", ">= 0.2.1"
   spec.add_dependency "dry-monitor"
   spec.add_dependency "dry-system",        "~> 0.19", ">= 0.19.0"
   spec.add_dependency "hanami-cli",        "~> 2.0.alpha"


### PR DESCRIPTION
It allows us to detect `CSRF` acronym on
`Hanami::Action::CSRFProtection`, which is needed in the application
template.

See hanami/hanami-2-application-template#33