### PR TITLE
Allow injecting file system

### DIFF
--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-configurable", "~> 0.15"
   spec.add_dependency "dry-core",         "~> 0.7"
   spec.add_dependency "dry-types",        "~> 1.5"
+  spec.add_dependency "dry-files",        "~> 0.1"
   spec.add_dependency "dry-inflector",    "~> 0.2", ">= 0.2.1"
   spec.add_dependency "dry-system",       "~> 0.24"
   spec.add_dependency "dry-monitor",      "~> 0.5"

--- a/lib/hanami/boot.rb
+++ b/lib/hanami/boot.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "setup"
+require "hanami"
 
 Hanami.boot

--- a/lib/hanami/prepare.rb
+++ b/lib/hanami/prepare.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
-require_relative "setup"
-
 Hanami.prepare

--- a/lib/hanami/setup.rb
+++ b/lib/hanami/setup.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/setup"
 require "hanami"
 
-begin
-  application_require_path = File.join(Dir.pwd, "config/application")
-  require application_require_path
-rescue LoadError => e
-  raise e unless e.path == application_require_path
-end
+Hanami.setup


### PR DESCRIPTION
It's interesting to allow a hanami application to run in an in-memory
filesystem for testing purposes. We need to make explicit the transitive
dependency on `dry-files` and reorganize the `setup/prepare/boot`
commands to accept a filesystem argument.