### PR TITLE
Clarify `env` handling in configuration by removing writer method

### DIFF
--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -13,6 +13,7 @@ require_relative "configuration/middleware"
 require_relative "configuration/router"
 require_relative "configuration/sessions"
 require_relative "configuration/source_dirs"
+require_relative "constants"
 
 module Hanami
   # Hanami application configuration
@@ -25,9 +26,6 @@ module Hanami
 
     DEFAULT_ENVIRONMENTS = Concurrent::Hash.new { |h, k| h[k] = Concurrent::Array.new }
     private_constant :DEFAULT_ENVIRONMENTS
-
-    MODULE_DELIMITER = "::"
-    private_constant :MODULE_DELIMITER
 
     attr_reader :env
 

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -29,6 +29,8 @@ module Hanami
     MODULE_DELIMITER = "::"
     private_constant :MODULE_DELIMITER
 
+    attr_reader :env
+
     attr_reader :actions
     attr_reader :middleware
     attr_reader :router
@@ -41,7 +43,7 @@ module Hanami
       @namespace = application_name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER)
 
       @environments = DEFAULT_ENVIRONMENTS.clone
-      config.env = env
+      @env = env
 
       # Some default setting values must be assigned at initialize-time to ensure they
       # have appropriate values for the current application
@@ -115,13 +117,6 @@ module Hanami
 
     def application_name
       inflector.underscore(@namespace).to_sym
-    end
-
-    setting :env
-
-    def env=(new_env)
-      config.env = env
-      apply_env_config(new_env)
     end
 
     setting :root, constructor: -> path { Pathname(path) }

--- a/spec/unit/hanami/configuration_spec.rb
+++ b/spec/unit/hanami/configuration_spec.rb
@@ -38,20 +38,6 @@ RSpec.describe Hanami::Configuration do
       it "does not apply the settings when finalizing" do
         expect { config.finalize! }.not_to change { config.settings_path }
       end
-
-      context "env changed to match" do
-        before do
-          config.env = :production
-        end
-
-        it "applies the settings" do
-          expect(config.settings_path).to eq "config/production_settings"
-        end
-
-        it "leaves the settings in place when finalizing" do
-          expect { config.finalize! }.not_to change { config.settings_path }
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
In actual practice, we expect env to be set once when the configuration is initially loaded (typically via the `HANAMI_ENV` env var), and not changed afterwards.

This change codifies this expectation by removing the `#env=` writer method from `Hanami::Configuration`.

---

## Changes

- The `env` provided to `Hanami::Configuration` (which is based on the value in the `HANAMI_ENV` env var) can no longer be changed after the the configuration is initialized, ensuring consistent behavior for any default configs that are dependent on the env, such as the `config.logger` defaults.