### PR TITLE
Support partial slice imports and exports

### DIFF
--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -39,6 +39,10 @@ module Hanami
       slice_block = application.configuration.slices[name]
       instance_eval(&slice_block) if slice_block
 
+      # This is here and not inside define_container to allow for the slice block to
+      # interact with container config
+      container.configured!
+
       self
     end
 
@@ -180,8 +184,6 @@ module Hanami
         namespace.const_set :Container, container
         namespace.const_set :Deps, container.injector
       end
-
-      container.configured!
 
       container
     end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -59,12 +59,19 @@ module Hanami
       @container ||= define_container
     end
 
-    def import(*slice_names)
+    def import(from:, **kwargs)
+      # TODO: This should be handled via dry-system (see dry-rb/dry-system#228)
       raise "Cannot import after booting" if booted?
 
-      slice_names.each do |slice_name|
-        container.import from: application.slices.fetch(slice_name.to_sym).container, as: slice_name.to_sym
+      if from.is_a?(Symbol) || from.is_a?(String)
+        slice_name = from
+        # TODO: better error than the KeyError from fetch if the slice doesn't exist
+        from = application.slices.fetch(from.to_sym).container
       end
+
+      as = kwargs[:as] || slice_name
+
+      container.import(from: from, as: as, **kwargs)
     end
 
     def register(*args, &block)


### PR DESCRIPTION
[_We can't just have imports without exports_](https://www.youtube.com/watch?v=LnIKiNAupRs)

This change makes it possible to use all the container import/export features from dry-system 0.23.0.

Firstly, it changes our `Slice#import` API to match and extend `Dry::System::Container.import`. You can now use all the `Container.import` arguments, with the only difference being that you can supply a slice name (string or symbol) instead of a whole container object to `from:`.

For example:

```ruby
# Import from "search" slice, uses "search" as the imported key namespace
import(from: :search)

# Import from "search" slice with custom namespace
import(from: :search, as: :search_engine)

# Import specific keys from "search" slice
import(keys: ["run_query"], from: :search)
```

Currently, these `import` calls all need to be made inside the `config.slice` blocks we provide, e.g.

```ruby
class MyApplication < Hanami::Application
  config.slice(:admin) do
    import(from: :search)
  end
end
```

I'll be planning to improve slice configuration as part of the next alpha.

Secondly, I've made some tweaks to the way these slice config blocks are handled to make it possible for you to configure the slice container within them, which means we can also take advantage of dry-system's configurable exports:

```ruby
class MyApplication < Hanami::Application
  config.slice(:admin) do
    import(from: :search)
  end

  config.slice(:search) do
    container.config.exports = %w[run_query index_item]
  end
end
```

With this in place, users can take complete advantage of the new dry-system import/export functionality for the upcoming Hanami 2 alpha.

The exact way of achieving this may change in the subsequent alpha (when I plan to rebuild slice setup and configuration), but any changes required at that point should only be mechanical, i.e. just shifting around a couple bits of code. The overall import/export functionality will always remain in place.