### PR TITLE
Rack Logger: Ensure to print current timestamp and indicate `ms` for elapsed time

### DIFF
--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -39,15 +39,16 @@ module Hanami
         end
       end
 
-      def log_request(env, status, time)
+      def log_request(env, status, elapsed)
         data = {
           verb: env[REQUEST_METHOD],
           status: status,
+          elapsed: "#{elapsed}ms",
           ip: env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR],
           path: env[SCRIPT_NAME] + env[PATH_INFO].to_s,
           length: extract_content_length(env),
           params: env[ROUTER_PARAMS],
-          time: time,
+          time: Time.now,
         }
 
         logger.info(data)

--- a/spec/unit/hanami/web/rack_logger_spec.rb
+++ b/spec/unit/hanami/web/rack_logger_spec.rb
@@ -20,10 +20,13 @@ RSpec.describe Hanami::Web::RackLogger do
 
   describe "#log_request" do
     it "logs current request" do
+      time = Time.parse("2022-02-04 11:38:25.218816 +0100")
+      expect(Time).to receive(:now).at_least(:once).and_return(time)
+
       path = "/users"
       ip = "127.0.0.1"
       status = 200
-      time = 0.0001
+      elapsed = 0.0001
       content_length = 23
       verb = "POST"
 
@@ -34,12 +37,12 @@ RSpec.describe Hanami::Web::RackLogger do
       params = {"user" => {"password" => "secret"}}
       env["router.params"] = params
 
-      subject.log_request(env, status, time)
+      subject.log_request(env, status, elapsed)
 
       stream.rewind
       actual = stream.read
 
-      expect(actual).to include(%([#{application_name}] [INFO] [#{time}] #{verb} #{status} #{ip} #{path} #{content_length} {"user"=>{"password"=>"[FILTERED]"}}))
+      expect(actual).to include(%([#{application_name}] [INFO] [#{time}] #{verb} #{status} #{elapsed}ms #{ip} #{path} #{content_length} {"user"=>{"password"=>"[FILTERED]"}}))
     end
 
     context "ip" do


### PR DESCRIPTION
This is a follow up of #1139, where I messed up with a couple of things:

* Timestamp disappeared from logs
* Elapsed time didn't have a unit measure (`ms`)

This PR fixes those problems.