### PR TITLE
Improve LOAD_PATH handling

### DIFF
--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -33,7 +33,10 @@ module Hanami
           @configuration = Hanami::Configuration.new(app_name: slice_name, env: Hanami.env)
           @autoloader = Zeitwerk::Loader.new
 
-          prepare_base_load_path
+          # Prepare the load path (based on the default root of `Dir.pwd`) as early as
+          # possible, so you can make a `require` inside the body of an `App` subclass,
+          # which may be useful for certain kinds of app configuration.
+          prepare_load_path
         end
       end
     end
@@ -46,14 +49,52 @@ module Hanami
         slice_name
       end
 
-      private
+      # Prepares the $LOAD_PATH based on the app's configured root, prepending the `lib/`
+      # directory if it exists. If the lib directory is already added, this will do
+      # nothing.
+      #
+      # In ordinary circumstances, you should never have to call this method: this method
+      # is called immediately upon subclassing {Hanami::App}, as a convenicence to put
+      # lib/ (under the default root of `Dir.pwd`) on the load path automatically. This is
+      # helpful if you need to require files inside the subclass body for performing
+      # certain app configuration steps.
+      #
+      # If you change your app's `config.root` and you need to require files from its
+      # `lib/` directory within your {App} subclass body, you should call
+      # {.prepare_load_path} explicitly after setting the new root.
+      #
+      # Otherwise, this method is called again as part of the app {.prepare} step, so if
+      # you've changed your app's root and do _not_ need to require files within your {App}
+      # subclass body, then you don't need to call this method.
+      #
+      # @example
+      #   module MyApp
+      #     class App < Hanami::App
+      #       config.root = Pathname(__dir__).join("../src")
+      #       prepare_load_path
+      #
+      #       # You can make requires for your files here
+      #     end
+      #   end
+      #
+      # @return [self]
+      #
+      # @api public
+      # @since 2.0.0
+      def prepare_load_path
+        if (lib_path = root.join(LIB_DIR)).directory?
+          path = lib_path.realpath.to_s
+          $LOAD_PATH.prepend(path) unless $LOAD_PATH.include?(path)
+        end
 
-      def prepare_base_load_path
-        base_path = root.join(LIB_DIR)
-        $LOAD_PATH.unshift(base_path) unless $LOAD_PATH.include?(base_path)
+        self
       end
 
+      private
+
       def prepare_all
+        prepare_load_path
+
         # Make app-wide notifications available as early as possible
         container.use(:notifications)
 

--- a/spec/new_integration/code_loading/loading_from_lib_spec.rb
+++ b/spec/new_integration/code_loading/loading_from_lib_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+RSpec.describe "Code loading / Loading from lib directory", :app_integration do
+  describe "default root" do
+    before :context do
+      with_directory(@dir = make_tmp_directory.realpath) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "lib/external_class.rb", <<~'RUBY'
+          class ExternalClass
+          end
+        RUBY
+
+        write "lib/test_app/test_class.rb", <<~'RUBY'
+          module TestApp
+            class TestClass
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "setup app" do
+      before do
+        with_directory(@dir) { require "hanami/setup" }
+      end
+
+      it "adds the lib directory to the load path" do
+        expect($LOAD_PATH).to include(@dir.join("lib").to_s)
+      end
+
+      specify "classes in lib/ can be required directly" do
+        expect(require("external_class")).to be true
+        expect(ExternalClass).to be
+      end
+
+      specify "classes in lib/[app_namespace]/ cannot yet be autoloaded" do
+        expect { TestApp::TestClass }.to raise_error(NameError)
+      end
+    end
+
+    context "prepared app" do
+      before do
+        with_directory(@dir) { require "hanami/prepare" }
+      end
+
+      it "leaves the lib directory already in the load path" do
+        expect($LOAD_PATH).to include(@dir.join("lib").to_s).exactly(1).times
+      end
+
+      specify "classes in lib/[app_namespace]/ can be autoloaded" do
+        expect(TestApp::TestClass).to be
+      end
+    end
+
+    context "lib dir missing" do
+      before do
+        with_directory(@dir = make_tmp_directory.realpath) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+              end
+            end
+          RUBY
+
+          require "hanami/setup"
+        end
+      end
+
+      it "does not add the lib directory to the load path" do
+        expect($LOAD_PATH).not_to include(@dir.join("lib").to_s)
+      end
+    end
+  end
+
+  context "app root reconfigured" do
+    before :context do
+      with_directory(@dir = make_tmp_directory.realpath) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+              config.root = Pathname(__dir__).join("..", "src").realpath
+            end
+          end
+        RUBY
+
+        write "src/lib/external_class.rb", <<~'RUBY'
+          class ExternalClass
+          end
+        RUBY
+
+        write "src/lib/test_app/test_class.rb", <<~'RUBY'
+          module TestApp
+            class TestClass
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "setup app" do
+      before do
+        with_directory(@dir) { require "hanami/setup" }
+      end
+
+      it "does not add the lib directory to the load path (already done at time of subclassing)" do
+        expect($LOAD_PATH).not_to include(@dir.join("src", "lib").to_s)
+      end
+
+      it "adds the lib directory under the new root with `prepare_load_path`" do
+        expect { Hanami.app.prepare_load_path }
+          .to change { $LOAD_PATH }
+          .to include(@dir.join("src", "lib").to_s)
+      end
+    end
+
+    context "prepared app" do
+      before do
+        with_directory(@dir) { require "hanami/prepare" }
+      end
+
+      it "adds the lib directory to the load path" do
+        expect($LOAD_PATH).to include(@dir.join("src", "lib").to_s)
+      end
+
+      specify "classes in lib/ can be required directly" do
+        expect(require("external_class")).to be true
+        expect(ExternalClass).to be
+      end
+
+      specify "classes in lib/[app_namespace]/ can be autoloaded" do
+        expect(TestApp::TestClass).to be
+      end
+    end
+  end
+
+  context "app root reconfigured and load path immediately prepared" do
+    before :context do
+      with_directory(@dir = make_tmp_directory.realpath) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+              config.root = Pathname(__dir__).join("..", "src").realpath and prepare_load_path
+            end
+          end
+        RUBY
+
+        write "src/lib/external_class.rb", <<~'RUBY'
+          class ExternalClass
+          end
+        RUBY
+
+        write "src/lib/test_app/test_class.rb", <<~'RUBY'
+          module TestApp
+            class TestClass
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "setup app" do
+      before do
+        with_directory(@dir) { require "hanami/setup" }
+      end
+
+      it "adds the lib directory to the load path" do
+        expect($LOAD_PATH).to include(@dir.join("src", "lib").to_s)
+      end
+
+      specify "classes in lib/ can be required directly" do
+        expect(require("external_class")).to be true
+        expect(ExternalClass).to be
+      end
+
+      specify "classes in lib/[app_namespace]/ cannot yet be autoloaded" do
+        expect { TestApp::TestClass }.to raise_error(NameError)
+      end
+    end
+
+    context "prepared app" do
+      before do
+        with_directory(@dir) { require "hanami/prepare" }
+      end
+
+      it "leaves the lib directory to the load path" do
+        expect($LOAD_PATH).to include(@dir.join("src", "lib").to_s).exactly(1).times
+      end
+
+      specify "classes in lib/[app_namespace]/ can be autoloaded" do
+        expect(TestApp::TestClass).to be
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this PR we have robust and complete handling (as well as better tests!) around the setup of $LOAD_PATH as part of app booting.

There are two key changes here:

- We now re-run `App.prepare_load_path` as part of the `App.prepare` step to ensure the load path is updated in the case of a re-configured app root.
- We also make `App.prepare_load_path` public API for people who have modified the `config.root` and want to ensure the new root’s `lib/` subdir is immediately added to the load path.