### PR TITLE
Simplify `Hanami::Web::RackLogger`

### DIFF
--- a/lib/hanami/application/container/boot/rack_logger.rb
+++ b/lib/hanami/application/container/boot/rack_logger.rb
@@ -7,11 +7,7 @@ Hanami.application.register_bootable :rack_logger do |container|
     use :logger
     use :rack_monitor
 
-    rack_logger = Hanami::Web::RackLogger.new(
-      container[:logger],
-      filter_params: Hanami.application.configuration.logger.filters
-    )
-
+    rack_logger = Hanami::Web::RackLogger.new(container[:logger])
     rack_logger.attach container[:rack_monitor]
 
     register :rack_logger, rack_logger

--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -1,19 +1,32 @@
 # frozen_string_literal: true
 
-require "json"
-require "rack/request"
-require "hanami/utils/hash"
-
 module Hanami
   module Web
     # Rack logger for Hanami applications
     class RackLogger
-      attr_reader :logger
-      attr_reader :filter_params
+      REQUEST_METHOD = "REQUEST_METHOD"
+      private_constant :REQUEST_METHOD
 
-      def initialize(logger, filter_params: [])
+      HTTP_X_FORWARDED_FOR = "HTTP_X_FORWARDED_FOR"
+      private_constant :HTTP_X_FORWARDED_FOR
+
+      REMOTE_ADDR = "REMOTE_ADDR"
+      private_constant :REMOTE_ADDR
+
+      SCRIPT_NAME = "SCRIPT_NAME"
+      private_constant :SCRIPT_NAME
+
+      PATH_INFO = "PATH_INFO"
+      private_constant :PATH_INFO
+
+      ROUTER_PARAMS = "router.params"
+      private_constant :ROUTER_PARAMS
+
+      CONTENT_LENGTH = "Content-Length"
+      private_constant :CONTENT_LENGTH
+
+      def initialize(logger)
         @logger = logger
-        @filter_params = filter_params
       end
 
       def attach(rack_monitor)
@@ -26,22 +39,19 @@ module Hanami
         end
       end
 
-      # rubocop:disable Metrics/MethodLength
       def log_request(env, status, time)
         data = {
-          http: env[HTTP_VERSION],
           verb: env[REQUEST_METHOD],
           status: status,
           ip: env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR],
           path: env[SCRIPT_NAME] + env[PATH_INFO].to_s,
           length: extract_content_length(env),
-          params: extract_params(env),
-          elapsed: time,
+          params: env[ROUTER_PARAMS],
+          time: time,
         }
 
-        logger.info JSON.generate(data)
+        logger.info(data)
       end
-      # rubocop:enable Metrics/MethodLength
 
       def log_exception(exception)
         logger.error exception.message
@@ -50,47 +60,12 @@ module Hanami
 
       private
 
-      HTTP_VERSION = "HTTP_VERSION"
-      REQUEST_METHOD = "REQUEST_METHOD"
-      HTTP_X_FORWARDED_FOR = "HTTP_X_FORWARDED_FOR"
-      REMOTE_ADDR = "REMOTE_ADDR"
-      SCRIPT_NAME = "SCRIPT_NAME"
-      PATH_INFO = "PATH_INFO"
-      RACK_ERRORS = "rack.errors"
-      QUERY_HASH = "rack.request.query_hash"
-      FORM_HASH = "rack.request.form_hash"
-      ROUTER_PARAMS = "router.params"
-      CONTENT_LENGTH = "Content-Length"
+      attr_reader :logger
 
       def extract_content_length(env)
         value = env[CONTENT_LENGTH]
         !value || value.to_s == "0" ? "-" : value
       end
-
-      def extract_params(env)
-        result = env.fetch(QUERY_HASH, {})
-        result.merge!(env.fetch(FORM_HASH, {}))
-        result.merge!(Hanami::Utils::Hash.deep_stringify(env.fetch(ROUTER_PARAMS, {})))
-        result
-      end
-
-      FILTERED = "[FILTERED]"
-
-      # rubocop:disable Metrics/MethodLength
-      def filter(params)
-        params.each_with_object({}) do |(k, v), h|
-          if filter_params.include?(k)
-            h.update(k => FILTERED)
-          elsif v.is_a?(Hash)
-            h.update(k => filter(v))
-          elsif v.is_a?(Array)
-            h.update(k => v.map { |m| m.is_a?(Hash) ? filter(m) : m })
-          else
-            h[k] = v
-          end
-        end
-      end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/spec/unit/hanami/web/rack_logger_spec.rb
+++ b/spec/unit/hanami/web/rack_logger_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "hanami/web/rack_logger"
+require "hanami/logger"
+require "stringio"
+require "rack/mock"
+
+RSpec.describe Hanami::Web::RackLogger do
+  subject { described_class.new(logger) }
+  let(:logger) { Hanami::Logger.new(application_name, stream: stream, level: Hanami::Logger::DEBUG, filter: filters) }
+  let(:stream) { StringIO.new }
+  let(:filters) { ["user.password"] }
+  let(:application_name) { "my_app" }
+
+  describe "#initialize" do
+    it "returns an instance of #{described_class}" do
+      expect(subject).to be_kind_of(described_class)
+    end
+  end
+
+  describe "#log_request" do
+    it "logs current request" do
+      path = "/users"
+      ip = "127.0.0.1"
+      status = 200
+      time = 0.0001
+      content_length = 23
+      verb = "POST"
+
+      env = Rack::MockRequest.env_for(path, method: verb)
+      env["Content-Length"] = content_length
+      env["REMOTE_ADDR"] = ip
+
+      params = {"user" => {"password" => "secret"}}
+      env["router.params"] = params
+
+      subject.log_request(env, status, time)
+
+      stream.rewind
+      actual = stream.read
+
+      expect(actual).to include(%([#{application_name}] [INFO] [#{time}] #{verb} #{status} #{ip} #{path} #{content_length} {"user"=>{"password"=>"[FILTERED]"}}))
+    end
+
+    context "ip" do
+      it "takes into account HTTP proxy forwarding" do
+        env = Rack::MockRequest.env_for("/")
+        env["REMOTE_ADDR"] = remote = "127.0.0.1"
+        env["HTTP_X_FORWARDED_FOR"] = forwarded = "::1"
+
+        subject.log_request(env, 200, 0.1)
+
+        stream.rewind
+        actual = stream.read
+
+        expect(actual).to include(forwarded)
+        expect(actual).to_not include(remote)
+      end
+    end
+
+    context "path prefix" do
+      it "logs full referenced relative path" do
+        env = Rack::MockRequest.env_for(path = "/users")
+        env["SCRIPT_NAME"] = script_name = "/v1"
+
+        subject.log_request(env, 200, 0.1)
+
+        stream.rewind
+        actual = stream.read
+
+        expect(actual).to include(script_name + path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Enhancements

Removed responsibilities from `Hanami::Web::RackLogger` to simplify its implementation and delegate those responsibilities to proper collaborator objects.

### Parsing Params

`Hanami::Web::RackLogger` should NOT be responsible of **parsing Rack env**.
This is is a Router responsibility. See https://github.com/hanami/router/pull/217

Logging params that aren't parsed by router can lead to bugs and confusion.

### Filtering Params

`Hanami::Web::RackLogger` should NOT be responsible of **filtering params** that contain sensitive data.
This is a logger responsibility of the logger (`Hanami::Loggger` for now, then `dry-logger`).

### Log Formatting

`Hanami::Web::RackLogger` should NOT be responsible of **formatting logs**.
This is a logger responsibility of the logger (`Hanami::Loggger` for now, then `dry-logger`).

## Technical notes

I removed HTTP version from the logs, because it's deprecated in Rack. https://github.com/rack/rack/pull/1691