### PR TITLE
Introduce Hanami::SliceName

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -47,6 +47,8 @@ module Hanami
     module ClassMethods
       attr_reader :application_name, :configuration, :autoloader, :container
 
+      alias_method :slice_name, :application_name
+
       alias_method :config, :configuration
 
       def application

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -149,11 +149,6 @@ module Hanami
         application_name.namespace
       end
 
-      # TODO: Remove this after https://github.com/hanami/hanami/pull/1156 is merged
-      def namespace_path
-        application_name.name
-      end
-
       def root
         configuration.root
       end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -7,6 +7,7 @@ require "rack"
 require "zeitwerk"
 require_relative "constants"
 require_relative "slice"
+require_relative "slice_name"
 require_relative "application/slice_registrar"
 
 module Hanami
@@ -23,7 +24,8 @@ module Hanami
         @_mutex.synchronize do
           subclass.class_eval do
             @_mutex = Mutex.new
-            @_configuration = Hanami::Configuration.new(application_name: klass.name, env: Hanami.env)
+            @application_name = SliceName.new(subclass, inflector: -> { subclass.inflector })
+            @configuration = Hanami::Configuration.new(application_name: @application_name, env: Hanami.env)
             @autoloader = Zeitwerk::Loader.new
             @container = Class.new(Dry::System::Container)
 
@@ -43,17 +45,13 @@ module Hanami
     #
     # rubocop:disable Metrics/ModuleLength
     module ClassMethods
-      attr_reader :autoloader, :container
+      attr_reader :application_name, :configuration, :autoloader, :container
+
+      alias_method :config, :configuration
 
       def application
         self
       end
-
-      def configuration
-        @_configuration
-      end
-
-      alias_method :config, :configuration
 
       def prepare(provider_name = nil)
         container.prepare(provider_name) and return self if provider_name
@@ -148,19 +146,12 @@ module Hanami
       end
 
       def namespace
-        configuration.namespace
+        application_name.namespace
       end
 
-      def namespace_name
-        namespace.name
-      end
-
+      # TODO: Remove this after https://github.com/hanami/hanami/pull/1156 is merged
       def namespace_path
-        inflector.underscore(namespace)
-      end
-
-      def application_name
-        configuration.application_name
+        application_name.name
       end
 
       def root
@@ -208,8 +199,8 @@ module Hanami
 
       def prepare_autoload_paths
         # Autoload classes defined in lib/[app_namespace]/
-        if root.join("lib", namespace_path).directory?
-          autoloader.push_dir(root.join("lib", namespace_path), namespace: namespace)
+        if root.join("lib", application_name.name).directory?
+          autoloader.push_dir(root.join("lib", application_name.name), namespace: namespace)
         end
       end
 
@@ -225,8 +216,8 @@ module Hanami
 
       def prepare_autoloader
         # Autoload classes defined in lib/[app_namespace]/
-        if root.join("lib", namespace_path).directory?
-          autoloader.push_dir(root.join("lib", namespace_path), namespace: namespace)
+        if root.join("lib", application_name.name).directory?
+          autoloader.push_dir(root.join("lib", application_name.name), namespace: namespace)
         end
 
         autoloader.setup
@@ -244,7 +235,7 @@ module Hanami
       end
 
       def autodiscover_application_constant(constants)
-        inflector.constantize([namespace_name, *constants].join(MODULE_DELIMITER))
+        inflector.constantize([application_name.namespace_name, *constants].join(MODULE_DELIMITER))
       end
 
       def load_router

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -17,11 +17,11 @@ module Hanami
     @_mutex = Mutex.new
 
     class << self
-      def inherited(klass)
+      def inherited(subclass)
         super
 
         @_mutex.synchronize do
-          klass.class_eval do
+          subclass.class_eval do
             @_mutex = Mutex.new
             @_configuration = Hanami::Configuration.new(application_name: klass.name, env: Hanami.env)
             @autoloader = Zeitwerk::Loader.new
@@ -30,9 +30,9 @@ module Hanami
             extend ClassMethods
           end
 
-          klass.send :prepare_base_load_path
+          subclass.send :prepare_base_load_path
 
-          Hanami.application = klass
+          Hanami.application = subclass
         end
       end
     end

--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -27,6 +27,8 @@ module Hanami
             @autoloader = Zeitwerk::Loader.new
             @container = Class.new(Dry::System::Container)
 
+            @prepared = @booted = false
+
             extend ClassMethods
           end
 
@@ -42,12 +44,6 @@ module Hanami
     # rubocop:disable Metrics/ModuleLength
     module ClassMethods
       attr_reader :autoloader, :container
-
-      def self.extended(klass)
-        klass.class_eval do
-          @prepared = @booted = false
-        end
-      end
 
       def application
         self

--- a/lib/hanami/application/view/slice_configured_view.rb
+++ b/lib/hanami/application/view/slice_configured_view.rb
@@ -70,7 +70,7 @@ module Hanami
         end
 
         def namespace_from_path(path)
-          path = "#{slice.namespace_path}/#{path}"
+          path = "#{slice.slice_name.path}/#{path}"
 
           begin
             require path
@@ -88,7 +88,7 @@ module Hanami
           slice
             .inflector
             .underscore(view_class.name)
-            .sub(/^#{slice.namespace_path}\//, "")
+            .sub(/^#{slice.slice_name.path}\//, "")
             .sub(/^#{view_class.config.template_inference_base}\//, "")
         end
 

--- a/lib/hanami/application/view_name_inferrer.rb
+++ b/lib/hanami/application/view_name_inferrer.rb
@@ -44,7 +44,7 @@ module Hanami
           slice
             .inflector
             .underscore(action_name)
-            .sub(%r{^#{slice.namespace_path}#{PATH_DELIMITER}}, "")
+            .sub(%r{^#{slice.slice_name.path}#{PATH_DELIMITER}}, "")
             .sub(%r{^#{key_base}#{PATH_DELIMITER}}, "")
             .gsub("/", CONTAINER_KEY_DELIMITER)
         end

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -25,6 +25,7 @@ module Hanami
     DEFAULT_ENVIRONMENTS = Concurrent::Hash.new { |h, k| h[k] = Concurrent::Array.new }
     private_constant :DEFAULT_ENVIRONMENTS
 
+    attr_reader :application_name
     attr_reader :env
 
     attr_reader :actions
@@ -37,7 +38,7 @@ module Hanami
 
     # rubocop:disable Metrics/AbcSize
     def initialize(application_name:, env:)
-      @namespace = application_name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER)
+      @application_name = application_name
 
       @environments = DEFAULT_ENVIRONMENTS.clone
       @env = env
@@ -47,7 +48,7 @@ module Hanami
       self.root = Dir.pwd
       self.settings_store = Application::Settings::DotenvStore.new.with_dotenv_loaded
 
-      config.logger = Configuration::Logger.new(env: env, application_name: method(:application_name))
+      config.logger = Configuration::Logger.new(env: env, application_name: application_name)
 
       @assets = load_dependent_config("hanami/assets/application_configuration") {
         Hanami::Assets::ApplicationConfiguration.new
@@ -89,14 +90,6 @@ module Hanami
       router.finalize!
 
       super
-    end
-
-    def namespace
-      inflector.constantize(@namespace)
-    end
-
-    def application_name
-      inflector.underscore(@namespace).to_sym
     end
 
     setting :root, constructor: -> path { Pathname(path) }

--- a/lib/hanami/configuration/logger.rb
+++ b/lib/hanami/configuration/logger.rb
@@ -11,9 +11,9 @@ module Hanami
     class Logger
       include Dry::Configurable
 
-      protected :config
+      attr_reader :application_name
 
-      setting :application_name
+      protected :config
 
       setting :level
 
@@ -30,7 +30,6 @@ module Hanami
       setting :logger_class, default: Hanami::Logger
 
       def initialize(env:, application_name:)
-        @env = env
         @application_name = application_name
 
         config.level = case env
@@ -58,12 +57,16 @@ module Hanami
                         end
       end
 
-      def finalize!
-        config.application_name = @application_name.call
-      end
-
       def instance
-        logger_class.new(application_name, *options, stream: stream, level: level, formatter: formatter, filter: filters, colorizer: colors)
+        logger_class.new(
+          application_name.name,
+          *options,
+          stream: stream,
+          level: level,
+          formatter: formatter,
+          filter: filters,
+          colorizer: colors
+        )
       end
 
       private

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -33,11 +33,6 @@ module Hanami
         slice_name.namespace
       end
 
-      # TODO: Remove this after https://github.com/hanami/hanami/pull/1156 is merged
-      def namespace_path
-        slice_name.name
-      end
-
       def root
         application.root.join(SLICES_DIR, slice_name.to_s)
       end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -10,14 +10,14 @@ module Hanami
   #
   # @since 2.0.0
   class Slice
-    def self.inherited(klass)
+    def self.inherited(subclass)
       super
 
-      klass.extend(ClassMethods)
+      subclass.extend(ClassMethods)
 
       # Eagerly initialize any variables that may be accessed inside the subclass body
-      klass.instance_variable_set(:@application, Hanami.application)
-      klass.instance_variable_set(:@container, Class.new(Dry::System::Container))
+      subclass.instance_variable_set(:@application, Hanami.application)
+      subclass.instance_variable_set(:@container, Class.new(Dry::System::Container))
     end
 
     # rubocop:disable Metrics/ModuleLength

--- a/lib/hanami/slice_name.rb
+++ b/lib/hanami/slice_name.rb
@@ -43,22 +43,9 @@ module Hanami
       inflector.underscore(namespace_name)
     end
 
-    alias_method :to_s, :name
-
-    # Returns the name of a slice as a downcased, underscored symbol.
-    #
-    # @example
-    #   slice_name.name # => :main
-    #
-    # @return [Symbol] the slice name
-    #
-    # @see name, to_s
-    #
     # @api public
     # @since 2.0.0
-    def to_sym
-      name.to_sym
-    end
+    alias_method :path, :name
 
     # Returns the name of the slice's module namespace.
     #
@@ -86,7 +73,28 @@ module Hanami
       inflector.constantize(namespace_name)
     end
 
+    # @api public
+    # @since 2.0.0
     alias_method :namespace, :namespace_const
+
+    # @api public
+    # @since 2.0.0
+    alias_method :to_s, :name
+
+    # Returns the name of a slice as a downcased, underscored symbol.
+    #
+    # @example
+    #   slice_name.name # => :main
+    #
+    # @return [Symbol] the slice name
+    #
+    # @see name, to_s
+    #
+    # @api public
+    # @since 2.0.0
+    def to_sym
+      name.to_sym
+    end
 
     private
 

--- a/lib/hanami/slice_name.rb
+++ b/lib/hanami/slice_name.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative "constants"
+
+module Hanami
+  # Represents the name of an {Application} or {Slice}.
+  #
+  # @see Application::ClassMethods#application_name
+  # @see Slice::ClassMethods#slice_name
+  #
+  # @api public
+  # @since 2.0.0
+  class SliceName
+    # Returns a new SliceName for the slice or application.
+    #
+    # You must provide an inflector for the manipulation of the name into various formats.
+    # This should be given in the form of a Proc that returns the inflector when called.
+    # The reason for this is that the inflector may be replaced by the user during the
+    # application configuration phase, so the proc should ensure that the current instance
+    # of the inflector is returned whenever needed.
+    #
+    # @param slice [#name] the slice or application object
+    # @param inflector [Proc] Proc returning the application's inflector when called
+    #
+    # @api private
+    def initialize(slice, inflector:)
+      @slice = slice
+      @inflector = inflector
+    end
+
+    # Returns the name of the slice as a downcased, underscored string.
+    #
+    # This is considered the canonical name of the slice.
+    #
+    # @example
+    #   slice_name.name # => "main"
+    #
+    # @return [String] the slice name
+    #
+    # @api public
+    # @since 2.0.0
+    def name
+      inflector.underscore(namespace_name)
+    end
+
+    alias_method :to_s, :name
+
+    # Returns the name of a slice as a downcased, underscored symbol.
+    #
+    # @example
+    #   slice_name.name # => :main
+    #
+    # @return [Symbol] the slice name
+    #
+    # @see name, to_s
+    #
+    # @api public
+    # @since 2.0.0
+    def to_sym
+      name.to_sym
+    end
+
+    # Returns the name of the slice's module namespace.
+    #
+    # @example
+    #   slice_name.namespace_name # => "Main"
+    #
+    # @return [String] the namespace name
+    #
+    # @api public
+    # @since 2.0.0
+    def namespace_name
+      slice_name.split(MODULE_DELIMITER)[0..-2].join(MODULE_DELIMITER)
+    end
+
+    # Returns the constant for the slice's module namespace.
+    #
+    # @example
+    #   slice_name.namespace_const # => Main
+    #
+    # @return [Module] the namespace module constant
+    #
+    # @api public
+    # @since 2.0.0
+    def namespace_const
+      inflector.constantize(namespace_name)
+    end
+
+    alias_method :namespace, :namespace_const
+
+    private
+
+    def slice_name
+      @slice.name
+    end
+
+    # The inflector is callable to allow for it to be configured/replaced after this
+    # object has been initialized
+    def inflector
+      @inflector.()
+    end
+  end
+end

--- a/spec/unit/hanami/configuration/logger_spec.rb
+++ b/spec/unit/hanami/configuration/logger_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "hanami/configuration/logger"
+require "hanami/slice_name"
+require "dry/inflector"
 require "logger"
 
 RSpec.describe Hanami::Configuration::Logger do
   subject { described_class.new(application_name: application_name, env: env) }
-  let(:application_name) { -> { :my_app } }
+  let(:application_name) { Hanami::SliceName.new(double(name: "MyApp::Application"), inflector: -> { Dry::Inflector.new }) }
   let(:env) { :development }
 
   describe "#logger_class" do
@@ -19,16 +21,6 @@ RSpec.describe Hanami::Configuration::Logger do
       expect { subject.logger_class = another_class }
         .to change { subject.logger_class }
         .to(another_class)
-    end
-  end
-
-  describe "#application_name" do
-    before do
-      subject.finalize!
-    end
-
-    it "defaults returns application name" do
-      expect(subject.application_name).to eq(application_name.call)
     end
   end
 
@@ -173,10 +165,9 @@ RSpec.describe Hanami::Configuration::Logger do
   end
 end
 
-
 RSpec.describe Hanami::Configuration do
   subject(:config) { described_class.new(application_name: application_name, env: env) }
-  let(:application_name) { "SOS::Application" }
+  let(:application_name) { Hanami::SliceName.new(double(name: "SOS::Application"), inflector: -> { Dry::Inflector.new }) }
   let(:env) { :development }
 
   describe "#logger" do

--- a/spec/unit/hanami/slice_name_spec.rb
+++ b/spec/unit/hanami/slice_name_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "hanami/slice_name"
+
+require "dry/inflector"
+
+RSpec.describe Hanami::SliceName do
+  subject(:slice_name) { described_class.new(slice, inflector: -> { inflector }) }
+  let(:slice) { double(name: "Main::Slice") }
+  let(:inflector) { Dry::Inflector.new }
+
+  let(:slice_module) { Module.new }
+
+  before do
+    stub_const "Main", slice_module
+  end
+
+  describe "#name" do
+    it "returns the downcased, underscored string name of the module containing the slice" do
+      expect(slice_name.name).to eq "main"
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the downcased, underscored string name of the module containing the slice" do
+      expect(slice_name.to_s).to eq "main"
+    end
+  end
+
+  describe "#to_sym" do
+    it "returns the downcased, underscored, symbolized name of the module containing the slice" do
+      expect(slice_name.to_sym).to eq :main
+    end
+  end
+
+  describe "#namespace_name" do
+    it "returns the string name of the module containing the slice" do
+      expect(slice_name.namespace_name).to eq "Main"
+    end
+  end
+
+  describe "#namespace_const" do
+    it "returns the module containing the slice" do
+      expect(slice_name.namespace).to be slice_module
+    end
+  end
+end


### PR DESCRIPTION
This gives us a single object that can do the work of determining a slice/application's name and namespace, which means we can now set this up early and then pass it to any places that need it, like the configuration (since it wants to provide the app name as part of logger configuration).

This is an improvement on the (temporary) solution we had for the logger configuration, which required us to entirely relocate the work of determining the namespace etc. to the configuration object itself, which isn't really its job.