### PR TITLE
Fix use of session middleware

### DIFF
--- a/lib/hanami/configuration/sessions.rb
+++ b/lib/hanami/configuration/sessions.rb
@@ -30,7 +30,7 @@ module Hanami
       end
 
       def middleware
-        [storage_middleware, options, nil]
+        [storage_middleware, options]
       end
 
       private

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -404,8 +404,8 @@ module Hanami
           resolver: configuration.router.resolver.new(slice: self),
           **configuration.router.options
         ) do
-          use rack_monitor
-          use config.sessions.middleware if config.sessions.enabled?
+          use(rack_monitor)
+          use(*config.sessions.middleware) if config.sessions.enabled?
 
           middleware_stack.update(config.middleware_stack)
         end


### PR DESCRIPTION
With the `nil` as the final option (intended to represent a nil block) in the array of middleware args, we received this error when trying to use it:

```
ArgumentError: wrong number of arguments (given 3, expected 1..2)
```