### PR TITLE
Avoid redundant auto-registrations for lib/ files

### DIFF
--- a/spec/new_integration/code_loading/loading_from_app_spec.rb
+++ b/spec/new_integration/code_loading/loading_from_app_spec.rb
@@ -86,8 +86,12 @@ RSpec.describe "Code loading / Loading from app directory", :app_integration do
       expect(TestApp::TestClass).to be
     end
 
-    specify "Classes in app directory are auto-registered" do
+    specify "Classes in app/lib/ directory are auto-registered" do
       expect(TestApp::App["test_class"]).to be_an_instance_of TestApp::TestClass
+    end
+
+    specify "Classes in app/lib/ directory are not redundantly auto-registered under 'lib' key namespace" do
+      expect(TestApp::App.key?("lib.test_class")).to be false
     end
   end
 

--- a/spec/new_integration/code_loading/loading_from_slice_spec.rb
+++ b/spec/new_integration/code_loading/loading_from_slice_spec.rb
@@ -102,6 +102,10 @@ RSpec.describe "Code loading / Loading from slice directory", :app_integration d
     specify "Classes in slice lib/ directory are auto-registered" do
       expect(Main::Slice["test_class"]).to be_an_instance_of Main::TestClass
     end
+
+    specify "Classes in slice lib/ directory are not redundantly auto-registered under 'lib' key namespace" do
+      expect(Main::Slice.key?("lib.test_class")).to be false
+    end
   end
 
   # rubocop:disable Style/GlobalVars


### PR DESCRIPTION
This is a leftover tidy-up from my work in unifying the app/slice code loading rules in #1174. Per that PR description, we allow the `lib/` sub-directory to be treated specially as being an extra dir holding files in the root of the app/slice namespace.

Until this PR however, files under the `lib/` sub-dir generated redundant container registrations, with e.g. `app/lib/foo.rb` creating `"foo"` (desired) and `"lib.foo"` (undesired, and actually broken if you try to resolve it) components.

With this change, the redundant `"lib.foo"` components are no more.