### PR TITLE
Content Security Policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "main"
 gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "main"
-gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "main"
+gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "feature/content-security-policy"
 gem "hanami-cli", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/cli.git", branch: "main"
 gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", branch: "main"
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "main"
 gem "hanami-router", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/router.git", branch: "main"
-gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "feature/content-security-policy"
+gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "main"
 gem "hanami-cli", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/cli.git", branch: "main"
 gem "hanami-view", "~> 2.0.alpha", git: "https://github.com/hanami/view.git", branch: "main"
 

--- a/lib/hanami/assets/application_configuration.rb
+++ b/lib/hanami/assets/application_configuration.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "hanami/assets/configuration"
+require "dry/configurable"
+
+module Hanami
+  module Assets
+    class ApplicationConfiguration
+      include Dry::Configurable
+
+      setting :server_url, default: "http://localhost:8080"
+
+      def initialize(*)
+        super
+
+        @base_configuration = Assets::Configuration.new
+      end
+
+      def finalize!
+      end
+
+      # Returns the list of available settings
+      #
+      # @return [Set]
+      #
+      # @since 2.0.0
+      # @api private
+      def settings
+        base_configuration.settings + self.class.settings
+      end
+
+      private
+
+      attr_reader :base_configuration
+
+      def method_missing(name, *args, &block)
+        if config.respond_to?(name)
+          config.public_send(name, *args, &block)
+        elsif base_configuration.respond_to?(name)
+          base_configuration.public_send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, _incude_all = false)
+        config.respond_to?(name) || base_configuration.respond_to?(name) || super
+      end
+    end
+  end
+end

--- a/lib/hanami/assets/application_configuration.rb
+++ b/lib/hanami/assets/application_configuration.rb
@@ -5,17 +5,23 @@ require "dry/configurable"
 
 module Hanami
   module Assets
+    # @since 2.0.0
+    # @api public
     class ApplicationConfiguration
       include Dry::Configurable
 
       setting :server_url, default: "http://localhost:8080"
 
+      # @since 2.0.0
+      # @api private
       def initialize(*)
         super
 
         @base_configuration = Assets::Configuration.new
       end
 
+      # @since 2.0.0
+      # @api private
       def finalize!
       end
 
@@ -31,8 +37,12 @@ module Hanami
 
       private
 
+      # @since 2.0.0
+      # @api private
       attr_reader :base_configuration
 
+      # @since 2.0.0
+      # @api private
       def method_missing(name, *args, &block)
         if config.respond_to?(name)
           config.public_send(name, *args, &block)
@@ -43,6 +53,8 @@ module Hanami
         end
       end
 
+      # @since 2.0.0
+      # @api private
       def respond_to_missing?(name, _incude_all = false)
         config.respond_to?(name) || base_configuration.respond_to?(name) || super
       end

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -4,6 +4,8 @@ require "dry/configurable"
 
 module Hanami
   module Assets
+    # @since 2.0.0
+    # @api public
     class Configuration
       include Dry::Configurable
 
@@ -32,6 +34,8 @@ module Hanami
 
       private
 
+      # @since 2.0.0
+      # @api private
       def method_missing(name, *args, &block)
         if config.respond_to?(name)
           config.public_send(name, *args, &block)
@@ -40,6 +44,8 @@ module Hanami
         end
       end
 
+      # @since 2.0.0
+      # @api private
       def respond_to_missing?(name, _incude_all = false)
         config.respond_to?(name) || super
       end

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "dry/configurable"
+
+module Hanami
+  module Assets
+    class Configuration
+      include Dry::Configurable
+
+      # Initialize the Configuration
+      #
+      # @yield [config] the configuration object
+      #
+      # @return [Configuration]
+      #
+      # @since 2.0.0
+      # @api private
+      def initialize(*)
+        super
+        yield self if block_given?
+      end
+
+      # Returns the list of available settings
+      #
+      # @return [Set]
+      #
+      # @since 2.0.0
+      # @api private
+      def settings
+        self.class.settings
+      end
+
+      private
+
+      def method_missing(name, *args, &block)
+        if config.respond_to?(name)
+          config.public_send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, _incude_all = false)
+        config.respond_to?(name) || super
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Feature

Handle Content Security Policy (CSP) defaults.
CSP defaults are handled by `hanami-controller` gem, but it needs to take into account `hanami-assets` settings (the Webpack server URL).

## Implementation details

This PR introduces code that will be moved later on in `hanami-assets` gem.
For the sake of not porting now that gem into 2.0 ready state, I preferred to put this new code here first.

Application configuration now exposes `assets`, which is an instance of `Hanami::Assets::ApplicationConfiguration`.
This follow the same pattern already established with actions and views configurations.

## API

### Content Security Policy

```ruby
module MyApp
  class Application < Hanami::Application
    config.actions.content_security_policy
  end
end
```

For a list of examples, please refer to: https://github.com/hanami/controller/pull/353

### Assets Configuration

```ruby
module MyApp
  class Application < Hanami::Application
    config.assets
  end
end
```

For now it only exposes `server_url`.

## FIXME

`server_url` for now it's hardcoded (`http://localhost:8080`).

When we will work on `hanami-assets` we need to take into account:

* The default value
* A custom value that a user wants to assign
* Pass exactly the same URL to Webpack