### PR TITLE
Don't declare inflector value as cloneable

### DIFF
--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -126,7 +126,7 @@ module Hanami
 
     setting :root, constructor: -> path { Pathname(path) }
 
-    setting :inflector, default: Dry::Inflector.new, cloneable: true
+    setting :inflector, default: Dry::Inflector.new
 
     def inflections(&block)
       self.inflector = Dry::Inflector.new(&block)


### PR DESCRIPTION
This is not a mutable object, since it has all its inflection rules received at initialization time only, so we can treat it as a non-cloneable value. This fixes the assumptions in our test cases that were no longer true with cloneable objects as of dry-configurable 0.14.0