### PR TITLE
Fix Content-Security-Policy

### DIFF
--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -56,7 +56,7 @@ module Hanami
 
       @actions = load_dependent_config("hanami/action") {
         require_relative "configuration/actions"
-        Actions.new(assets_server_url: assets.server_url)
+        Actions.new(assets: assets)
       }
 
       @middleware = Middleware.new

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -56,7 +56,7 @@ module Hanami
 
       @actions = load_dependent_config("hanami/action") {
         require_relative "configuration/actions"
-        Actions.new
+        Actions.new(assets_server_url: assets.server_url)
       }
 
       @middleware = Middleware.new

--- a/lib/hanami/configuration/actions.rb
+++ b/lib/hanami/configuration/actions.rb
@@ -34,9 +34,9 @@ module Hanami
 
         @base_configuration = Hanami::Action::Configuration.new
         @content_security_policy = ContentSecurityPolicy.new do |csp|
-          if assets_server_url = options[:assets_server_url]
-            csp[:script_src] += " #{assets_server_url}"
-            csp[:style_src] += " #{assets_server_url}"
+          if assets = options[:assets] and assets.class.to_s != "Hanami::Configuration::NullConfiguration"
+            csp[:script_src] += " #{assets.server_url}"
+            csp[:style_src] += " #{assets.server_url}"
           end
         end
 

--- a/lib/hanami/configuration/actions/content_security_policy.rb
+++ b/lib/hanami/configuration/actions/content_security_policy.rb
@@ -102,7 +102,7 @@ module Hanami
         def to_str
           @policy.map do |key, value|
             "#{dasherize(key)} #{value}"
-          end.join(";\n")
+          end.join("; ")
         end
 
         private

--- a/spec/unit/hanami/configuration/actions/content_security_policy_spec.rb
+++ b/spec/unit/hanami/configuration/actions/content_security_policy_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Hanami::Configuration::Actions, "#content_security_policy" do
           %(plugin-types application/pdf;),
           %(script-src 'self';),
           %(style-src 'self' 'unsafe-inline' https:)
-        ].join("\n")
+        ].join(" ")
 
         expect(content_security_policy.to_str).to eq(expected)
       end


### PR DESCRIPTION
CSP was not working for two reasons:

1. `assets-server-url` was not passed to `Actions` initialization, so it wasn't added to `scritp-src` and `style-src`.
2. For some reason, the CSP header was parsed incorrectly by both Firefox and Chromium when it contained values joined by a new line. This seems to be in line with [RFC 7230 section 3.2.4](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.4), however adding a space after a `\n` didn't help - only having the header value as a single line works in these browsers.