### PR TITLE
Use concrete classes for slices, and various app/slice tidy-ups

### DIFF
--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
+require_relative "hanami/application"
+require_relative "hanami/errors"
+require_relative "hanami/version"
+
+
 # A complete web framework for Ruby
 #
 # @since 0.1.0
 #
 # @see http://hanamirb.org
 module Hanami
-  require "hanami/version"
-  require "hanami/application"
-
   @_mutex = Mutex.new
 
   def self.application
     @_mutex.synchronize do
-      raise "Hanami.application not configured" unless defined?(@_application)
+      unless defined?(@_application)
+        raise ApplicationLoadError,
+          "Hanami.application is not yet configured. " \
+          "You may need to `require \"hanami/setup\"` to load your config/application.rb file."
+      end
 
       @_application
     end
@@ -25,7 +31,9 @@ module Hanami
 
   def self.application=(klass)
     @_mutex.synchronize do
-      raise "Hanami.application already configured" if defined?(@_application)
+      if defined?(@_application)
+        raise ApplicationLoadError, "Hanami.application is already configured."
+      end
 
       @_application = klass unless klass.name.nil?
     end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -82,7 +82,7 @@ module Hanami
 
         container.finalize!(&block)
 
-        slices.values.each(&:boot)
+        slices.each_value(&:boot)
 
         @booted = true
         self

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -6,6 +6,7 @@ require "hanami/configuration"
 require "pathname"
 require "rack"
 require "zeitwerk"
+require_relative "constants"
 require_relative "slice"
 
 module Hanami
@@ -315,9 +316,6 @@ module Hanami
       rescue LoadError
         Settings.new
       end
-
-      MODULE_DELIMITER = "::"
-      private_constant :MODULE_DELIMITER
 
       def autodiscover_application_constant(constants)
         inflector.constantize([namespace_name, *constants].join(MODULE_DELIMITER))

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -203,9 +203,9 @@ module Hanami
       end
 
       def prepare_container_plugins
-        container.use :env, inferrer: -> { Hanami.env }
-        container.use :zeitwerk, loader: autoloader, run_setup: false, eager_load: false
-        container.use :notifications
+        container.use(:env, inferrer: -> { Hanami.env })
+        container.use(:zeitwerk, loader: autoloader, run_setup: false, eager_load: false)
+        container.use(:notifications)
       end
 
       def prepare_container_base_config

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -225,8 +225,6 @@ module Hanami
         container.add_to_load_path!("lib") if root.join("lib").directory?
 
         container.configured!
-
-        container
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -290,18 +290,19 @@ module Hanami
         File.join(root, config.slices_dir)
       end
 
-      # Attempts to load a namespaced `Slice` class defined in "slice.rb" within the given
-      # `slice_path`, then registers the slice with the matching class, if found.
+      # Attempts to load a slice class defined in `config/slices/[slice_name].rb`, then
+      # registers the slice with the matching class, if found.
       def load_slice(slice_path)
         slice_path = Pathname(slice_path)
 
         slice_name = slice_path.relative_path_from(Pathname(slices_path)).to_s
         slice_const_name = inflector.camelize(slice_name)
+        slice_require_path = root.join("config", "slices", slice_name).to_s
 
         begin
-          require(slice_path.join("slice").to_s)
+          require(slice_require_path)
         rescue LoadError => e
-          raise e unless File.basename(e.path) == "slice"
+          raise e unless e.path == slice_require_path
         end
 
         slice_class =

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -85,11 +85,11 @@ module Hanami
       end
 
       def prepared?
-        @prepared
+        !!@prepared
       end
 
       def booted?
-        @booted
+        !!@booted
       end
 
       def router

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -139,21 +139,7 @@ module Hanami
         raise "Slice +#{name}+ already registered" if slices.key?(name.to_sym)
         # TODO: raise error unless name meets format (i.e. single level depth only)
 
-        if !slice_class
-          slice_module =
-            begin
-              slice_module_name = inflector.camelize(name.to_s)
-              slice_module = inflector.constantize(slice_module_name)
-            rescue NameError => e
-              Object.const_set(inflector.camelize(slice_module_name), Module.new)
-            end
-
-          slice_class = slice_module.const_set(:Slice, Class.new(Hanami::Slice))
-        end
-
-        slice_class.instance_eval(&block) if block
-
-        slices[name.to_sym] = slice_class
+        slices[name.to_sym] = slice_class || Slice.build_slice(name, &block)
       end
 
       def register(...)

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -134,7 +134,7 @@ module Hanami
         @slices ||= {}
       end
 
-      def register_slice(name, slice_class = nil)
+      def register_slice(name, slice_class = nil, &block)
         # TODO: real error class
         raise "Slice +#{name}+ already registered" if slices.key?(name.to_sym)
         # TODO: raise error unless name meets format (i.e. single level depth only)
@@ -150,6 +150,8 @@ module Hanami
 
           slice_class = slice_module.const_set(:Slice, Class.new(Hanami::Slice))
         end
+
+        slice_class.instance_eval(&block) if block
 
         slices[name.to_sym] = slice_class
       end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "dry/system/container"
-require "dry/system/loader/autoloading"
 require "hanami/configuration"
 require "pathname"
 require "rack"

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -55,10 +55,7 @@ module Hanami
       alias_method :config, :configuration
 
       def prepare(provider_name = nil)
-        if provider_name
-          container.prepare(provider_name)
-          return self
-        end
+        container.prepare(provider_name) and return self if provider_name
 
         return self if prepared?
 

--- a/lib/hanami/application/slice_registrar.rb
+++ b/lib/hanami/application/slice_registrar.rb
@@ -18,8 +18,10 @@ module Hanami
       end
 
       def register(name, slice_class = nil, &block)
-        # TODO: real error class
-        raise "Slice +#{name}+ already registered" if slices.key?(name.to_sym)
+        if slices.key?(name.to_sym)
+          raise SliceLoadError, "Slice '#{name.to_s}' is already registered"
+        end
+
         # TODO: raise error unless name meets format (i.e. single level depth only)
 
         slices[name.to_sym] = slice_class || Slice.build_slice(name, &block)
@@ -27,7 +29,7 @@ module Hanami
 
       def [](name)
         slices.fetch(name) do
-          raise "Slice #{name} not found"
+          raise SliceLoadError, "Slice '#{name}' not found"
         end
       end
 

--- a/lib/hanami/application/slice_registrar.rb
+++ b/lib/hanami/application/slice_registrar.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../constants"
+require_relative "../slice"
 
 module Hanami
   class Application
@@ -24,7 +25,7 @@ module Hanami
 
         # TODO: raise error unless name meets format (i.e. single level depth only)
 
-        slices[name.to_sym] = slice_class || Slice.build_slice(name, &block)
+        slices[name.to_sym] = slice_class || build_slice(name, &block)
       end
 
       def [](name)
@@ -83,6 +84,18 @@ module Hanami
           end
 
         register(slice_name, slice_class)
+      end
+
+      def build_slice(slice_name, &block)
+        slice_module =
+          begin
+            slice_module_name = inflector.camelize(slice_name.to_s)
+            inflector.constantize(slice_module_name)
+          rescue NameError
+            Object.const_set(inflector.camelize(slice_module_name), Module.new)
+          end
+
+        slice_module.const_set(:Slice, Class.new(Hanami::Slice, &block))
       end
 
       def root

--- a/lib/hanami/application/slice_registrar.rb
+++ b/lib/hanami/application/slice_registrar.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Application
+    # @api private
+    class SliceRegistrar
+      attr_reader :slices
+      private :slices
+
+      def initialize
+        @slices = {}
+      end
+
+      def register(name, slice_class = nil, &block)
+        # TODO: real error class
+        raise "Slice +#{name}+ already registered" if slices.key?(name.to_sym)
+        # TODO: raise error unless name meets format (i.e. single level depth only)
+
+        slices[name.to_sym] = slice_class || Slice.build_slice(name, &block)
+      end
+
+      def [](name)
+        slices.fetch(name) do
+          raise "Slice #{name} not found"
+        end
+      end
+
+      def each(&block)
+        slices.each_value(&block)
+      end
+
+      def to_a
+        slices.values
+      end
+    end
+  end
+end

--- a/lib/hanami/application/slice_registrar.rb
+++ b/lib/hanami/application/slice_registrar.rb
@@ -22,13 +22,7 @@ module Hanami
 
         # TODO: raise error unless name meets format (i.e. single level depth only)
 
-        slice = slice_class || build_slice(name, &block)
-
-        unless slice.application.eql?(application)
-          raise SliceLoadError, "Slice #{slice} must be registered with its own application"
-        end
-
-        slices[name.to_sym] = slice
+        slices[name.to_sym] = slice_class || build_slice(name, &block)
       end
 
       def [](name)
@@ -98,12 +92,7 @@ module Hanami
             Object.const_set(inflector.camelize(slice_module_name), Module.new)
           end
 
-        slice = Class.new(Hanami::Slice) { |klass|
-          klass.application(application)
-          klass.instance_eval(&block) if block
-        }
-
-        slice_module.const_set(:Slice, slice)
+        slice_module.const_set(:Slice, Class.new(Hanami::Slice, &block))
       end
 
       def root

--- a/lib/hanami/application/slice_registrar.rb
+++ b/lib/hanami/application/slice_registrar.rb
@@ -7,11 +7,8 @@ module Hanami
   class Application
     # @api private
     class SliceRegistrar
-      attr_reader :application
-      private :application
-
-      attr_reader :slices
-      private :slices
+      attr_reader :application, :slices
+      private :application, :slices
 
       def initialize(application)
         @application = application
@@ -20,7 +17,7 @@ module Hanami
 
       def register(name, slice_class = nil, &block)
         if slices.key?(name.to_sym)
-          raise SliceLoadError, "Slice '#{name.to_s}' is already registered"
+          raise SliceLoadError, "Slice '#{name}' is already registered"
         end
 
         # TODO: raise error unless name meets format (i.e. single level depth only)

--- a/lib/hanami/application/slice_registrar.rb
+++ b/lib/hanami/application/slice_registrar.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
+require_relative "../constants"
+
 module Hanami
   class Application
     # @api private
     class SliceRegistrar
+      attr_reader :application
+      private :application
+
       attr_reader :slices
       private :slices
 
-      def initialize
+      def initialize(application)
+        @application = application
         @slices = {}
       end
 
@@ -25,12 +31,64 @@ module Hanami
         end
       end
 
+      def freeze
+        slices.freeze
+        super
+      end
+
+      def load_slices
+        slice_configs = Dir[root.join(CONFIG_DIR, "slices", "*#{RB_EXT}")]
+          .map { |file| File.basename(file, RB_EXT) }
+
+        slice_dirs = Dir[File.join(root, SLICES_DIR, "*")]
+          .select { |path| File.directory?(path) }
+          .map { |path| File.basename(path) }
+
+        (slice_dirs + slice_configs).uniq.sort.each do |slice_name|
+          load_slice(slice_name)
+        end
+
+        self
+      end
+
       def each(&block)
         slices.each_value(&block)
       end
 
       def to_a
         slices.values
+      end
+
+      private
+
+      # Attempts to load a slice class defined in `config/slices/[slice_name].rb`, then
+      # registers the slice with the matching class, if found.
+      def load_slice(slice_name)
+        slice_const_name = inflector.camelize(slice_name)
+        slice_require_path = root.join("config", "slices", slice_name).to_s
+
+        begin
+          require(slice_require_path)
+        rescue LoadError => e
+          raise e unless e.path == slice_require_path
+        end
+
+        slice_class =
+          begin
+            inflector.constantize("#{slice_const_name}::Slice")
+          rescue NameError => e
+            raise e unless e.name == :Slice
+          end
+
+        register(slice_name, slice_class)
+      end
+
+      def root
+        application.root
+      end
+
+      def inflector
+        application.inflector
       end
     end
   end

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -38,6 +38,7 @@ module Hanami
     private :environments
 
     def initialize(application_name:, env:)
+      # FIXME: Ugh, this shouldn't be here
       @namespace = application_name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER)
 
       @environments = DEFAULT_ENVIRONMENTS.clone

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -149,8 +149,6 @@ module Hanami
 
     setting :settings_store, default: Application::Settings::DotenvStore
 
-    setting :slices_dir, default: "slices"
-
     setting :source_dirs, default: Configuration::SourceDirs.new, cloneable: true
 
     setting :base_url, default: "http://0.0.0.0:2300", constructor: -> url { URI(url) }

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -151,8 +151,6 @@ module Hanami
 
     setting :slices_dir, default: "slices"
 
-    setting :slices_namespace, default: Object
-
     # TODO: convert into a dedicated object with explicit behaviour around blocks per
     # slice, etc.
     setting :slices, default: {}, constructor: :dup.to_proc

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -151,15 +151,7 @@ module Hanami
 
     setting :slices_dir, default: "slices"
 
-    # TODO: convert into a dedicated object with explicit behaviour around blocks per
-    # slice, etc.
-    setting :slices, default: {}, constructor: :dup.to_proc
-
     setting :source_dirs, default: Configuration::SourceDirs.new, cloneable: true
-
-    def slice(slice_name, &block)
-      slices[slice_name] = block
-    end
 
     setting :base_url, default: "http://0.0.0.0:2300", constructor: -> url { URI(url) }
 

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -38,7 +38,6 @@ module Hanami
     private :environments
 
     def initialize(application_name:, env:)
-      # FIXME: Ugh, this shouldn't be here
       @namespace = application_name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER)
 
       @environments = DEFAULT_ENVIRONMENTS.clone

--- a/lib/hanami/constants.rb
+++ b/lib/hanami/constants.rb
@@ -1,0 +1,5 @@
+module Hanami
+  # @api private
+  MODULE_DELIMITER = "::"
+  private_constant :MODULE_DELIMITER
+end

--- a/lib/hanami/constants.rb
+++ b/lib/hanami/constants.rb
@@ -1,5 +1,19 @@
+# frozen_string_literal: true
+
 module Hanami
   # @api private
   MODULE_DELIMITER = "::"
   private_constant :MODULE_DELIMITER
+
+  # @api private
+  CONFIG_DIR = "config"
+  private_constant :CONFIG_DIR
+
+  # @api private
+  SLICES_DIR = "slices"
+  private_constant :SLICES_DIR
+
+  # @api private
+  RB_EXT = ".rb"
+  private_constant :RB_EXT
 end

--- a/lib/hanami/constants.rb
+++ b/lib/hanami/constants.rb
@@ -14,6 +14,10 @@ module Hanami
   private_constant :SLICES_DIR
 
   # @api private
+  LIB_DIR = "lib"
+  private_constant :LIB_DIR
+
+  # @api private
   RB_EXT = ".rb"
   private_constant :RB_EXT
 end

--- a/lib/hanami/errors.rb
+++ b/lib/hanami/errors.rb
@@ -5,5 +5,8 @@ module Hanami
   Error = Class.new(StandardError)
 
   # @since 2.0.0
+  ApplicationLoadError = Class.new(Error)
+
+  # @since 2.0.0
   SliceLoadError = Class.new(Error)
 end

--- a/lib/hanami/errors.rb
+++ b/lib/hanami/errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Hanami
+  # @since 2.0.0
+  Error = Class.new(StandardError)
+
+  # @since 2.0.0
+  SliceLoadError = Class.new(Error)
+end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -201,8 +201,7 @@ module Hanami
 
           component_dir = component_dir.dup
 
-          # TODO: this `== "lib"` check should be codified into a method somewhere
-          if component_dir.path == "lib"
+          if component_dir.path == LIB_DIR
             # Expect component files in the root of the lib/ component dir to define
             # classes inside the slice's namespace.
             #
@@ -210,8 +209,6 @@ module Hanami
             # "foo"
             component_dir.namespaces.delete_root
             component_dir.namespaces.add_root(key: nil, const: namespace_path)
-
-            container.config.component_dirs.add(component_dir)
           else
             # Expect component files in the root of non-lib/ component dirs to define
             # classes inside a namespace matching that dir.
@@ -223,9 +220,9 @@ module Hanami
 
             component_dir.namespaces.delete_root
             component_dir.namespaces.add_root(const: dir_namespace_path, key: component_dir.path)
-
-            container.config.component_dirs.add(component_dir)
           end
+
+          container.config.component_dirs.add(component_dir)
         end
       end
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -78,6 +78,8 @@ module Hanami
       end
 
       def boot
+        return self if booted?
+
         container.finalize!
 
         @booted = true

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -41,7 +41,7 @@ module Hanami
       end
 
       def root
-        application.root.join("slices", slice_name.to_s)
+        application.root.join(application.config.slices_dir, slice_name.to_s)
       end
 
       def inflector

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -52,7 +52,7 @@ module Hanami
       end
 
       def root
-        application.root.join(application.config.slices_dir, slice_name.to_s)
+        application.root.join(SLICES_DIR, slice_name.to_s)
       end
 
       def inflector

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -182,7 +182,7 @@ module Hanami
       def prepare_container_base_config
         container.config.name = slice_name
         container.config.root = root
-        container.config.provider_dirs = ["config/providers"]
+        container.config.provider_dirs = [File.join("config", "providers")]
 
         container.config.env = application.configuration.env
         container.config.inflector = application.configuration.inflector

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -32,12 +32,20 @@ module Hanami
         inflector.constantize(name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER))
       end
 
-      def namespace_path
-        inflector.underscore(namespace)
+      def application
+        Hanami.application
       end
 
       def slice_name
         inflector.underscore(name.split(MODULE_DELIMITER)[-2]).to_sym
+      end
+
+      def namespace
+        inflector.constantize(name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER))
+      end
+
+      def namespace_path
+        inflector.underscore(namespace)
       end
 
       def root
@@ -135,10 +143,6 @@ module Hanami
       end
 
       private
-
-      def application
-        Hanami.application
-      end
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def __prepare_container

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -79,9 +79,6 @@ module Hanami
 
         prepare_all
 
-        namespace.const_set :Container, container
-        namespace.const_set :Deps, container.injector
-
         @prepared = true
         self
       end
@@ -171,9 +168,9 @@ module Hanami
         prepare_container_plugins
         prepare_container_base_config
         prepare_container_component_dirs
-        prepare_autoload_paths
+        prepare_autoloader
         prepare_container_imports
-
+        prepare_container_consts
         instance_exec(container, &@prepare_container_block) if @prepare_container_block
         container.configured!
       end
@@ -195,7 +192,7 @@ module Hanami
         container.config.inflector = application.configuration.inflector
       end
 
-      def prepare_container_component_dirs
+      def prepare_container_component_dirs # rubocop:disable Metrics/AbcSize
         return unless root&.directory?
 
         container.config.root = root
@@ -234,7 +231,7 @@ module Hanami
         end
       end
 
-      def prepare_autoload_paths
+      def prepare_autoloader # rubocop:disable Metrics/AbcSize
         return unless root&.directory?
 
         # Pass configured autoload dirs to the autoloader
@@ -258,6 +255,11 @@ module Hanami
 
       def prepare_container_imports
         container.import from: application.container, as: :application
+      end
+
+      def prepare_container_consts
+        namespace.const_set :Container, container
+        namespace.const_set :Deps, container.injector
       end
     end
   end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -21,20 +21,6 @@ module Hanami
         klass.instance_variable_set(:@container, Class.new(Dry::System::Container))
       end
 
-      def build_slice(slice_name, &block)
-        inflector = application.inflector
-
-        slice_module =
-          begin
-            slice_module_name = inflector.camelize(slice_name.to_s)
-            inflector.constantize(slice_module_name)
-          rescue NameError
-            Object.const_set(inflector.camelize(slice_module_name), Module.new)
-          end
-
-        slice_module.const_set(:Slice, Class.new(Hanami::Slice, &block))
-      end
-
       def application
         Hanami.application
       end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -59,14 +59,6 @@ module Hanami
         application.inflector
       end
 
-      def prepared?
-        !!@prepared
-      end
-
-      def booted?
-        !!@booted
-      end
-
       def prepare(provider_name = nil)
         container.prepare(provider_name) and return self if provider_name
 
@@ -93,6 +85,14 @@ module Hanami
         @booted = true
 
         self
+      end
+
+      def prepared?
+        !!@prepared
+      end
+
+      def booted?
+        !!@booted
       end
 
       def register(...)

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -59,7 +59,6 @@ module Hanami
         application.inflector
       end
 
-      # rubocop:disable Style/DoubleNegation
       def prepared?
         !!@prepared
       end
@@ -67,7 +66,6 @@ module Hanami
       def booted?
         !!@booted
       end
-      # rubocop:enable Style/DoubleNegation
 
       def prepare(provider_name = nil)
         container.prepare(provider_name) and return self if provider_name

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -174,12 +174,14 @@ module Hanami
       end
 
       def prepare_container_plugins
-        container.use :env
+        container.use(:env, inferrer: -> { Hanami.env })
 
-        container.use :zeitwerk,
+        container.use(
+          :zeitwerk,
           loader: application.autoloader,
           run_setup: false,
           eager_load: false
+        )
       end
 
       def prepare_container_base_config

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -12,6 +12,10 @@ module Hanami
   #
   # @since 2.0.0
   class Slice
+    # TODO: Move to a common constants file
+    MODULE_DELIMITER = "::"
+    private_constant :MODULE_DELIMITER
+
     class << self
       attr_reader :container
 
@@ -23,8 +27,6 @@ module Hanami
         klass.instance_variable_set(:@container, Class.new(Dry::System::Container))
       end
 
-      MODULE_DELIMITER = "::"
-      private_constant :MODULE_DELIMITER
 
       def namespace
         inflector.constantize(name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER))

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -186,6 +186,7 @@ module Hanami
 
       def prepare_container_base_config
         container.config.name = slice_name
+        container.config.root = root
         container.config.provider_dirs = ["config/providers"]
 
         container.config.env = application.configuration.env
@@ -194,8 +195,6 @@ module Hanami
 
       def prepare_container_component_dirs # rubocop:disable Metrics/AbcSize
         return unless root&.directory?
-
-        container.config.root = root
 
         # Add component dirs for each configured component path
         application.configuration.source_dirs.component_dirs.each do |component_dir|

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -3,190 +3,210 @@
 require "dry/system/container"
 require "pathname"
 
+# Changes here
+#
+# 1. Requiring every slice to have an actual namespace (no more `if namespace` checks)
+
 module Hanami
   # Distinct area of concern within an Hanami application
   #
   # @since 2.0.0
   class Slice
-    attr_reader :application, :name, :namespace, :root
+    class << self
+      attr_reader :container
 
-    def initialize(application, name:, namespace: nil, root: nil, container: nil)
-      @application = application
-      @name = name.to_sym
-      @namespace = namespace
-      @root = root ? Pathname(root) : root
-      @container = container
-    end
+      def inherited(klass)
+        super
 
-    def inflector
-      application.inflector
-    end
-
-    def namespace_path
-      @namespace_path ||= inflector.underscore(namespace.to_s)
-    end
-
-    def prepare(provider_name = nil)
-      if provider_name
-        container.prepare(provider_name)
-        return self
+        # Create a (to be configured later) container as early as possible, since other
+        # slices may want to refer to it via their import declarations
+        klass.instance_variable_set(:@container, Class.new(Dry::System::Container))
       end
 
-      @container ||= define_container
+      MODULE_DELIMITER = "::"
+      private_constant :MODULE_DELIMITER
 
-      container.import from: application.container, as: :application
-
-      slice_block = application.configuration.slices[name]
-      instance_eval(&slice_block) if slice_block
-
-      # This is here and not inside define_container to allow for the slice block to
-      # interact with container config
-      container.configured!
-
-      self
-    end
-
-    def boot
-      container.finalize!
-
-      @booted = true
-      self
-    end
-
-    # rubocop:disable Style/DoubleNegation
-    def booted?
-      !!@booted
-    end
-    # rubocop:enable Style/DoubleNegation
-
-    def container
-      @container ||= define_container
-    end
-
-    def import(from:, **kwargs)
-      # TODO: This should be handled via dry-system (see dry-rb/dry-system#228)
-      raise "Cannot import after booting" if booted?
-
-      if from.is_a?(Symbol) || from.is_a?(String)
-        slice_name = from
-        # TODO: better error than the KeyError from fetch if the slice doesn't exist
-        from = application.slices.fetch(from.to_sym).container
+      def namespace
+        inflector.constantize(name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER))
       end
 
-      as = kwargs[:as] || slice_name
-
-      container.import(from: from, as: as, **kwargs)
-    end
-
-    def register(*args, &block)
-      container.register(*args, &block)
-    end
-
-    def register_provider(...)
-      container.register_provider(...)
-    end
-
-    def start(...)
-      container.start(...)
-    end
-
-    def key?(...)
-      container.key?(...)
-    end
-
-    def keys
-      container.keys
-    end
-
-    def [](...)
-      container.[](...)
-    end
-
-    def resolve(...)
-      container.resolve(...)
-    end
-
-    private
-
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    def define_container
-      container = Class.new(Dry::System::Container)
-
-      container.use :env
-      container.use :zeitwerk,
-        loader: application.autoloader,
-        run_setup: false,
-        eager_load: false
-
-      container.config.name = name
-      container.config.env = application.configuration.env
-      container.config.inflector = application.configuration.inflector
-
-      if root&.directory?
-        container.config.root = root
-        container.config.provider_dirs = ["config/providers"]
-
-        # Add component dirs for each configured component path
-        application.configuration.source_dirs.component_dirs.each do |component_dir|
-          next unless root.join(component_dir.path).directory?
-
-          component_dir = component_dir.dup
-
-          # TODO: this `== "lib"` check should be codified into a method somewhere
-          if component_dir.path == "lib"
-            # Expect component files in the root of the lib/ component dir to define
-            # classes inside the slice's namespace.
-            #
-            # e.g. "lib/foo.rb" should define SliceNamespace::Foo, to be registered as
-            # "foo"
-            component_dir.namespaces.delete_root
-            component_dir.namespaces.add_root(key: nil, const: namespace_path)
-
-            container.config.component_dirs.add(component_dir)
-          else
-            # Expect component files in the root of non-lib/ component dirs to define
-            # classes inside a namespace matching that dir.
-            #
-            # e.g. "actions/foo.rb" should define SliceNamespace::Actions::Foo, to be
-            # registered as "actions.foo"
-
-            dir_namespace_path = File.join(namespace_path, component_dir.path)
-
-            component_dir.namespaces.delete_root
-            component_dir.namespaces.add_root(const: dir_namespace_path, key: component_dir.path)
-
-            container.config.component_dirs.add(component_dir)
-          end
-        end
+      def namespace_path
+        inflector.underscore(namespace)
       end
 
-      if root&.directory?
-        # Pass configured autoload dirs to the autoloader
-        application.configuration.source_dirs.autoload_paths.each do |autoload_path|
-          next unless root.join(autoload_path).directory?
-
-          dir_namespace_path = File.join(namespace_path, autoload_path)
-
-          autoloader_namespace = begin
-            inflector.constantize(inflector.camelize(dir_namespace_path))
-          rescue NameError
-            namespace.const_set(inflector.camelize(autoload_path), Module.new)
-          end
-
-          container.config.autoloader.push_dir(
-            container.root.join(autoload_path),
-            namespace: autoloader_namespace
-          )
-        end
+      def slice_name
+        inflector.underscore(name.split(MODULE_DELIMITER)[-2]).to_sym
       end
 
-      if namespace
+      def root
+        application.root.join("slices", slice_name.to_s)
+      end
+
+      def inflector
+        application.inflector
+      end
+
+      # rubocop:disable Style/DoubleNegation
+      def prepared?
+        !!@prepared
+      end
+
+      def booted?
+        !!@booted
+      end
+      # rubocop:enable Style/DoubleNegation
+
+      def prepare(provider_name = nil)
+        container.prepare(provider_name) and return self if provider_name
+
+        return self if prepared?
+
+        prepare_container
+
         namespace.const_set :Container, container
         namespace.const_set :Deps, container.injector
+
+        slice_block = application.configuration.slices[slice_name]
+        instance_eval(&slice_block) if slice_block
+
+        # This is here and not inside define_container to allow for the slice block to
+        # interact with container config
+        container.configured!
+
+        @prepared = true
+        self
       end
 
-      container
+      def boot
+        container.finalize!
+
+        @booted = true
+
+        self
+      end
+
+      def register(*args, &block)
+        container.register(*args, &block)
+      end
+
+      def register_provider(...)
+        container.register_provider(...)
+      end
+
+      def start(...)
+        container.start(...)
+      end
+
+      def key?(...)
+        container.key?(...)
+      end
+
+      def keys
+        container.keys
+      end
+
+      def [](...)
+        container.[](...)
+      end
+
+      def resolve(...)
+        container.resolve(...)
+      end
+
+      def import(from:, **kwargs)
+        # TODO: This should be handled via dry-system (see dry-rb/dry-system#228)
+        raise "Cannot import after booting" if booted?
+
+        if from.is_a?(Symbol) || from.is_a?(String)
+          slice_name = from
+          # TODO: better error than the KeyError from fetch if the slice doesn't exist
+          from = application.slices.fetch(from.to_sym).container
+        end
+
+        as = kwargs[:as] || slice_name
+
+        container.import(from: from, as: as, **kwargs)
+      end
+
+      private
+
+      def application
+        Hanami.application
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def prepare_container
+        container.use :env
+        container.use :zeitwerk,
+          loader: application.autoloader,
+          run_setup: false,
+          eager_load: false
+
+        container.config.name = slice_name
+        container.config.env = application.configuration.env
+        container.config.inflector = application.configuration.inflector
+
+        if root&.directory?
+          container.config.root = root
+          container.config.provider_dirs = ["config/providers"]
+
+          # Add component dirs for each configured component path
+          application.configuration.source_dirs.component_dirs.each do |component_dir|
+            next unless root.join(component_dir.path).directory?
+
+            component_dir = component_dir.dup
+
+            # TODO: this `== "lib"` check should be codified into a method somewhere
+            if component_dir.path == "lib"
+              # Expect component files in the root of the lib/ component dir to define
+              # classes inside the slice's namespace.
+              #
+              # e.g. "lib/foo.rb" should define SliceNamespace::Foo, to be registered as
+              # "foo"
+              component_dir.namespaces.delete_root
+              component_dir.namespaces.add_root(key: nil, const: namespace_path)
+
+              container.config.component_dirs.add(component_dir)
+            else
+              # Expect component files in the root of non-lib/ component dirs to define
+              # classes inside a namespace matching that dir.
+              #
+              # e.g. "actions/foo.rb" should define SliceNamespace::Actions::Foo, to be
+              # registered as "actions.foo"
+
+              dir_namespace_path = File.join(namespace_path, component_dir.path)
+
+              component_dir.namespaces.delete_root
+              component_dir.namespaces.add_root(const: dir_namespace_path, key: component_dir.path)
+
+              container.config.component_dirs.add(component_dir)
+            end
+          end
+
+          # Pass configured autoload dirs to the autoloader
+          application.configuration.source_dirs.autoload_paths.each do |autoload_path|
+            next unless root.join(autoload_path).directory?
+
+            dir_namespace_path = File.join(namespace_path, autoload_path)
+
+            autoloader_namespace = begin
+              inflector.constantize(inflector.camelize(dir_namespace_path))
+            rescue NameError
+              namespace.const_set(inflector.camelize(autoload_path), Module.new)
+            end
+
+            container.config.autoloader.push_dir(
+              container.root.join(autoload_path),
+              namespace: autoloader_namespace
+            )
+          end
+        end
+
+        container.import from: application.container, as: :application
+
+        container
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end
 end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -3,16 +3,13 @@
 require "dry/system/container"
 require "hanami/errors"
 require "pathname"
+require_relative "constants"
 
 module Hanami
   # Distinct area of concern within an Hanami application
   #
   # @since 2.0.0
   class Slice
-    # TODO: Move to a common constants file
-    MODULE_DELIMITER = "::"
-    private_constant :MODULE_DELIMITER
-
     class << self
       attr_reader :container
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -16,23 +16,13 @@ module Hanami
       klass.extend(ClassMethods)
 
       # Eagerly initialize any variables that may be accessed inside the subclass body
+      klass.instance_variable_set(:@application, Hanami.application)
       klass.instance_variable_set(:@container, Class.new(Dry::System::Container))
-      klass.application(Hanami.application)
     end
 
     # rubocop:disable Metrics/ModuleLength
     module ClassMethods
-      attr_reader :container
-
-      def application(new_application = nil)
-        if new_application
-          raise SliceLoadError, "Slice application must be set before slice is prepared" if prepared?
-
-          @application = new_application
-        else
-          @application
-        end
-      end
+      attr_reader :application, :container
 
       def slice_name
         inflector.underscore(name.split(MODULE_DELIMITER)[-2]).to_sym

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -61,13 +61,18 @@ module Hanami
 
         return self if prepared?
 
-        prepare_container
+        __prepare_container
 
         namespace.const_set :Container, container
         namespace.const_set :Deps, container.injector
 
         @prepared = true
+
         self
+      end
+
+      def prepare_container(&block)
+        @prepare_container_block = block
       end
 
       def boot
@@ -134,7 +139,7 @@ module Hanami
       end
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      def prepare_container
+      def __prepare_container
         container.use :env
         container.use :zeitwerk,
           loader: application.autoloader,
@@ -202,6 +207,8 @@ module Hanami
         end
 
         container.import from: application.container, as: :application
+
+        instance_exec(container, &@prepare_container_block) if @prepare_container_block
 
         container.configured!
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -131,6 +131,10 @@ module Hanami
         container.resolve(...)
       end
 
+      def export(keys)
+        container.config.exports = keys
+      end
+
       def import(from:, **kwargs)
         # TODO: This should be handled via dry-system (see dry-rb/dry-system#228)
         raise "Cannot import after booting" if booted?

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -77,11 +77,11 @@ module Hanami
 
         return self if prepared?
 
-        raise SliceLoadError, "Slice must have a class name before it can be prepared" unless name
+        ensure_slice_name
+        ensure_slice_consts
 
         __prepare_container
 
-        # TODO: Raise error if these consts are already set
         namespace.const_set :Container, container
         namespace.const_set :Deps, container.injector
 
@@ -152,6 +152,21 @@ module Hanami
       end
 
       private
+
+      def ensure_slice_name
+        unless name
+          raise SliceLoadError, "Slice must have a class name before it can be prepared"
+        end
+      end
+
+      def ensure_slice_consts
+        if namespace.const_defined?(:Container) || namespace.const_defined?(:Deps)
+          raise(
+            SliceLoadError,
+            "#{namespace}::Container and #{namespace}::Deps constants must not already be defined"
+          )
+        end
+      end
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def __prepare_container

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -4,10 +4,6 @@ require "dry/system/container"
 require "hanami/errors"
 require "pathname"
 
-# Changes here
-#
-# 1. Requiring every slice to have an actual namespace (no more `if namespace` checks)
-
 module Hanami
   # Distinct area of concern within an Hanami application
   #

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -141,8 +141,7 @@ module Hanami
         container.after(:configure) do
           if from.is_a?(Symbol) || from.is_a?(String)
             slice_name = from
-            # TODO: better error than the KeyError from fetch if the slice doesn't exist
-            from = application.slices.fetch(from.to_sym).container
+            from = application.slices[from.to_sym].container
           end
 
           as = kwargs[:as] || slice_name

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -87,8 +87,8 @@ module Hanami
         self
       end
 
-      def register(*args, &block)
-        container.register(*args, &block)
+      def register(...)
+        container.register(...)
       end
 
       def register_provider(...)

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -18,8 +18,8 @@ module Hanami
       def inherited(klass)
         super
 
-        # Create a (to be configured later) container as early as possible, since other
-        # slices may want to refer to it via their import declarations
+        # Create a (to be configured later) container as early as possible, since code in
+        # the slice subclass may want to start referring to it right away (e.g. `.import`)
         klass.instance_variable_set(:@container, Class.new(Dry::System::Container))
       end
 

--- a/spec/new_integration/application/component_provider_spec.rb
+++ b/spec/new_integration/application/component_provider_spec.rb
@@ -12,12 +12,7 @@ RSpec.describe Hanami::Application, "#component_provider", :application_integrat
       end
     end
 
-    module Main
-      class Slice < Hanami::Slice
-      end
-    end
-
-    application.register_slice :main, Main::Slice
+    application.register_slice :main
 
     Hanami.prepare
   end

--- a/spec/new_integration/application/component_provider_spec.rb
+++ b/spec/new_integration/application/component_provider_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe Hanami::Application, "#component_provider", :application_integrat
     end
 
     module Main
+      class Slice < Hanami::Slice
+      end
     end
 
-    application.register_slice :main, namespace: Main
+    application.register_slice :main, Main::Slice
 
     Hanami.prepare
   end

--- a/spec/new_integration/container/imports_spec.rb
+++ b/spec/new_integration/container/imports_spec.rb
@@ -227,9 +227,7 @@ RSpec.describe "Container imports", :application_integration do
       write "config/slices/search.rb", <<~RUBY
         module Search
           class Slice < Hanami::Slice
-            prepare_container do |container|
-              container.config.exports = %w[query]
-            end
+            export(%w[query])
           end
         end
       RUBY

--- a/spec/new_integration/container/imports_spec.rb
+++ b/spec/new_integration/container/imports_spec.rb
@@ -227,7 +227,9 @@ RSpec.describe "Container imports", :application_integration do
       write "config/slices/search.rb", <<~RUBY
         module Search
           class Slice < Hanami::Slice
-            container.config.exports = %w[query]
+            prepare_container do |container|
+              container.config.exports = %w[query]
+            end
           end
         end
       RUBY

--- a/spec/new_integration/container/imports_spec.rb
+++ b/spec/new_integration/container/imports_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe "Container imports", :application_integration do
         end
       RUBY
 
-      write "slices/admin/.keep", ""
+      write "config/slices/admin.rb", <<~RUBY
+        module Admin
+          class Slice < Hanami::Slice
+          end
+        end
+      RUBY
 
       require "hanami/setup"
 
@@ -34,14 +39,17 @@ RSpec.describe "Container imports", :application_integration do
 
         module TestApp
           class Application < Hanami::Application
-            config.slice :admin do
-              import from: :search
-            end
           end
         end
       RUBY
 
-      write "slices/admin/.keep", ""
+      write "config/slices/admin.rb", <<~RUBY
+        module Admin
+          class Slice < Hanami::Slice
+            import from: :search
+          end
+        end
+      RUBY
 
       write "slices/search/lib/index_entity.rb", <<~RUBY
         module Search
@@ -50,8 +58,7 @@ RSpec.describe "Container imports", :application_integration do
         end
       RUBY
 
-      require "hanami/setup"
-      Hanami.boot
+      require "hanami/boot"
 
       expect(Admin::Slice["search.index_entity"]).to be_a Search::IndexEntity
 
@@ -71,17 +78,20 @@ RSpec.describe "Container imports", :application_integration do
 
         module TestApp
           class Application < Hanami::Application
-            config.slice :admin do
-              import(
-                keys: ["query"],
-                from: :search
-              )
-            end
           end
         end
       RUBY
 
-      write "slices/admin/.keep", ""
+      write "config/slices/admin.rb", <<~RUBY
+        module Admin
+          class Slice < Hanami::Slice
+            import(
+              keys: ["query"],
+              from: :search
+            )
+          end
+        end
+      RUBY
 
       write "slices/search/lib/index_entity.rb", <<~RUBY
         module Search
@@ -109,18 +119,21 @@ RSpec.describe "Container imports", :application_integration do
 
         module TestApp
           class Application < Hanami::Application
-            config.slice :admin do
-              import(
-                keys: ["query"],
-                from: :search,
-                as: :search_engine
-              )
-            end
           end
         end
       RUBY
 
-      write "slices/admin/.keep", ""
+      write "config/slices/admin.rb", <<~RUBY
+        module Admin
+          class Slice < Hanami::Slice
+            import(
+              keys: ["query"],
+              from: :search,
+              as: :search_engine
+            )
+          end
+        end
+      RUBY
 
       write "slices/search/lib/index_entity.rb", <<~RUBY
         module Search
@@ -148,9 +161,14 @@ RSpec.describe "Container imports", :application_integration do
 
         module TestApp
           class Application < Hanami::Application
-            config.slice :admin do
-              import from: :search
-            end
+          end
+        end
+      RUBY
+
+      write "config/slices/admin.rb", <<~RUBY
+        module Admin
+          class Slice < Hanami::Slice
+            import from: :search
           end
         end
       RUBY
@@ -191,21 +209,28 @@ RSpec.describe "Container imports", :application_integration do
 
         module TestApp
           class Application < Hanami::Application
-            config.slice :admin do
-              import(
-                keys: %w[index_entity query],
-                from: :search
-              )
-            end
-
-            config.slice :search do
-              container.config.exports = %w[query]
-            end
           end
         end
       RUBY
 
-      write "slices/admin/.keep", ""
+      write "config/slices/admin.rb", <<~RUBY
+        module Admin
+          class Slice < Hanami::Slice
+            import(
+              keys: %w[index_entity query],
+              from: :search
+            )
+          end
+        end
+      RUBY
+
+      write "config/slices/search.rb", <<~RUBY
+        module Search
+          class Slice < Hanami::Slice
+            container.config.exports = %w[query]
+          end
+        end
+      RUBY
 
       write "slices/search/lib/index_entity.rb", <<~RUBY
         module Search

--- a/spec/new_integration/slices_spec.rb
+++ b/spec/new_integration/slices_spec.rb
@@ -31,6 +31,30 @@ RSpec.describe "Slices", :application_integration do
     end
   end
 
+  it "Loading a slice with a defined slice class but no slice dir" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "config/slices/main.rb", <<~RUBY
+        module Main
+          class Slice < Hanami::Slice
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      expect(Hanami.application.slices[:main]).to be Main::Slice
+    end
+  end
+
   it "Loading a slice generates a slice class if none is defined" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/application.rb", <<~RUBY

--- a/spec/new_integration/slices_spec.rb
+++ b/spec/new_integration/slices_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Slices", :application_integration do
         end
       RUBY
 
-      write "slices/main/slice.rb", <<~RUBY
+      write "config/slices/main.rb", <<~RUBY
         module Main
           class Slice < Hanami::Slice
           end

--- a/spec/new_integration/slices_spec.rb
+++ b/spec/new_integration/slices_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe "Slices", :application_integration do
+  it "Loading a slice uses a defined slice class" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "slices/main/slice.rb", <<~RUBY
+        module Main
+          class Slice < Hanami::Slice
+          end
+        end
+      RUBY
+
+      write "slices/main/lib/foo.rb", <<~RUBY
+        module Main
+          class Foo; end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      expect(Hanami.application.slices[:main]).to be Main::Slice
+    end
+  end
+
+  it "Loading a slice generates a slice class if none is defined" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+          end
+        end
+      RUBY
+
+      write "slices/main/lib/foo.rb", <<~RUBY
+        module Main
+          class Foo; end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      expect(Hanami.application.slices[:main]).to be Main::Slice
+    end
+  end
+end

--- a/spec/new_integration/slices_spec.rb
+++ b/spec/new_integration/slices_spec.rb
@@ -77,4 +77,25 @@ RSpec.describe "Slices", :application_integration do
       expect(Hanami.application.slices[:main]).to be Main::Slice
     end
   end
+
+  it "Registering a slice with a block creates a slice class and evals the block" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/application.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class Application < Hanami::Application
+            register_slice :main do
+              register "greeting", "hello world"
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      expect(Hanami.application.slices[:main]).to be Main::Slice
+      expect(Main::Slice["greeting"]).to eq "hello world"
+    end
+  end
 end

--- a/spec/unit/hanami/slice_spec.rb
+++ b/spec/unit/hanami/slice_spec.rb
@@ -2,15 +2,10 @@ require "hanami/slice"
 
 RSpec.describe Hanami::Slice, :application_integration do
   before do
-    # FIXME: It's a problem that this doesn't work
-    # Test::Application = Class.new(Hanami::Application)
-
     module Test
       class Application < Hanami::Application
       end
     end
-
-    Test::Application.prepare
   end
 
   describe ".prepare" do
@@ -24,10 +19,10 @@ RSpec.describe Hanami::Slice, :application_integration do
     let(:application_modules) { %i[Test Slice1 Slice2] }
 
     it "allows the user to configure the container after defaults settings have been applied" do
-      slice = described_class.build_slice(:slice1).prepare
+      slice = Hanami.application.register_slice(:slice1).prepare
       expect(slice.container.config.name).to eq :slice1
 
-      slice = described_class.build_slice(:slice2) {
+      slice = Hanami.application.register_slice(:slice2) {
         prepare_container do |container|
           container.config.name = :my_slice
         end

--- a/spec/unit/hanami/slice_spec.rb
+++ b/spec/unit/hanami/slice_spec.rb
@@ -1,8 +1,6 @@
 require "hanami/slice"
 
 RSpec.describe Hanami::Slice, :application_integration do
-  subject(:slice) { Test::Slice = Class.new(described_class) }
-
   before do
     # FIXME: It's a problem that this doesn't work
     # Test::Application = Class.new(Hanami::Application)
@@ -15,17 +13,25 @@ RSpec.describe Hanami::Slice, :application_integration do
     Test::Application.prepare
   end
 
-  describe ".prepare_container" do
-    it "allows the user to configure the container after defaults settings have been applied" do
-      slice = Test::Slice = Class.new(described_class)
-      slice.prepare
-      expect(slice.container.config.name).to eq :test
+  describe ".prepare" do
+    it "raises an error if the slice class is anonymous" do
+      expect { Class.new(described_class).prepare }
+        .to raise_error Hanami::SliceLoadError, /Slice must have a class name/
+    end
+  end
 
-      slice = Test::Slice = Class.new(described_class)
-      slice.prepare_container do |container|
-        container.config.name = :my_slice
-      end
-      slice.prepare
+  describe ".prepare_container" do
+    let(:application_modules) { %i[Test Slice1 Slice2] }
+
+    it "allows the user to configure the container after defaults settings have been applied" do
+      slice = described_class.build_slice(:slice1).prepare
+      expect(slice.container.config.name).to eq :slice1
+
+      slice = described_class.build_slice(:slice2) {
+        prepare_container do |container|
+          container.config.name = :my_slice
+        end
+      }.prepare
       expect(slice.container.config.name).to eq :my_slice
     end
   end

--- a/spec/unit/hanami/slice_spec.rb
+++ b/spec/unit/hanami/slice_spec.rb
@@ -1,0 +1,32 @@
+require "hanami/slice"
+
+RSpec.describe Hanami::Slice, :application_integration do
+  subject(:slice) { Test::Slice = Class.new(described_class) }
+
+  before do
+    # FIXME: It's a problem that this doesn't work
+    # Test::Application = Class.new(Hanami::Application)
+
+    module Test
+      class Application < Hanami::Application
+      end
+    end
+
+    Test::Application.prepare
+  end
+
+  describe ".prepare_container" do
+    it "allows the user to configure the container after defaults settings have been applied" do
+      slice = Test::Slice = Class.new(described_class)
+      slice.prepare
+      expect(slice.container.config.name).to eq :test
+
+      slice = Test::Slice = Class.new(described_class)
+      slice.prepare_container do |container|
+        container.config.name = :my_slice
+      end
+      slice.prepare
+      expect(slice.container.config.name).to eq :my_slice
+    end
+  end
+end


### PR DESCRIPTION
## Enhancements

- Introduce `Hanami::ApplicationLoadError` and `Hanami::SliceLoadError` exceptions to represent errors encountered during application and slice loading.

## Changes

- Slices are now represented as concrete classes (such as `Main::Slice`) inheriting from `Hanami::Slice`, as opposed to _instances_ of `Hanami::Slice`. You may create your own definitions for these slices in `config/slices/[slice_name].rb`, which you can then use for customising per-slice config and behavior, e.g.

    ```ruby
    # config/slices/main.rb:

    module Main
      class Slice < Hanami::Slice
        # slice config here
      end
    end
    ```
- Application-level `config.slice(slice_name, &block)` setting has been removed in favour of slice configuration within concrete slice class definitions
- You can configure your slice imports inside your slice classes, e.g.

    ```ruby
    # config/slices/main.rb:

    module Main
      class Slice < Hanami::Slice
        # Import all exported components from "search" slice
        import from: :search
      end
    end
    ```
- You can configure your slice exports inside your slice classes, e.g.

    ```ruby
    # config/slices/search.rb:

    module Search
      class Slice < Hanami::Slice
        # Export the "index_entity" component only
        export ["index_entity"]
      end
    end
    ```
- For advanced cases, you can configure your slice's container via a `prepare_container` block:

    ```ruby
    # config/slices/search.rb:

    module Search
      class Slice < Hanami::Slice
        prepare_container do |container|
          # `container` object is available here, with 
          # slice-specific configuration already applied
        end
      end
    end
    ```

---

## Implementation notes

Aside from the user-facing changes noted above, there's a few internal implementation details worth highlighting here:

- All responsibility for slice loading, class building, and registration has moved from `Application` to a new `SliceRegistrar`
- The `.prepare` methods in both `Application` and `Slice` are now roughly identical in structure, with all of their specific setup steps moved into individual methods called from a `.prepare_all` private method. This should make it clearer at a higher-level what exactly is being prepared, and could also pave the way for pluggable Application/Slice lifecycle hooks in a post-2.0 world.
- I removed the `config.slices_namespace` setting from `Application`. This existed in theory to allow slices to also live inside the application's own module namespace if a user desired (e.g. `MyApp::Main` instead of just `Main`), but I think this will never really be used, and the our slices always being representative of single top-level modules will be important for our documentation (and generators, and many other things I'm sure) to be clearer.
- I also removed the `config.slices_dir` setting from `Application`, for all the same reasons as above. Hanami applications should always load their slices from the same directory, this doesn't make sense to be configurable.
- I've introduced a `lib/hanami/constants.rb` for sharing common constants
- In both `Application` and `Slice` I've initialized a few extra things as early as possible in their respective `.inherited` hooks, such as the `autoloader` (for the application) and the `container` (for the application and slice), since it's helpful to have these objects available _before_ the user even runs `prepare`. In the case of the container, it's helpful because it allows us to call `import` on it for any `import` statements the user makes inside their own slice classes.