### PR TITLE
Update link to supporter Trung Lê in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can give back to Open Source, by supporting Hanami development via a [donati
 
 ### Supporters
 
-  * [Trung Lê](https://github.com/joneslee85)
+  * [Trung Lê](https://github.com/runlevel5)
   * [James Carlson](https://github.com/jxxcarlson)
   * [Creditas](https://www.creditas.com.br/)
 


### PR DESCRIPTION
Was clicking at supporter links and the first one led to a 404 page.

I'm assuming the supporter mentioned is the same one as the contributor @runlevel5 so I changed the url to his profile page