### PR TITLE
Remove routes and settings file configs

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -243,10 +243,10 @@ module Hanami
 
         prepare_base_load_path
 
-        settings_require_path = File.join(configuration.root, configuration.settings_path)
+        settings_require_path = File.join(configuration.root, SETTINGS_PATH)
         require settings_require_path
 
-        settings_class = autodiscover_application_constant(configuration.settings_class_name)
+        settings_class = autodiscover_application_constant(SETTINGS_CLASS_NAME)
         settings_class.new(configuration.settings_store)
       rescue LoadError => e
         raise e unless e.path == settings_require_path
@@ -277,10 +277,10 @@ module Hanami
       def load_routes
         require_relative "./routes"
 
-        routes_require_path = File.join(configuration.root, configuration.router.routes_path)
+        routes_require_path = File.join(configuration.root, ROUTES_PATH)
         require routes_require_path
 
-        routes_class = autodiscover_application_constant(configuration.router.routes_class_name)
+        routes_class = autodiscover_application_constant(ROUTES_CLASS_NAME)
         routes_class.routes
       rescue LoadError => e
         raise e unless e.path == routes_require_path

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -109,10 +109,6 @@ module Hanami
       @logger_instance || logger.instance
     end
 
-    setting :settings_path, default: File.join("config", "settings")
-
-    setting :settings_class_name, default: "Settings"
-
     setting :settings_store, default: Hanami::Settings::DotenvStore
 
     setting :base_url, default: "http://0.0.0.0:2300", constructor: -> url { URI(url) }

--- a/lib/hanami/configuration/router.rb
+++ b/lib/hanami/configuration/router.rb
@@ -22,10 +22,6 @@ module Hanami
         @base_configuration = base_configuration
       end
 
-      setting :routes_path, default: File.join("config", "routes")
-
-      setting :routes_class_name, default: "Routes"
-
       setting :resolver, default: Application::Routing::Resolver
 
       # @api private

--- a/lib/hanami/constants.rb
+++ b/lib/hanami/constants.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Hanami
+  # @api private
   CONTAINER_KEY_DELIMITER = "."
   private_constant :CONTAINER_KEY_DELIMITER
 
@@ -8,6 +9,7 @@ module Hanami
   MODULE_DELIMITER = "::"
   private_constant :MODULE_DELIMITER
 
+  # @api private
   PATH_DELIMITER = "/"
   private_constant :PATH_DELIMITER
 
@@ -26,6 +28,22 @@ module Hanami
   # @api private
   SLICES_DIR = "slices"
   private_constant :SLICES_DIR
+
+  # @api private
+  ROUTES_PATH = File.join(CONFIG_DIR, "routes")
+  private_constant :ROUTES_PATH
+
+  # @api private
+  ROUTES_CLASS_NAME = "Routes"
+  private_constant :ROUTES_CLASS_NAME
+
+  # @api private
+  SETTINGS_PATH = File.join(CONFIG_DIR, "settings")
+  private_constant :SETTINGS_PATH
+
+  # @api private
+  SETTINGS_CLASS_NAME = "Settings"
+  private_constant :SETTINGS_CLASS_NAME
 
   # @api private
   RB_EXT = ".rb"

--- a/spec/unit/hanami/configuration_spec.rb
+++ b/spec/unit/hanami/configuration_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Hanami::Configuration do
 
   describe "environment-specific configuration" do
     before do
-      config.settings_path = "config/default_settings"
+      config.logger.level = :debug__set_without_env
     end
 
     before do
       config.environment :production do |c|
-        c.settings_path = "config/production_settings"
+        c.logger.level = :info__set_for_production_env
       end
     end
 
@@ -20,11 +20,11 @@ RSpec.describe Hanami::Configuration do
       let(:env) { :production }
 
       it "applies the settings" do
-        expect(config.settings_path).to eq "config/production_settings"
+        expect(config.logger.level).to eq :info__set_for_production_env
       end
 
       it "leaves the settings in place when finalizing" do
-        expect { config.finalize! }.not_to change { config.settings_path }
+        expect { config.finalize! }.not_to(change { config.logger.level })
       end
     end
 
@@ -32,11 +32,11 @@ RSpec.describe Hanami::Configuration do
       let(:env) { :development }
 
       it "does not apply the settings" do
-        expect(config.settings_path).to eq "config/default_settings"
+        expect(config.logger.level).to eq :debug__set_without_env
       end
 
       it "does not apply the settings when finalizing" do
-        expect { config.finalize! }.not_to change { config.settings_path }
+        expect { config.finalize! }.not_to(change { config.logger.level })
       end
     end
   end


### PR DESCRIPTION
We’ll better support our users by having these files found in the same place and with the same name in all cases.