### PR TITLE
Add source_dirs configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.
 gem "dry-files", git: "https://github.com/dry-rb/dry-files.git", branch: "master"
 gem "dry-configurable", git: "https://github.com/dry-rb/dry-configurable.git", branch: "master"
 
+gem "dry-system", git: "https://github.com/dry-rb/dry-system", branch: "more-flexible-component-dir-config"
+
 group :test do
   gem "dotenv"
   gem "dry-types"

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.
 gem "dry-files", git: "https://github.com/dry-rb/dry-files.git", branch: "master"
 gem "dry-configurable", git: "https://github.com/dry-rb/dry-configurable.git", branch: "master"
 
-gem "dry-system", git: "https://github.com/dry-rb/dry-system", branch: "more-flexible-component-dir-config"
-
 group :test do
   gem "dotenv"
   gem "dry-types"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_dependency "dry-core",          "~> 0.4"
   spec.add_dependency "dry-inflector",     "~> 0.2", ">= 0.2.1"
   spec.add_dependency "dry-monitor"
-  spec.add_dependency "dry-system",        "~> 0.19", ">= 0.21.0"
+  spec.add_dependency "dry-system",        "~> 0.22", ">= 0.22.0"
   spec.add_dependency "hanami-cli",        "~> 2.0.alpha"
   spec.add_dependency "hanami-utils",      "~> 2.0.alpha"
   spec.add_dependency "zeitwerk",          "~> 2.4"

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -12,6 +12,7 @@ require_relative "configuration/logger"
 require_relative "configuration/middleware"
 require_relative "configuration/router"
 require_relative "configuration/sessions"
+require_relative "configuration/source_dirs"
 
 module Hanami
   # Hanami application configuration
@@ -155,9 +156,7 @@ module Hanami
     # slice, etc.
     setting :slices, default: {}, constructor: :dup.to_proc
 
-    # TODO: turn this into a richer "source dirs" setting that can support enabling
-    # of container component loading as an opt in behvior
-    setting :component_dir_paths, default: %w[actions repositories views]
+    setting :source_dirs, default: Configuration::SourceDirs.new, cloneable: true
 
     def slice(slice_name, &block)
       slices[slice_name] = block

--- a/lib/hanami/configuration/source_dirs.rb
+++ b/lib/hanami/configuration/source_dirs.rb
@@ -9,7 +9,7 @@ module Hanami
     #
     # @since 2.0.0
     class SourceDirs
-      DEFAULT_COMPONENT_DIR_PATHS = %w[actions repositories views].freeze
+      DEFAULT_COMPONENT_DIR_PATHS = %w[lib actions repositories views].freeze
       private_constant :DEFAULT_COMPONENT_DIR_PATHS
 
       include Dry::Configurable

--- a/lib/hanami/configuration/source_dirs.rb
+++ b/lib/hanami/configuration/source_dirs.rb
@@ -5,7 +5,7 @@ require "dry/system/config/component_dirs"
 
 module Hanami
   class Configuration
-    # Hanami configuration for source dirs
+    # Configuration for slice source dirs
     #
     # @since 2.0.0
     class SourceDirs

--- a/lib/hanami/configuration/source_dirs.rb
+++ b/lib/hanami/configuration/source_dirs.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "dry/configurable"
+require "dry/system/config/component_dirs"
+
+module Hanami
+  class Configuration
+    # Hanami configuration for source dirs
+    #
+    # @since 2.0.0
+    class SourceDirs
+      DEFAULT_COMPONENT_DIR_PATHS = %w[actions repositories views].freeze
+      private_constant :DEFAULT_COMPONENT_DIR_PATHS
+
+      include Dry::Configurable
+
+      setting :component_dirs,
+        default: Dry::System::Config::ComponentDirs.new.tap { |dirs|
+          DEFAULT_COMPONENT_DIR_PATHS.each do |path|
+            dirs.add path
+          end
+        },
+        cloneable: true
+
+      setting :autoload_paths, default: %w[entities]
+
+      private
+
+      def method_missing(name, *args, &block)
+        if config.respond_to?(name)
+          config.public_send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, _include_all = false)
+        config.respond_to?(name) || super
+      end
+    end
+  end
+end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -112,29 +112,30 @@ module Hanami
           config.bootable_dirs = ["config/boot"]
 
           # Add component dirs for each configured component path
-          application.configuration.source_dirs.component_dirs.each do |common_component_dir|
-            next unless root.join(common_component_dir.path).directory?
+          application.configuration.source_dirs.component_dirs.each do |component_dir|
+            next unless root.join(component_dir.path).directory?
 
-            component_dir = common_component_dir.dup
+            component_dir = component_dir.dup
 
             # TODO: this `== "lib"` check should be codified into a method somewhere
             if component_dir.path == "lib"
-              # Expect component files in the root of the lib
-              # component dir to define classes inside the slice's namespace.
+              # Expect component files in the root of the lib/ component dir to define
+              # classes inside the slice's namespace.
               #
-              # e.g. "lib/foo.rb" should define SliceNamespace::Foo, and will be
-              # registered as "foo"
-              component_dir.namespaces.root(key: nil, const: namespace_path)
-
-              application.autoloader.push_dir(root.join("lib"), namespace: namespace)
+              # e.g. "lib/foo.rb" should define SliceNamespace::Foo, to be registered as
+              # "foo"
+              component_dir.namespaces.delete_root
+              component_dir.namespaces.add_root(key: nil, const: namespace_path)
 
               config.component_dirs.add(component_dir)
+
+              application.autoloader.push_dir(root.join("lib"), namespace: namespace)
             else
-              # Expect component files in the root of these component dirs to define
-              # classes inside a namespace matching the dir.
+              # Expect component files in the root of non-lib/ component dirs to define
+              # classes inside a namespace matching that dir.
               #
-              # e.g. "actions/foo.rb" should define SliceNamespace::Actions::Foo, and
-              # will be registered as "actions.foo"
+              # e.g. "actions/foo.rb" should define SliceNamespace::Actions::Foo, to be
+              # registered as "actions.foo"
 
               dir_namespace_path = File.join(namespace_path, component_dir.path)
 
@@ -144,8 +145,9 @@ module Hanami
                 namespace.const_set(inflector.camelize(component_dir.path), Module.new)
               end
 
-              # TODO: do we need to do something special to clear out any previously configured root namespace here?
-              component_dir.namespaces.root(const: dir_namespace_path, key: component_dir.path) # TODO: do we need to swap path delimiters for key delimiters here?
+              component_dir.namespaces.delete_root
+              component_dir.namespaces.add_root(const: dir_namespace_path, key: component_dir.path) # TODO: do we need to swap path delimiters for key delimiters here?
+
               config.component_dirs.add(component_dir)
 
               application.autoloader.push_dir(

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -156,6 +156,24 @@ module Hanami
               )
             end
           end
+
+          # Pass configured autoload dirs to the autoloader
+          application.configuration.source_dirs.autoload_paths.each do |autoload_path|
+            next unless root.join(autoload_path).directory?
+
+            dir_namespace_path = File.join(namespace_path, autoload_path)
+
+            autoloader_namespace = begin
+              inflector.constantize(inflector.camelize(dir_namespace_path))
+            rescue NameError
+              namespace.const_set(inflector.camelize(autoload_path), Module.new)
+            end
+
+            application.autoloader.push_dir(
+              container.root.join(autoload_path),
+              namespace: autoloader_namespace
+            )
+          end
         end
       end
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -126,31 +126,33 @@ module Hanami
           end
 
           # Add component dirs for each configured component path
-          application.configuration.component_dir_paths.each do |slice_dir|
-            next unless root.join(slice_dir).directory?
+          application.configuration.source_dirs.component_dirs.each do |common_component_dir|
+            next unless root.join(common_component_dir.path).directory?
 
-            config.component_dirs.add(slice_dir) do |component_dir|
-              # Expect component files in the root of these component dirs to define
-              # classes inside a namespace matching the dir.
-              #
-              # e.g. "actions/foo.rb" should define SliceNamespace::Actions::Foo, and
-              # will be registered as "actions.foo"
+            component_dir = common_component_dir.dup
 
-              dir_namespace_path = File.join(namespace_path, slice_dir)
+            # Expect component files in the root of these component dirs to define
+            # classes inside a namespace matching the dir.
+            #
+            # e.g. "actions/foo.rb" should define SliceNamespace::Actions::Foo, and
+            # will be registered as "actions.foo"
 
-              autoloader_namespace = begin
-                inflector.constantize(inflector.camelize(dir_namespace_path))
-              rescue NameError
-                namespace.const_set(inflector.camelize(slice_dir), Module.new)
-              end
+            dir_namespace_path = File.join(namespace_path, component_dir.path)
 
-              component_dir.namespaces.root(const: dir_namespace_path, key: slice_dir)
-
-              application.autoloader.push_dir(
-                container.root.join(slice_dir),
-                namespace: autoloader_namespace
-              )
+            autoloader_namespace = begin
+              inflector.constantize(inflector.camelize(dir_namespace_path))
+            rescue NameError
+              namespace.const_set(inflector.camelize(component_dir.path), Module.new)
             end
+
+            # TODO: do we need to do something special to clear out any previously configured root namespace here?
+            component_dir.namespaces.root(const: dir_namespace_path, key: component_dir.path) # TODO: do we need to swap path delimiters for key delimiters here?
+            config.component_dirs.add_dir(component_dir)
+
+            application.autoloader.push_dir(
+              container.root.join(component_dir.path),
+              namespace: autoloader_namespace
+            )
           end
         end
       end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -128,7 +128,7 @@ module Hanami
 
               application.autoloader.push_dir(root.join("lib"), namespace: namespace)
 
-              config.component_dirs.add_dir(component_dir)
+              config.component_dirs.add(component_dir)
             else
               # Expect component files in the root of these component dirs to define
               # classes inside a namespace matching the dir.
@@ -146,7 +146,7 @@ module Hanami
 
               # TODO: do we need to do something special to clear out any previously configured root namespace here?
               component_dir.namespaces.root(const: dir_namespace_path, key: component_dir.path) # TODO: do we need to swap path delimiters for key delimiters here?
-              config.component_dirs.add_dir(component_dir)
+              config.component_dirs.add(component_dir)
 
               application.autoloader.push_dir(
                 container.root.join(component_dir.path),

--- a/spec/new_integration/source_dirs/autoload_paths_spec.rb
+++ b/spec/new_integration/source_dirs/autoload_paths_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe "Source dirs / autoload paths", :application_integration do
+  specify "Default autoload paths are configured with the autoloader" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "slices/main/entities/post.rb", <<~RUBY
+        module Main
+          module Entities
+            class Post
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+      expect(Main::Entities::Post).to be
+    end
+  end
+
+  specify "User-configured autoload paths are configured with the autoloader" do
+    write "config/application.rb", <<~RUBY
+      require "hanami"
+
+      module TestApp
+        class Application < Hanami::Application
+          config.source_dirs.autoload_paths = ["entities", "structs"]
+        end
+      end
+    RUBY
+
+    write "slices/main/entities/post.rb", <<~RUBY
+      module Main
+        module Entities
+          class Post
+          end
+        end
+      end
+    RUBY
+
+    write "slices/main/structs/post.rb", <<~RUBY
+      module Main
+        module Structs
+          class Post
+          end
+        end
+      end
+    RUBY
+
+    require "hanami/init"
+    expect(Main::Entities::Post).to be
+    expect(Main::Structs::Post).to be
+  end
+end

--- a/spec/new_integration/source_dirs/autoload_paths_spec.rb
+++ b/spec/new_integration/source_dirs/autoload_paths_spec.rb
@@ -25,36 +25,38 @@ RSpec.describe "Source dirs / autoload paths", :application_integration do
   end
 
   specify "User-configured autoload paths are configured with the autoloader" do
-    write "config/application.rb", <<~RUBY
-      require "hanami"
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
 
-      module TestApp
-        class Application < Hanami::Application
-          config.source_dirs.autoload_paths = ["entities", "structs"]
-        end
-      end
-    RUBY
-
-    write "slices/main/entities/post.rb", <<~RUBY
-      module Main
-        module Entities
-          class Post
+        module TestApp
+          class Application < Hanami::Application
+            config.source_dirs.autoload_paths = ["entities", "structs"]
           end
         end
-      end
-    RUBY
+      RUBY
 
-    write "slices/main/structs/post.rb", <<~RUBY
-      module Main
-        module Structs
-          class Post
+      write "slices/main/entities/post.rb", <<~RUBY
+        module Main
+          module Entities
+            class Post
+            end
           end
         end
-      end
-    RUBY
+      RUBY
 
-    require "hanami/init"
-    expect(Main::Entities::Post).to be
-    expect(Main::Structs::Post).to be
+      write "slices/main/structs/post.rb", <<~RUBY
+        module Main
+          module Structs
+            class Post
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/init"
+      expect(Main::Entities::Post).to be
+      expect(Main::Structs::Post).to be
+    end
   end
 end

--- a/spec/unit/hanami/configuration/source_dirs_spec.rb
+++ b/spec/unit/hanami/configuration/source_dirs_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "hanami/configuration"
+
+RSpec.describe Hanami::Configuration, "#source_dirs" do
+  subject(:source_dirs) { described_class.new(env: :development).source_dirs }
+
+  describe "#component_dirs" do
+    it "defaults to 'lib, actions, repositories, views'" do
+      expect(source_dirs.component_dirs.paths).to eq %w[lib actions repositories views]
+    end
+
+    it "can have configuration set that applies to all directories" do
+      auto_register_proc = -> * { true }
+      expect { source_dirs.component_dirs.auto_register = auto_register_proc }
+        .to change { source_dirs.component_dirs.dir("lib").auto_register }
+        .to(auto_register_proc)
+    end
+
+    it "can have extra configuration applied to specific default directories" do
+      auto_register_proc = -> * { true }
+      expect { source_dirs.component_dirs.dir("lib").auto_register = auto_register_proc }
+        .to change { source_dirs.component_dirs.dir("lib").auto_register }
+        .to(auto_register_proc)
+    end
+
+    it "can have default directories removed" do
+      expect { source_dirs.component_dirs.delete("views") }
+        .to change { source_dirs.component_dirs.paths }
+        .from(%w[lib actions repositories views])
+        .to(%w[lib actions repositories])
+    end
+  end
+
+  describe "#autoload_paths" do
+    it "defaults to 'entities'" do
+      expect(source_dirs.autoload_paths).to eq %w[entities]
+    end
+
+    it "can have new paths added" do
+      expect { source_dirs.autoload_paths << "structs" }
+        .to change { source_dirs.autoload_paths }
+        .to(%w[entities structs])
+    end
+
+    it "can have multiple new paths added" do
+      expect { source_dirs.autoload_paths += %w[structs values] }
+        .to change { source_dirs.autoload_paths }
+        .to(%w[entities structs values])
+    end
+
+    it "can have paths deleted" do
+      expect { source_dirs.autoload_paths.delete("entities") }
+        .to change { source_dirs.autoload_paths }
+        .to([])
+    end
+  end
+end

--- a/spec/unit/hanami/configuration/source_dirs_spec.rb
+++ b/spec/unit/hanami/configuration/source_dirs_spec.rb
@@ -3,7 +3,8 @@
 require "hanami/configuration"
 
 RSpec.describe Hanami::Configuration, "#source_dirs" do
-  subject(:source_dirs) { described_class.new(env: :development).source_dirs }
+  subject(:source_dirs) { described_class.new(application_name: application_name, env: :development).source_dirs }
+  let(:application_name) { "MyApp::Application" }
 
   describe "#component_dirs" do
     it "defaults to 'lib, actions, repositories, views'" do


### PR DESCRIPTION
This PR improves upon the temporary `component_dir_paths` setting that was introduced in #1123 with the revamp of our component and source directory structure.

Here we replace `component_dir_paths` with a unified `source_dirs` config, which itself contains both `component_dirs` and `autoload_paths`:

- `component_dirs` is an instance of `Dry::System::Config::ComponentDirs`, which in conjunction with https://github.com/dry-rb/dry-system/pull/195 gives the user full access to the component dir config, as well as the ability to remove default dirs and configure their own entirely separately.
- `autoload_paths` is a simple array of paths

During the Hanami application setup, the component dirs are used to configure the slice containers as well as the autoloader, and the autoload paths are used to configure the autoloader only (those directories are intended to hold source files that do not need to become container components).

See `spec/unit/hanami/configuration/source_dirs_spec.rb` for how a user may interact with both `component_dirs` and `autoload_paths` to customise their config.