### PR TITLE
Respect RACK_ENV if HANAMI_ENV is not set

### DIFF
--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -44,7 +44,7 @@ module Hanami
   end
 
   def self.env
-    (ENV["HANAMI_ENV"] || "development").to_sym
+    ENV.fetch("HANAMI_ENV") { ENV.fetch("RACK_ENV", "development") }.to_sym
   end
 
   def self.env?(*names)

--- a/spec/unit/hanami/env_spec.rb
+++ b/spec/unit/hanami/env_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami, ".env" do
+  subject(:env) { described_class.env }
+
+  before do
+    @orig_env = ENV.to_h
+  end
+
+  after do
+    ENV.replace(@orig_env)
+  end
+
+  context "HANAMI_ENV in ENV" do
+    before do
+      ENV["HANAMI_ENV"] = "test"
+    end
+
+    it "is the value of HANAMI_ENV" do
+      is_expected.to eq :test
+    end
+  end
+
+  context "RACK_ENV in ENV" do
+    before do
+      ENV["RACK_ENV"] = "test"
+    end
+
+    it "is the value of RACK_ENV" do
+      is_expected.to eq :test
+    end
+  end
+
+  context "both HANAMI_ENV and RACK_ENV in ENV" do
+    before do
+      ENV["HANAMI_ENV"] = "test"
+      ENV["RACK_ENV"] = "production"
+    end
+
+    it "is the value of HANAMI_ENV" do
+      is_expected.to eq :test
+    end
+  end
+
+  context "no ENV vars set" do
+    before do
+      ENV.delete("HANAMI_ENV")
+    end
+
+    it "defaults to \"development\"" do
+      is_expected.to eq :development
+    end
+  end
+end


### PR DESCRIPTION
Given RACK_ENV is an established, commonly used env var for signifying the application environment, it would be useful for us to respect it in the case of HANAMI_ENV not being present.

This change was inspired by a friend of mine working on porting a previous dry-rb-based application to Hanami 2, and having his development database wiped clean because his spec_helper.rb was still only setting RACK_ENV, not HANAMI_ENV.