### PR TITLE
Stop error building slice when module is missing

### DIFF
--- a/lib/hanami/application/slice_registrar.rb
+++ b/lib/hanami/application/slice_registrar.rb
@@ -76,8 +76,7 @@ module Hanami
         slice_class =
           begin
             inflector.constantize("#{slice_const_name}::Slice")
-          rescue NameError => e
-            raise e unless e.name == :Slice
+          rescue NameError # rubocop:disable Lint/SuppressedException
           end
 
         register(slice_name, slice_class)

--- a/spec/new_integration/application/component_provider_spec.rb
+++ b/spec/new_integration/application/component_provider_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Hanami::Application, "#component_provider", :application_integrat
   end
 
   context "component from external (non-app/slice) namespace" do
+    before do
+      module External; end
+    end
+
     let(:component) { External::Component = Class.new }
 
     it "returns nil" do

--- a/spec/unit/hanami/slice_spec.rb
+++ b/spec/unit/hanami/slice_spec.rb
@@ -2,7 +2,7 @@ require "hanami/slice"
 
 RSpec.describe Hanami::Slice, :application_integration do
   before do
-    module Test
+    module TestApp
       class Application < Hanami::Application
       end
     end
@@ -16,7 +16,7 @@ RSpec.describe Hanami::Slice, :application_integration do
   end
 
   describe ".prepare_container" do
-    let(:application_modules) { %i[Test Slice1 Slice2] }
+    let(:application_modules) { %i[TestApp Slice1 Slice2] }
 
     it "allows the user to configure the container after defaults settings have been applied" do
       slice = Hanami.application.register_slice(:slice1).prepare


### PR DESCRIPTION
Our application template wasn't actually working with the 2.0.0.alpha7 release, because the SliceRegistrar was raising a NameError when building a slice class due to the enclosing module (e.g. `::Main`) not being present.

It's intended functionality of the SliceRegistrar to build this enclosing module as required at the same time as the slice, so this was a bug.

The bug wasn't revealed in our test suite because our `:application_integration` behavior was always eagerly creating the modules that we intended to clean up at the end of the test. 

I've fixed both the issue in SliceRegistrar while also adjusting our test support code to no longer create these modules up-front, allowing for more faithful testing environments.