### PR TITLE
Fix flaky integration spec

### DIFF
--- a/spec/new_integration/application_settings_spec.rb
+++ b/spec/new_integration/application_settings_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "hanami/application/settings"
+
 RSpec.describe "Application settings", :application_integration do
   before do
     @env = ENV.to_h


### PR DESCRIPTION
Add require so we can ensure error class exists, otherwise the spec asserting the error in this file may flake (which I've observed locally)