### PR TITLE
Shutdown slices as well as application

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -81,7 +81,9 @@ module Hanami
       end
 
       def shutdown
+        slices.each(&:shutdown)
         container.shutdown!
+        self
       end
 
       def prepared?

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -72,6 +72,11 @@ module Hanami
         self
       end
 
+      def shutdown
+        container.shutdown!
+        self
+      end
+
       def prepared?
         !!@prepared
       end


### PR DESCRIPTION
This extends upon the work you did with `Application#shutdown`, @jodosha, and ensures that slices are shutdown at the same time (since they can and in many cases will have their own slice-specific providers).

Changeloggy bits:

---

## Additions

- `Hanami::Slice.shutdown` can be used to stop all the providers in a slice

## Changes

- `Hanami::Application.shutdown` will now also shutdown all registered slices