### PR TITLE
Logger defaults

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -24,7 +24,7 @@ module Hanami
         @_mutex.synchronize do
           klass.class_eval do
             @_mutex         = Mutex.new
-            @_configuration = Hanami::Configuration.new(env: Hanami.env)
+            @_configuration = Hanami::Configuration.new(application_name: name, env: Hanami.env)
 
             extend ClassMethods
             include InstanceMethods
@@ -169,11 +169,8 @@ module Hanami
         @_settings ||= load_settings
       end
 
-      MODULE_DELIMITER = "::"
-      private_constant :MODULE_DELIMITER
-
       def namespace
-        inflector.constantize(name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER))
+        configuration.namespace
       end
 
       def namespace_name
@@ -185,7 +182,7 @@ module Hanami
       end
 
       def application_name
-        inflector.underscore(namespace).to_sym
+        configuration.application_name
       end
 
       def root
@@ -350,6 +347,9 @@ module Hanami
       rescue LoadError
         Settings.new
       end
+
+      MODULE_DELIMITER = "::"
+      private_constant :MODULE_DELIMITER
 
       def autodiscover_application_constant(constants)
         inflector.constantize([namespace_name, *constants].join(MODULE_DELIMITER))

--- a/lib/hanami/application/container/boot/rack_logger.rb
+++ b/lib/hanami/application/container/boot/rack_logger.rb
@@ -9,7 +9,7 @@ Hanami.application.register_bootable :rack_logger do |container|
 
     rack_logger = Hanami::Web::RackLogger.new(
       container[:logger],
-      filter_params: Hanami.application.configuration.logger.filter_params
+      filter_params: Hanami.application.configuration.logger.filters
     )
 
     rack_logger.attach container[:rack_monitor]

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -36,11 +36,8 @@ module Hanami
     attr_reader :environments
     private :environments
 
-    attr_reader :application_name
-
     def initialize(application_name:, env:)
       @namespace = application_name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER)
-      @application_name = inflector.underscore(@namespace).to_sym
 
       @environments = DEFAULT_ENVIRONMENTS.clone
       config.env = env
@@ -50,7 +47,7 @@ module Hanami
       self.root = Dir.pwd
       self.settings_store = Application::Settings::DotenvStore.new.with_dotenv_loaded
 
-      config.logger = Configuration::Logger.new(env: env, application_name: self.application_name)
+      config.logger = Configuration::Logger.new(env: env, application_name: method(:application_name))
 
       @assets = begin
         require_path = "hanami/assets/application_configuration"
@@ -113,6 +110,10 @@ module Hanami
 
     def namespace
       inflector.constantize(@namespace)
+    end
+
+    def application_name
+      inflector.underscore(@namespace).to_sym
     end
 
     setting :env

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -137,7 +137,7 @@ module Hanami
     end
 
     def logger_instance
-      @logger_instance || logger.logger_class.new(**logger.options)
+      @logger_instance || logger.instance
     end
 
     setting :settings_path, default: File.join("config", "settings")

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -50,7 +50,7 @@ module Hanami
       self.root = Dir.pwd
       self.settings_store = Application::Settings::DotenvStore.new.with_dotenv_loaded
 
-      config.logger = Configuration::Logger.new(application_name: self.application_name)
+      config.logger = Configuration::Logger.new(env: env, application_name: self.application_name)
 
       @assets = begin
         require_path = "hanami/assets/application_configuration"

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -25,6 +25,9 @@ module Hanami
     DEFAULT_ENVIRONMENTS = Concurrent::Hash.new { |h, k| h[k] = Concurrent::Array.new }
     private_constant :DEFAULT_ENVIRONMENTS
 
+    MODULE_DELIMITER = "::"
+    private_constant :MODULE_DELIMITER
+
     attr_reader :actions
     attr_reader :middleware
     attr_reader :router
@@ -33,7 +36,12 @@ module Hanami
     attr_reader :environments
     private :environments
 
-    def initialize(env:)
+    attr_reader :application_name
+
+    def initialize(application_name:, env:)
+      @namespace = application_name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER)
+      @application_name = inflector.underscore(@namespace).to_sym
+
       @environments = DEFAULT_ENVIRONMENTS.clone
       config.env = env
 
@@ -99,6 +107,10 @@ module Hanami
       router.finalize!
 
       super
+    end
+
+    def namespace
+      inflector.constantize(@namespace)
     end
 
     setting :env

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -50,6 +50,8 @@ module Hanami
       self.root = Dir.pwd
       self.settings_store = Application::Settings::DotenvStore.new.with_dotenv_loaded
 
+      config.logger = Configuration::Logger.new(application_name: self.application_name)
+
       @assets = begin
         require_path = "hanami/assets/application_configuration"
         require require_path
@@ -128,7 +130,7 @@ module Hanami
       self.inflector = Dry::Inflector.new(&block)
     end
 
-    setting :logger, default: Configuration::Logger.new, cloneable: true
+    setting :logger, cloneable: true
 
     def logger=(logger_instance)
       @logger_instance = logger_instance

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -13,6 +13,8 @@ module Hanami
 
       protected :config
 
+      setting :application_name
+
       setting :logger_class, default: Hanami::Logger
 
       setting :options, default: {level: :debug}
@@ -21,6 +23,10 @@ module Hanami
       #
       # TODO: incorporate this into the standard logging some way or another
       setting :filter_params, default: %w[_csrf password password_confirmation].freeze
+
+      def initialize(application_name:)
+        config.application_name = application_name
+      end
 
       private
 

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -15,6 +15,8 @@ module Hanami
 
       setting :application_name
 
+      setting :level
+
       setting :stream
 
       setting :logger_class, default: Hanami::Logger
@@ -29,6 +31,13 @@ module Hanami
       def initialize(env:, application_name:)
         @env = env
         config.application_name = application_name
+
+        config.level = case env
+                       when :production
+                         :info
+                       else
+                         :debug
+                       end
 
         config.stream = case env
                         when :test

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -15,6 +15,8 @@ module Hanami
 
       setting :application_name
 
+      setting :stream, default: $stdout
+
       setting :logger_class, default: Hanami::Logger
 
       setting :options, default: {level: :debug}

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -23,14 +23,11 @@ module Hanami
 
       setting :colors
 
+      setting :filters, default: %w[_csrf password password_confirmation].freeze
+
       setting :logger_class, default: Hanami::Logger
 
       setting :options, default: {level: :debug}
-
-      # Currently used for logging of Rack requests only.
-      #
-      # TODO: incorporate this into the standard logging some way or another
-      setting :filter_params, default: %w[_csrf password password_confirmation].freeze
 
       def initialize(env:, application_name:)
         @env = env

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -15,7 +15,7 @@ module Hanami
 
       setting :application_name
 
-      setting :stream, default: $stdout
+      setting :stream
 
       setting :logger_class, default: Hanami::Logger
 
@@ -26,8 +26,16 @@ module Hanami
       # TODO: incorporate this into the standard logging some way or another
       setting :filter_params, default: %w[_csrf password password_confirmation].freeze
 
-      def initialize(application_name:)
+      def initialize(env:, application_name:)
+        @env = env
         config.application_name = application_name
+
+        config.stream = case env
+                        when :test
+                          File.join("log", "#{env}.log")
+                        else
+                          $stdout
+                        end
       end
 
       private

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -21,6 +21,8 @@ module Hanami
 
       setting :formatter
 
+      setting :colors
+
       setting :logger_class, default: Hanami::Logger
 
       setting :options, default: {level: :debug}
@@ -52,6 +54,11 @@ module Hanami
                            when :production
                              :json
                            end
+
+        config.colors = case env
+                        when :production, :test
+                          false
+                        end
       end
 
       private

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -25,9 +25,9 @@ module Hanami
 
       setting :filters, default: %w[_csrf password password_confirmation].freeze
 
-      setting :logger_class, default: Hanami::Logger
+      setting :options, default: [], constructor: ->(value) { Array(value).flatten }, cloneable: true
 
-      setting :options, default: {level: :debug}
+      setting :logger_class, default: Hanami::Logger
 
       def initialize(env:, application_name:)
         @env = env
@@ -56,6 +56,10 @@ module Hanami
                         when :production, :test
                           false
                         end
+      end
+
+      def instance
+        logger_class.new(application_name, *options, stream: stream, level: level, formatter: formatter, filter: filters, colorizer: colors)
       end
 
       private

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -19,6 +19,8 @@ module Hanami
 
       setting :stream
 
+      setting :formatter
+
       setting :logger_class, default: Hanami::Logger
 
       setting :options, default: {level: :debug}
@@ -45,6 +47,11 @@ module Hanami
                         else
                           $stdout
                         end
+
+        config.formatter = case env
+                           when :production
+                             :json
+                           end
       end
 
       private

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -31,7 +31,7 @@ module Hanami
 
       def initialize(env:, application_name:)
         @env = env
-        config.application_name = application_name
+        @application_name = application_name
 
         config.level = case env
                        when :production
@@ -56,6 +56,10 @@ module Hanami
                         when :production, :test
                           false
                         end
+      end
+
+      def finalize!
+        config.application_name = @application_name.call
       end
 
       def instance

--- a/spec/new_integration/container/application_routes_helper_spec.rb
+++ b/spec/new_integration/container/application_routes_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Application routes helper", :application_integration do
 
         module TestApp
           class Application < Hanami::Application
-            config.logger.options[:stream] = File.new("/dev/null", "w")
+            config.logger.stream = File.new("/dev/null", "w")
           end
         end
       RUBY

--- a/spec/new_integration/web_app_spec.rb
+++ b/spec/new_integration/web_app_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Hanami web app", :application_integration do
 
         module TestApp
           class Application < Hanami::Application
-            config.logger.options[:stream] = File.new("/dev/null", "w")
+            config.logger.stream = File.new("/dev/null", "w")
           end
         end
       RUBY

--- a/spec/unit/hanami/configuration/actions_spec.rb
+++ b/spec/unit/hanami/configuration/actions_spec.rb
@@ -4,7 +4,9 @@ require "hanami/configuration"
 require "hanami/action/application_configuration"
 
 RSpec.describe Hanami::Configuration, "#actions" do
-  let(:configuration) { described_class.new(env: :development) }
+  let(:configuration) { described_class.new(application_name: application_name, env: :development) }
+  let(:application_name) { "MyApp::Application" }
+
   subject(:actions) { configuration.actions }
 
   context "Hanami::Action available" do

--- a/spec/unit/hanami/configuration/base_url_spec.rb
+++ b/spec/unit/hanami/configuration/base_url_spec.rb
@@ -4,7 +4,8 @@ require "hanami/configuration"
 require "uri"
 
 RSpec.describe Hanami::Configuration, "base_url" do
-  subject(:config) { described_class.new(env: :development) }
+  subject(:config) { described_class.new(application_name: application_name, env: :development) }
+  let(:application_name) { "MyApp::Application" }
 
   it "defaults to a URI of 'http://0.0.0.0:2300'" do
     expect(config.base_url).to eq URI("http://0.0.0.0:2300")

--- a/spec/unit/hanami/configuration/inflector_spec.rb
+++ b/spec/unit/hanami/configuration/inflector_spec.rb
@@ -3,7 +3,8 @@
 require "hanami/configuration"
 
 RSpec.describe Hanami::Configuration do
-  subject(:config) { described_class.new(env: :development) }
+  subject(:config) { described_class.new(application_name: application_name, env: :development) }
+  let(:application_name) { "MyApp::Application" }
 
   describe "inflector" do
     it "defaults to a Dry::Inflector instance" do

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Hanami::Configuration do
       end
     end
 
+    describe "#application_name" do
+      it "defaults to Hanami::Configuration#application_name" do
+        expect(config.logger.application_name).to eq(config.application_name)
+      end
+    end
+
     describe "#options" do
       it "defaults to {level: :debug}" do
         expect(config.logger.options).to eq(level: :debug)

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -4,7 +4,8 @@ require "hanami/configuration"
 require "logger"
 
 RSpec.describe Hanami::Configuration do
-  subject(:config) { described_class.new(env: :development) }
+  subject(:config) { described_class.new(application_name: application_name, env: :development) }
+  let(:application_name) { "MyApp::Application" }
 
   describe "#logger" do
     describe "#logger_class" do

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -149,20 +149,22 @@ RSpec.describe Hanami::Configuration::Logger do
   end
 
   describe "#options" do
-    it "defaults to {level: :debug}" do
-      expect(subject.options).to eq(level: :debug)
+    it "defaults to empty array" do
+      expect(subject.options).to eq([])
+    end
+  end
+
+  describe "#options=" do
+    it "accepts value" do
+      subject.options = expected = "daily"
+
+      expect(subject.options).to eq([expected])
     end
 
-    it "can have additional options set" do
-      expect { subject.options[:stream] = "/some/file" }
-        .to change { subject.options }
-        .to(level: :debug, stream: "/some/file")
-    end
+    it "accepts values" do
+      subject.options = expected = [0, 1048576]
 
-    it "can be changed to another hash of options" do
-      expect { subject.options = {level: :info} }
-        .to change { subject.options }
-        .to(level: :info)
+      expect(subject.options).to eq(expected)
     end
   end
 end
@@ -182,15 +184,6 @@ RSpec.describe Hanami::Configuration do
   end
 
   describe "#logger_instance" do
-    it "returns an instance of the configured logger class, with configured options given to its initializer" do
-      klass = Struct.new(:opts)
-
-      config.logger.logger_class = klass
-
-      expect(config.logger_instance).to be_an_instance_of klass
-      expect(config.logger_instance.opts).to eq config.logger.options
-    end
-
     it "defaults to an Hanami::Logger instance, based on the default logger settings" do
       expect(config.logger_instance).to be_an_instance_of config.logger.logger_class
       expect(config.logger_instance.level).to eq Logger::DEBUG

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -96,6 +96,36 @@ RSpec.describe Hanami::Configuration::Logger do
     end
   end
 
+  describe "#colors" do
+    it "defaults to nil" do
+      expect(subject.colors).to eq(nil)
+    end
+
+    context "when :test environment" do
+      let(:env) { :test }
+
+      it "returns false" do
+        expect(subject.colors).to eq(false)
+      end
+    end
+
+    context "when :production environment" do
+      let(:env) { :production }
+
+      it "returns false" do
+        expect(subject.colors).to eq(false)
+      end
+    end
+  end
+
+  describe "#colors=" do
+    it "accepts a value" do
+      expect { subject.colors = false }
+        .to change { subject.colors }
+        .to(false)
+    end
+  end
+
   describe "#options" do
     it "defaults to {level: :debug}" do
       expect(subject.options).to eq(level: :debug)

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -5,7 +5,7 @@ require "logger"
 
 RSpec.describe Hanami::Configuration::Logger do
   subject { described_class.new(application_name: application_name, env: env) }
-  let(:application_name) { :my_app }
+  let(:application_name) { -> { :my_app } }
   let(:env) { :development }
 
   describe "#logger_class" do
@@ -23,8 +23,12 @@ RSpec.describe Hanami::Configuration::Logger do
   end
 
   describe "#application_name" do
+    before do
+      subject.finalize!
+    end
+
     it "defaults returns application name" do
-      expect(subject.application_name).to eq(application_name)
+      expect(subject.application_name).to eq(application_name.call)
     end
   end
 
@@ -172,10 +176,18 @@ end
 
 RSpec.describe Hanami::Configuration do
   subject(:config) { described_class.new(application_name: application_name, env: env) }
-  let(:application_name) { "MyApp::Application" }
+  let(:application_name) { "SOS::Application" }
   let(:env) { :development }
 
   describe "#logger" do
+    before do
+      config.inflections do |inflections|
+        inflections.acronym "SOS"
+      end
+
+      config.logger.finalize!
+    end
+
     describe "#application_name" do
       it "defaults to Hanami::Configuration#application_name" do
         expect(config.logger.application_name).to eq(config.application_name)

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe Hanami::Configuration do
       end
     end
 
+    describe "#stream" do
+      it "defaults to $stdout" do
+        expect(config.logger.stream).to eq($stdout)
+      end
+    end
+
+    describe "#stream=" do
+      it "accepts a IO object or a path to a file" do
+        expect { config.logger.stream = "/dev/null" }
+          .to change { config.logger.stream }
+          .to("/dev/null")
+      end
+    end
+
     describe "#options" do
       it "defaults to {level: :debug}" do
         expect(config.logger.options).to eq(level: :debug)

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -126,6 +126,28 @@ RSpec.describe Hanami::Configuration::Logger do
     end
   end
 
+  describe "#filters" do
+    it "defaults to a standard array of sensitive param names" do
+      expect(subject.filters).to include(*%w[_csrf password password_confirmation])
+    end
+
+    it "can have other params names added" do
+      expect { subject.filters << "secret" }
+        .to change { subject.filters }
+        .to array_including("secret")
+
+      expect { subject.filters += ["yet", "another"] }
+        .to change { subject.filters }
+        .to array_including(["yet", "another"])
+    end
+
+    it "can be changed to another array" do
+      expect { subject.filters = ["secret"] }
+        .to change { subject.filters }
+        .to ["secret"]
+    end
+  end
+
   describe "#options" do
     it "defaults to {level: :debug}" do
       expect(subject.options).to eq(level: :debug)
@@ -141,24 +163,6 @@ RSpec.describe Hanami::Configuration::Logger do
       expect { subject.options = {level: :info} }
         .to change { subject.options }
         .to(level: :info)
-    end
-  end
-
-  describe "#filter_params" do
-    it "defaults to a standard array of sensitive param names" do
-      expect(subject.filter_params).to include(*%w[_csrf password password_confirmation])
-    end
-
-    it "can have other params names added" do
-      expect { subject.filter_params << "secret_param" }
-        .to change { subject.filter_params }
-        .to array_including("secret_param")
-    end
-
-    it "can be changed to another array" do
-      expect { subject.filter_params = ["secret_param"] }
-        .to change { subject.filter_params }
-        .to ["secret_param"]
     end
   end
 end

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -4,8 +4,9 @@ require "hanami/configuration/logger"
 require "logger"
 
 RSpec.describe Hanami::Configuration::Logger do
-  subject { described_class.new(application_name: application_name) }
+  subject { described_class.new(application_name: application_name, env: env) }
   let(:application_name) { :my_app }
+  let(:env) { :development }
 
   describe "#logger_class" do
     it "defaults to Hanami::Logger" do
@@ -30,6 +31,16 @@ RSpec.describe Hanami::Configuration::Logger do
   describe "#stream" do
     it "defaults to $stdout" do
       expect(subject.stream).to eq($stdout)
+    end
+
+    context "when :test environment" do
+      let(:env) { :test }
+
+      it "returns a file" do
+        expected = File.join("log", "test.log")
+
+        expect(subject.stream).to eq(expected)
+      end
     end
   end
 

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -74,6 +74,28 @@ RSpec.describe Hanami::Configuration::Logger do
     end
   end
 
+  describe "#formatter" do
+    it "defaults to nil" do
+      expect(subject.formatter).to eq(nil)
+    end
+
+    context "when :production environment" do
+      let(:env) { :production }
+
+      it "returns :json" do
+        expect(subject.formatter).to eq(:json)
+      end
+    end
+  end
+
+  describe "#formatter=" do
+    it "accepts a formatter" do
+      expect { subject.formatter = :json }
+        .to change { subject.formatter }
+        .to(:json)
+    end
+  end
+
   describe "#options" do
     it "defaults to {level: :debug}" do
       expect(subject.options).to eq(level: :debug)

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -28,6 +28,28 @@ RSpec.describe Hanami::Configuration::Logger do
     end
   end
 
+  describe "#level" do
+    it "defaults to :debug" do
+      expect(subject.level).to eq(:debug)
+    end
+
+    context "when :production environment" do
+      let(:env) { :production }
+
+      it "returns :info" do
+        expect(subject.level).to eq(:info)
+      end
+    end
+  end
+
+  describe "#level=" do
+    it "a value" do
+      expect { subject.level = :warn }
+        .to change { subject.level }
+        .to(:warn)
+    end
+  end
+
   describe "#stream" do
     it "defaults to $stdout" do
       expect(subject.stream).to eq($stdout)

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -1,80 +1,93 @@
 # frozen_string_literal: true
 
-require "hanami/configuration"
+require "hanami/configuration/logger"
 require "logger"
 
-RSpec.describe Hanami::Configuration do
-  subject(:config) { described_class.new(application_name: application_name, env: :development) }
-  let(:application_name) { "MyApp::Application" }
+RSpec.describe Hanami::Configuration::Logger do
+  subject { described_class.new(application_name: application_name) }
+  let(:application_name) { :my_app }
 
-  describe "#logger" do
-    describe "#logger_class" do
-      it "defaults to Hanami::Logger" do
-        expect(config.logger.logger_class).to eql Hanami::Logger
-      end
-
-      it "can be changed to another class" do
-        another_class = Class.new
-
-        expect { config.logger.logger_class = another_class }
-          .to change { config.logger.logger_class }
-          .to(another_class)
-      end
+  describe "#logger_class" do
+    it "defaults to Hanami::Logger" do
+      expect(subject.logger_class).to eql Hanami::Logger
     end
 
+    it "can be changed to another class" do
+      another_class = Class.new
+
+      expect { subject.logger_class = another_class }
+        .to change { subject.logger_class }
+        .to(another_class)
+    end
+  end
+
+  describe "#application_name" do
+    it "defaults returns application name" do
+      expect(subject.application_name).to eq(application_name)
+    end
+  end
+
+  describe "#stream" do
+    it "defaults to $stdout" do
+      expect(subject.stream).to eq($stdout)
+    end
+  end
+
+  describe "#stream=" do
+    it "accepts a IO object or a path to a file" do
+      expect { subject.stream = "/dev/null" }
+        .to change { subject.stream }
+        .to("/dev/null")
+    end
+  end
+
+  describe "#options" do
+    it "defaults to {level: :debug}" do
+      expect(subject.options).to eq(level: :debug)
+    end
+
+    it "can have additional options set" do
+      expect { subject.options[:stream] = "/some/file" }
+        .to change { subject.options }
+        .to(level: :debug, stream: "/some/file")
+    end
+
+    it "can be changed to another hash of options" do
+      expect { subject.options = {level: :info} }
+        .to change { subject.options }
+        .to(level: :info)
+    end
+  end
+
+  describe "#filter_params" do
+    it "defaults to a standard array of sensitive param names" do
+      expect(subject.filter_params).to include(*%w[_csrf password password_confirmation])
+    end
+
+    it "can have other params names added" do
+      expect { subject.filter_params << "secret_param" }
+        .to change { subject.filter_params }
+        .to array_including("secret_param")
+    end
+
+    it "can be changed to another array" do
+      expect { subject.filter_params = ["secret_param"] }
+        .to change { subject.filter_params }
+        .to ["secret_param"]
+    end
+  end
+end
+
+
+RSpec.describe Hanami::Configuration do
+  subject(:config) { described_class.new(application_name: application_name, env: env) }
+  let(:application_name) { "MyApp::Application" }
+  let(:env) { :development }
+
+  describe "#logger" do
     describe "#application_name" do
       it "defaults to Hanami::Configuration#application_name" do
         expect(config.logger.application_name).to eq(config.application_name)
-      end
-    end
-
-    describe "#stream" do
-      it "defaults to $stdout" do
-        expect(config.logger.stream).to eq($stdout)
-      end
-    end
-
-    describe "#stream=" do
-      it "accepts a IO object or a path to a file" do
-        expect { config.logger.stream = "/dev/null" }
-          .to change { config.logger.stream }
-          .to("/dev/null")
-      end
-    end
-
-    describe "#options" do
-      it "defaults to {level: :debug}" do
-        expect(config.logger.options).to eq(level: :debug)
-      end
-
-      it "can have additional options set" do
-        expect { config.logger.options[:stream] = "/some/file" }
-          .to change { config.logger.options }
-          .to(level: :debug, stream: "/some/file")
-      end
-
-      it "can be changed to another hash of options" do
-        expect { config.logger.options = {level: :info} }
-          .to change { config.logger.options }
-          .to(level: :info)
-      end
-    end
-
-    describe "#filter_params" do
-      it "defaults to a standard array of sensitive param names" do
-        expect(config.logger.filter_params).to include(*%w[_csrf password password_confirmation])
-      end
-
-      it "can have other params names added" do
-        expect { config.logger.filter_params << "secret_param" }
-          .to change { config.logger.filter_params }
-          .to array_including("secret_param")
-      end
-
-      it "can be changed to another array" do
-        expect { config.logger.filter_params = ["secret_param"] }
-          .to change { config.logger.filter_params }
-          .to ["secret_param"]
       end
     end
   end

--- a/spec/unit/hanami/configuration/middleware_spec.rb
+++ b/spec/unit/hanami/configuration/middleware_spec.rb
@@ -3,7 +3,8 @@
 require "hanami/configuration"
 
 RSpec.describe Hanami::Configuration do
-  subject(:config) { described_class.new(env: :development) }
+  subject(:config) { described_class.new(application_name: application_name, env: :development) }
+  let(:application_name) { "MyApp::Application" }
 
   describe "#middleware" do
     it "defaults to a stack with no configured middlewares" do

--- a/spec/unit/hanami/configuration/views_spec.rb
+++ b/spec/unit/hanami/configuration/views_spec.rb
@@ -4,7 +4,9 @@ require "hanami/configuration"
 require "hanami/view/application_configuration"
 
 RSpec.describe Hanami::Configuration, "#views" do
-  let(:configuration) { described_class.new(env: :development) }
+  let(:configuration) { described_class.new(application_name: application_name, env: :development) }
+  let(:application_name) { "MyApp::Application" }
+
   subject(:views) { configuration.views }
 
   context "Hanami::View available" do

--- a/spec/unit/hanami/configuration_spec.rb
+++ b/spec/unit/hanami/configuration_spec.rb
@@ -1,7 +1,8 @@
 require "hanami/configuration"
 
 RSpec.describe Hanami::Configuration do
-  let(:config) { described_class.new(env: env) }
+  let(:config) { described_class.new(application_name: application_name, env: env) }
+  let(:application_name) { "MyApp::Application" }
   let(:env) { :development }
 
   describe "environment-specific configuration" do


### PR DESCRIPTION
# Feature

Apply Zero-Config ™️ strategy to logger configuration.

Print the application name in the log prefix.

```
[my_app] [INFO] [2022-01-05 16:33:27 +0100] ...
```

## Env defaults

### Development

* level: debug
* stream: stdout
* format: single line
* color: yes

### Test

* level: debug
* stream: `log/test.log`
* format: single line
* color: no

### Production

* level: info
* stream: stdout
* format: json
* color: no

## Examples

### Brand new app

```ruby
# config/application.rb

require "hanami"

module MyApp
  class Application < Hanami::Application
  end
end
```


### Assign custom settings

```ruby
# config/application.rb

require "hanami"

module MyApp
  class Application < Hanami::Application
    config.logger.level = :info

    config.logger.stream = $stdout
    config.logger.stream = "/path/to/file"
    config.logger.stream = StringIO.new

    config.logger.format = :json
    config.logger.format = MyCustomFormatter.new

    config.logger.color = false # disable coloring
    config.logger.color = MyCustomColorizer.new

    config.logger.filters << "secret" # add
    config.logger.filters += ["yet", "another"] # add
    config.logger.filters = ["foo"] # replace

    # See https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html
    config.logger.options = ["daily"] # time based log rotation
    config.logger.options = [0, 1048576] # size based log rotation
  end
end
```

### Assign per env defaults

```ruby
# config/application.rb

require "hanami"

module MyApp
  class Application < Hanami::Application
    config.environment(:staging) do
      config.logger.level = :info
    end
  end
end
```

### Assign custom logger

```ruby
# config/application.rb

require "hanami"

module MyApp
  class Application < Hanami::Application
    config.logger = MyLogger.new
  end
end
```

# Breaking Changes (from 2.0.alpha5)

* `config.logger.options` used to be a `Hash` to hold all the settings, now it's an `Array` to hold Ruby `Logger#initialize` args.
* `config.logger.options[:stream]` was removed in favor of `config.logger.stream` etc..

---

Ref https://trello.com/c/OXxer9oU