### PR TITLE
Conditional slice loading

### DIFF
--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -29,18 +29,18 @@ module Hanami
 
     setting :settings_store, default: Hanami::Settings::EnvStore.new
 
+    setting :shared_app_component_keys, default: %w[
+      inflector
+      logger
+      notifications
+      rack.monitor
+      routes
+      settings
+    ]
+
     setting :slices do
       setting :load_slices
       setting :skip_slices
-
-      setting :shared_app_component_keys, default: %w[
-        inflector
-        logger
-        notifications
-        rack.monitor
-        routes
-        settings
-      ]
     end
 
     setting :base_url, default: "http://0.0.0.0:2300", constructor: ->(url) { URI(url) }

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -38,10 +38,7 @@ module Hanami
       settings
     ]
 
-    setting :slices do
-      setting :load_slices
-      setting :skip_slices
-    end
+    setting :slices
 
     setting :base_url, default: "http://0.0.0.0:2300", constructor: ->(url) { URI(url) }
 
@@ -202,8 +199,7 @@ module Hanami
     private
 
     def load_from_env
-      slices.load_slices = ENV["HANAMI_LOAD_SLICES"]&.split(",")&.map(&:strip)
-      slices.skip_slices = ENV["HANAMI_SKIP_SLICES"]&.split(",")&.map(&:strip)
+      self.slices = ENV["HANAMI_SLICES"]&.split(",")&.map(&:strip)
     end
 
     def apply_env_config(env = self.env)

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -30,7 +30,7 @@ module Hanami
     setting :settings_store, default: Hanami::Settings::EnvStore.new
 
     setting :slices do
-      setting :shared_component_keys, default: %w[
+      setting :shared_app_component_keys, default: %w[
         inflector
         logger
         notifications

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -30,6 +30,9 @@ module Hanami
     setting :settings_store, default: Hanami::Settings::EnvStore.new
 
     setting :slices do
+      setting :load_slices
+      setting :skip_slices
+
       setting :shared_app_component_keys, default: %w[
         inflector
         logger

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -56,9 +56,8 @@ module Hanami
         Hanami.app
       end
 
-      # A slice's configuration is copied from the app configuration at time of
-      # first access. The app should have its configuration completed before
-      # slices are loaded.
+      # A slice's configuration is copied from the app configuration at time of first access. The
+      # app should have its configuration completed before slices are loaded.
       def configuration
         @configuration ||= app.configuration.dup.tap do |config|
           # Remove specific values from app that will not apply to this slice

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -321,7 +321,7 @@ module Hanami
 
       def prepare_container_imports
         import(
-          keys: config.slices.shared_app_component_keys,
+          keys: config.shared_app_component_keys,
           from: app.container,
           as: nil
         )

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -322,7 +322,7 @@ module Hanami
 
       def prepare_container_imports
         import(
-          keys: config.slices.shared_component_keys,
+          keys: config.slices.shared_app_component_keys,
           from: app.container,
           as: nil
         )

--- a/lib/hanami/slice_registrar.rb
+++ b/lib/hanami/slice_registrar.rb
@@ -126,49 +126,28 @@ module Hanami
       # Slices require a root, so provide a sensible default based on the slice's parent
       slice.config.root ||= root.join(SLICES_DIR, slice_name.to_s)
 
-      slice.config.slices.load_slices = child_slice_names(slice_name, parent.config.slices.load_slices)
-      slice.config.slices.skip_slices = child_slice_names(slice_name, parent.config.slices.skip_slices)
+      slice.config.slices = child_slice_names(slice_name, parent.config.slices)
     end
 
-    # Returns a filtered array of slice names based on the parent's `load_slices` or `skip_slices`
-    # config.
+    # Returns a filtered array of slice names based on the parent's `config.slices`
     #
     # This works with both singular slice names (e.g. `"admin"`) as well as dot-delimited nested
     # slice names (e.g. `"admin.shop"`).
     #
-    # When using the `load_slices` config, it will consider only the base names of the slices (since
-    # in this case, a parent slice must be loaded in order for its children to be laoded).
+    # It will consider only the base names of the slices (since in this case, a parent slice must be
+    # loaded in order for its children to be loaded).
     #
-    # @example using `config.slices.load_slices`
-    #   parent.config.slices.load_slices # => ["admin.shop"]
+    # @example
+    #   parent.config.slices # => ["admin.shop"]
     #   filter_slice_names(["admin", "main"]) # => ["admin"]
     #
-    #   parent.config.slices.load_slices # => ["admin"]
+    #   parent.config.slices # => ["admin"]
     #   filter_slice_names(["admin", "main"]) # => ["admin"]
-    #
-    # When using the `skip_slices` config, it will match exact slice names only (since skipping a
-    # nested slice does not necessarily imply that its parent should also be skipped).
-    #
-    # @example using `config.slices.skip_slices`
-    #   parent.config.skip_slices # => ["admin.shop"]
-    #   filter_slice_names(["admin", "main"]) # => ["admin", "main"]
-    #
-    #   parent.config.skp_slices # => ["admin"]
-    #   filter_slice_names(["admin", "main"]) # => ["main"]
-    #
-    # In the case of both `load_slices` and `skip_slices` config, it prefers `load_slices`.
-    #
-    # @example using both `config.slices.load_slices` and `skip_slices`
-    #   parent.config.slices.load_slices # => ["main"]
-    #   parent.config.slices.skip_slices # => ["main"]
-    #   filter_slice_names(["admin", "main"]) # => ["main"]
     def filter_slice_names(slice_names)
       slice_names = slice_names.map(&:to_s)
 
-      if parent.config.slices.load_slices
-        slice_names & parent.config.slices.load_slices.map { base_slice_name(_1) }
-      elsif parent.config.slices.skip_slices
-        slice_names - parent.config.slices.skip_slices
+      if parent.config.slices
+        slice_names & parent.config.slices.map { base_slice_name(_1) }
       else
         slice_names
       end

--- a/spec/new_integration/slices/slice_loading_spec.rb
+++ b/spec/new_integration/slices/slice_loading_spec.rb
@@ -2,8 +2,6 @@
 
 require "rack/test"
 
-# TODO: Tests for HANAMI_LOAD_SLICES
-
 RSpec.describe "Slices / Slice loading", :app_integration do
   describe "loading specific slices" do
     describe "setup app" do

--- a/spec/new_integration/slices/slice_loading_spec.rb
+++ b/spec/new_integration/slices/slice_loading_spec.rb
@@ -5,7 +5,7 @@ require "rack/test"
 RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures do
   let(:app_modules) { %i[TestApp Admin Editorial Main Shop] }
 
-  describe "loading specific slices with config.slices.load_slices" do
+  describe "loading specific slices with config.slices" do
     describe "setup app" do
       it "ignores any explicitly registered slices not included in load_slices" do
         with_tmp_directory(Dir.mktmpdir) do
@@ -14,7 +14,7 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
 
             module TestApp
               class App < Hanami::App
-                config.slices.load_slices = %w[admin]
+                config.slices = %w[admin]
               end
             end
           RUBY
@@ -37,7 +37,7 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
 
               module TestApp
                 class App < Hanami::App
-                  config.slices.load_slices = %w[admin.shop]
+                  config.slices = %w[admin.shop]
                 end
               end
             RUBY
@@ -62,7 +62,7 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
 
             module TestApp
               class App < Hanami::App
-                config.slices.load_slices = %w[admin]
+                config.slices = %w[admin]
               end
             end
           RUBY
@@ -78,28 +78,6 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
         end
       end
 
-      it "prefers load_slices over skip_slices when both are configured" do
-        with_tmp_directory(Dir.mktmpdir) do
-          write "config/app.rb", <<~'RUBY'
-            require "hanami"
-
-            module TestApp
-              class App < Hanami::App
-                config.slices.load_slices = %w[admin]
-                config.slices.skip_slices = %w[admin]
-              end
-            end
-          RUBY
-
-          write "slices/admin/.keep"
-          write "slices/main/.keep"
-
-          require "hanami/prepare"
-
-          expect(Hanami.app.slices.keys).to eq [:admin]
-        end
-      end
-
       it "ignores unknown slices in load_slices" do
         with_tmp_directory(Dir.mktmpdir) do
           write "config/app.rb", <<~'RUBY'
@@ -107,7 +85,7 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
 
             module TestApp
               class App < Hanami::App
-                config.slices.load_slices = %w[admin meep morp]
+                config.slices = %w[admin meep morp]
               end
             end
           RUBY
@@ -129,7 +107,7 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
 
               module TestApp
                 class App < Hanami::App
-                  config.slices.load_slices = %w[admin.shop]
+                  config.slices = %w[admin.shop]
                 end
               end
             RUBY
@@ -155,137 +133,6 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
     end
   end
 
-  describe "skipping specific slices with config.slices.skip_slices" do
-    describe "setup app" do
-      it "skips explicitly registering slices included in skip_slices" do
-        with_tmp_directory(Dir.mktmpdir) do
-          write "config/app.rb", <<~'RUBY'
-            require "hanami"
-
-            module TestApp
-              class App < Hanami::App
-                config.slices.skip_slices = %w[admin]
-              end
-            end
-          RUBY
-
-          require "hanami/setup"
-
-          expect { Hanami.app.register_slice :admin }.not_to(change { Hanami.app.slices.keys })
-          expect { Admin }.to raise_error(NameError)
-
-          expect { Hanami.app.register_slice :main }.to change { Hanami.app.slices.keys }.to [:main]
-          expect(Main::Slice).to be
-        end
-      end
-
-      describe "nested slices" do
-        it "skips explicity registering slices included in skip_slices" do
-          with_tmp_directory(Dir.mktmpdir) do
-            write "config/app.rb", <<~'RUBY'
-              require "hanami"
-
-              module TestApp
-                class App < Hanami::App
-                  config.slices.skip_slices = %w[admin.shop]
-                end
-              end
-            RUBY
-
-            require "hanami/setup"
-
-            expect { Hanami.app.register_slice :admin }.to change { Hanami.app.slices.keys }.to [:admin]
-
-            expect { Admin::Slice.register_slice :shop }.not_to(change { Admin::Slice.slices.keys })
-            expect { Admin::Slice.register_slice :editorial }.to change { Admin::Slice.slices.keys }.to [:editorial]
-
-            expect(Admin::Slice).to be
-            expect(Editorial::Slice).to be
-            expect { Shop }.to raise_error(NameError)
-          end
-        end
-      end
-    end
-
-    describe "prepared app" do
-      it "loads all slices except those in skip_slices", :aggregate_failures do
-        with_tmp_directory(Dir.mktmpdir) do
-          write "config/app.rb", <<~'RUBY'
-            require "hanami"
-
-            module TestApp
-              class App < Hanami::App
-                config.slices.skip_slices = %w[admin]
-              end
-            end
-          RUBY
-
-          write "slices/admin/.keep"
-          write "slices/main/.keep"
-
-          require "hanami/prepare"
-
-          expect(Hanami.app.slices.keys).to eq [:main]
-          expect(Main::Slice).to be
-          expect { Admin }.to raise_error(NameError)
-        end
-      end
-
-      it "ignores unknown slices in skip_slices" do
-        with_tmp_directory(Dir.mktmpdir) do
-          write "config/app.rb", <<~'RUBY'
-            require "hanami"
-
-            module TestApp
-              class App < Hanami::App
-                config.slices.skip_slices = %w[admin meep morp]
-              end
-            end
-          RUBY
-
-          write "slices/admin/.keep"
-          write "slices/main/.keep"
-
-          require "hanami/prepare"
-
-          expect(Hanami.app.slices.keys).to eq [:main]
-        end
-      end
-
-      describe "nested slices" do
-        it "loads all child slices of slices except those in skip_slices (using dot-delimited nested slice names)" do
-          with_tmp_directory(Dir.mktmpdir) do
-            write "config/app.rb", <<~'RUBY'
-              require "hanami"
-
-              module TestApp
-                class App < Hanami::App
-                  config.slices.skip_slices = %w[admin.shop]
-                end
-              end
-            RUBY
-
-            write "slices/admin/.keep"
-            write "slices/admin/slices/shop/.keep"
-            write "slices/admin/slices/editorial/.keep"
-            write "slices/main/.keep"
-
-            require "hanami/prepare"
-
-            expect(Hanami.app.slices.keys).to eq %i[admin main]
-            expect(Admin::Slice.slices.keys).to eq [:editorial]
-
-            expect(Admin::Slice).to be
-            expect(Editorial::Slice).to be
-            expect(Main::Slice).to be
-
-            expect { Shop }.to raise_error(NameError)
-          end
-        end
-      end
-    end
-  end
-
   describe "using ENV vars" do
     before do
       @orig_env = ENV.to_h
@@ -295,8 +142,8 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
       ENV.replace(@orig_env)
     end
 
-    it "uses HANAMI_LOAD_SLICES" do
-      ENV["HANAMI_LOAD_SLICES"] = "admin"
+    it "uses HANAMI_SLICES" do
+      ENV["HANAMI_SLICES"] = "admin"
 
       with_tmp_directory(Dir.mktmpdir) do
         write "config/app.rb", <<~'RUBY'
@@ -313,37 +160,11 @@ RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures d
 
         require "hanami/setup"
 
-        expect(Hanami.app.config.slices.load_slices).to eq %w[admin]
+        expect(Hanami.app.config.slices).to eq %w[admin]
 
         require "hanami/prepare"
 
         expect(Hanami.app.slices.keys).to eq [:admin]
-      end
-    end
-
-    it "uses HANAMI_SKIP_SLICES" do
-      ENV["HANAMI_SKIP_SLICES"] = "admin"
-
-      with_tmp_directory(Dir.mktmpdir) do
-        write "config/app.rb", <<~'RUBY'
-          require "hanami"
-
-          module TestApp
-            class App < Hanami::App
-            end
-          end
-        RUBY
-
-        write "slices/admin/.keep"
-        write "slices/main/.keep"
-
-        require "hanami/setup"
-
-        expect(Hanami.app.config.slices.skip_slices).to eq %w[admin]
-
-        require "hanami/prepare"
-
-        expect(Hanami.app.slices.keys).to eq [:main]
       end
     end
   end

--- a/spec/new_integration/slices/slice_loading_spec.rb
+++ b/spec/new_integration/slices/slice_loading_spec.rb
@@ -2,10 +2,12 @@
 
 require "rack/test"
 
-RSpec.describe "Slices / Slice loading", :app_integration do
-  describe "loading specific slices" do
+RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures do
+  let(:app_modules) { %i[TestApp Admin Editorial Main Shop] }
+
+  describe "loading specific slices with config.slices.load_slices" do
     describe "setup app" do
-      it "ignores explicitly registered slices not otherwise configured", :aggregate_failures do
+      it "ignores any explicitly registered slices not included in load_slices" do
         with_tmp_directory(Dir.mktmpdir) do
           write "config/app.rb", <<~'RUBY'
             require "hanami"
@@ -22,16 +24,38 @@ RSpec.describe "Slices / Slice loading", :app_integration do
           expect { Hanami.app.register_slice :main }.not_to(change { Hanami.app.slices.keys })
           expect { Main }.to raise_error(NameError)
 
-          expect { Hanami.app.register_slice :admin }
-            .to change { Hanami.app.slices.keys }
-            .to [:admin]
+          expect { Hanami.app.register_slice :admin }.to change { Hanami.app.slices.keys }.to [:admin]
           expect(Admin::Slice).to be
+        end
+      end
+
+      describe "nested slices" do
+        it "ignores any explicitly registered slices not included in load_slices" do
+          with_tmp_directory(Dir.mktmpdir) do
+            write "config/app.rb", <<~'RUBY'
+              require "hanami"
+
+              module TestApp
+                class App < Hanami::App
+                  config.slices.load_slices = %w[admin.shop]
+                end
+              end
+            RUBY
+
+            require "hanami/setup"
+
+            expect { Hanami.app.register_slice :admin }.to change { Hanami.app.slices.keys }.to [:admin]
+
+            expect { Admin::Slice.register_slice :editorial }.not_to(change { Admin::Slice.slices.keys })
+            expect { Admin::Slice.register_slice :shop }.to change { Admin::Slice.slices.keys }.to [:shop]
+            expect(Shop::Slice).to be
+          end
         end
       end
     end
 
     describe "prepared app" do
-      it "only loads the configured slices", :aggregate_failures do
+      it "loads only the slices included in load_slices" do
         with_tmp_directory(Dir.mktmpdir) do
           write "config/app.rb", <<~'RUBY'
             require "hanami"
@@ -75,12 +99,65 @@ RSpec.describe "Slices / Slice loading", :app_integration do
           expect(Hanami.app.slices.keys).to eq [:admin]
         end
       end
+
+      it "ignores unknown slices in load_slices" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.slices.load_slices = %w[admin meep morp]
+              end
+            end
+          RUBY
+
+          write "slices/admin/.keep"
+          write "slices/main/.keep"
+
+          require "hanami/prepare"
+
+          expect(Hanami.app.slices.keys).to eq [:admin]
+        end
+      end
+
+      describe "nested slices" do
+        it "loads only the dot-delimited nested slices (and their parents) included in load_slices" do
+          with_tmp_directory(Dir.mktmpdir) do
+            write "config/app.rb", <<~'RUBY'
+              require "hanami"
+
+              module TestApp
+                class App < Hanami::App
+                  config.slices.load_slices = %w[admin.shop]
+                end
+              end
+            RUBY
+
+            write "slices/admin/.keep"
+            write "slices/admin/slices/shop/.keep"
+            write "slices/admin/slices/editorial/.keep"
+            write "slices/main/.keep"
+
+            require "hanami/prepare"
+
+            expect(Hanami.app.slices.keys).to eq [:admin]
+            expect(Admin::Slice.slices.keys).to eq [:shop]
+
+            expect(Admin::Slice).to be
+            expect(Shop::Slice).to be
+
+            expect { Editorial }.to raise_error(NameError)
+            expect { Main }.to raise_error(NameError)
+          end
+        end
+      end
     end
   end
 
-  describe "skipping specific slices" do
+  describe "skipping specific slices with config.slices.skip_slices" do
     describe "setup app" do
-      it "ignores explicitly registered slices not otherwise configured", :aggregate_failures do
+      it "skips explicitly registering slices included in skip_slices" do
         with_tmp_directory(Dir.mktmpdir) do
           write "config/app.rb", <<~'RUBY'
             require "hanami"
@@ -97,16 +174,41 @@ RSpec.describe "Slices / Slice loading", :app_integration do
           expect { Hanami.app.register_slice :admin }.not_to(change { Hanami.app.slices.keys })
           expect { Admin }.to raise_error(NameError)
 
-          expect { Hanami.app.register_slice :main }
-            .to change { Hanami.app.slices.keys }
-            .to [:main]
+          expect { Hanami.app.register_slice :main }.to change { Hanami.app.slices.keys }.to [:main]
           expect(Main::Slice).to be
+        end
+      end
+
+      describe "nested slices" do
+        it "skips explicity registering slices included in skip_slices" do
+          with_tmp_directory(Dir.mktmpdir) do
+            write "config/app.rb", <<~'RUBY'
+              require "hanami"
+
+              module TestApp
+                class App < Hanami::App
+                  config.slices.skip_slices = %w[admin.shop]
+                end
+              end
+            RUBY
+
+            require "hanami/setup"
+
+            expect { Hanami.app.register_slice :admin }.to change { Hanami.app.slices.keys }.to [:admin]
+
+            expect { Admin::Slice.register_slice :shop }.not_to(change { Admin::Slice.slices.keys })
+            expect { Admin::Slice.register_slice :editorial }.to change { Admin::Slice.slices.keys }.to [:editorial]
+
+            expect(Admin::Slice).to be
+            expect(Editorial::Slice).to be
+            expect { Shop }.to raise_error(NameError)
+          end
         end
       end
     end
 
     describe "prepared app" do
-      it "only loads the configured slices", :aggregate_failures do
+      it "loads all slices except those in skip_slices", :aggregate_failures do
         with_tmp_directory(Dir.mktmpdir) do
           write "config/app.rb", <<~'RUBY'
             require "hanami"
@@ -126,6 +228,59 @@ RSpec.describe "Slices / Slice loading", :app_integration do
           expect(Hanami.app.slices.keys).to eq [:main]
           expect(Main::Slice).to be
           expect { Admin }.to raise_error(NameError)
+        end
+      end
+
+      it "ignores unknown slices in skip_slices" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.slices.skip_slices = %w[admin meep morp]
+              end
+            end
+          RUBY
+
+          write "slices/admin/.keep"
+          write "slices/main/.keep"
+
+          require "hanami/prepare"
+
+          expect(Hanami.app.slices.keys).to eq [:main]
+        end
+      end
+
+      describe "nested slices" do
+        it "loads all child slices of slices except those in skip_slices (using dot-delimited nested slice names)" do
+          with_tmp_directory(Dir.mktmpdir) do
+            write "config/app.rb", <<~'RUBY'
+              require "hanami"
+
+              module TestApp
+                class App < Hanami::App
+                  config.slices.skip_slices = %w[admin.shop]
+                end
+              end
+            RUBY
+
+            write "slices/admin/.keep"
+            write "slices/admin/slices/shop/.keep"
+            write "slices/admin/slices/editorial/.keep"
+            write "slices/main/.keep"
+
+            require "hanami/prepare"
+
+            expect(Hanami.app.slices.keys).to eq %i[admin main]
+            expect(Admin::Slice.slices.keys).to eq [:editorial]
+
+            expect(Admin::Slice).to be
+            expect(Editorial::Slice).to be
+            expect(Main::Slice).to be
+
+            expect { Shop }.to raise_error(NameError)
+          end
         end
       end
     end

--- a/spec/new_integration/slices/slice_loading_spec.rb
+++ b/spec/new_integration/slices/slice_loading_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+# TODO: Tests for HANAMI_LOAD_SLICES
+
+RSpec.describe "Slices / Slice loading", :app_integration do
+  describe "loading specific slices" do
+    describe "setup app" do
+      it "ignores explicitly registered slices not otherwise configured", :aggregate_failures do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.slices.load_slices = %w[admin]
+              end
+            end
+          RUBY
+
+          require "hanami/setup"
+
+          expect { Hanami.app.register_slice :main }.not_to(change { Hanami.app.slices.keys })
+          expect { Main }.to raise_error(NameError)
+
+          expect { Hanami.app.register_slice :admin }
+            .to change { Hanami.app.slices.keys }
+            .to [:admin]
+          expect(Admin::Slice).to be
+        end
+      end
+    end
+
+    describe "prepared app" do
+      it "only loads the configured slices", :aggregate_failures do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.slices.load_slices = %w[admin]
+              end
+            end
+          RUBY
+
+          write "slices/admin/.keep"
+          write "slices/main/.keep"
+
+          require "hanami/prepare"
+
+          expect(Hanami.app.slices.keys).to eq [:admin]
+          expect(Admin::Slice).to be
+          expect { Main }.to raise_error(NameError)
+        end
+      end
+    end
+  end
+
+  describe "skipping specific slices" do
+    describe "setup app" do
+      it "ignores explicitly registered slices not otherwise configured", :aggregate_failures do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.slices.skip_slices = %w[admin]
+              end
+            end
+          RUBY
+
+          require "hanami/setup"
+
+          expect { Hanami.app.register_slice :admin }.not_to(change { Hanami.app.slices.keys })
+          expect { Admin }.to raise_error(NameError)
+
+          expect { Hanami.app.register_slice :main }
+            .to change { Hanami.app.slices.keys }
+            .to [:main]
+          expect(Main::Slice).to be
+        end
+      end
+    end
+
+    describe "prepared app" do
+      it "only loads the configured slices", :aggregate_failures do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.slices.skip_slices = %w[admin]
+              end
+            end
+          RUBY
+
+          write "slices/admin/.keep"
+          write "slices/main/.keep"
+
+          require "hanami/prepare"
+
+          expect(Hanami.app.slices.keys).to eq [:main]
+          expect(Main::Slice).to be
+          expect { Admin }.to raise_error(NameError)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/app_integration.rb
+++ b/spec/support/app_integration.rb
@@ -20,7 +20,7 @@ module RSpec
 end
 
 RSpec.shared_context "Application integration" do
-  let(:application_modules) { %i[TestApp Admin Main Search] }
+  let(:app_modules) { %i[TestApp Admin Main Search] }
 end
 
 RSpec.configure do |config|
@@ -67,7 +67,7 @@ RSpec.configure do |config|
     }
     $LOADED_FEATURES.replace(@loaded_features + new_features_to_keep)
 
-    application_modules.each do |app_module_name|
+    app_modules.each do |app_module_name|
       next unless Object.const_defined?(app_module_name)
 
       Object.const_get(app_module_name).tap do |mod|

--- a/spec/unit/hanami/configuration/slices_spec.rb
+++ b/spec/unit/hanami/configuration/slices_spec.rb
@@ -8,55 +8,27 @@ RSpec.describe Hanami::Configuration, "#slices" do
   subject(:config) { described_class.new(app_name: app_name, env: :development) }
   let(:app_name) { Hanami::SliceName.new(double(name: "MyApp::App"), inflector: Dry::Inflector.new) }
 
-  describe "#load_slices" do
-    subject(:load_slices) { config.slices.load_slices }
+  subject(:slices) { config.slices }
 
-    before do
-      @orig_env = ENV.to_h
-    end
-
-    after do
-      ENV.replace(@orig_env)
-    end
-
-    it "is nil by default" do
-      is_expected.to be nil
-    end
-
-    it "defaults to the HANAMI_LOAD_SLICES env var, separated by commas" do
-      ENV["HANAMI_LOAD_SLICES"] = "main,admin"
-      is_expected.to eq %w[main admin]
-    end
-
-    it "strips spaces from HANAMI_LOAD_SLICES env var entries" do
-      ENV["HANAMI_LOAD_SLICES"] = "main, admin"
-      is_expected.to eq %w[main admin]
-    end
+  before do
+    @orig_env = ENV.to_h
   end
 
-  describe "#skip_slices" do
-    subject(:skip_slices) { config.slices.skip_slices }
+  after do
+    ENV.replace(@orig_env)
+  end
 
-    before do
-      @orig_env = ENV.to_h
-    end
+  it "is nil by default" do
+    is_expected.to be nil
+  end
 
-    after do
-      ENV.replace(@orig_env)
-    end
+  it "defaults to the HANAMI_LOAD_SLICES env var, separated by commas" do
+    ENV["HANAMI_SLICES"] = "main,admin"
+    is_expected.to eq %w[main admin]
+  end
 
-    it "is nil by default" do
-      is_expected.to be nil
-    end
-
-    it "defaults to the HANAMI_LOAD_SLICES env var, separated by commas" do
-      ENV["HANAMI_SKIP_SLICES"] = "main,admin"
-      is_expected.to eq %w[main admin]
-    end
-
-    it "strips spaces from HANAMI_LOAD_SLICES env var entries" do
-      ENV["HANAMI_SKIP_SLICES"] = "main, admin"
-      is_expected.to eq %w[main admin]
-    end
+  it "strips spaces from HANAMI_LOAD_SLICES env var entries" do
+    ENV["HANAMI_SLICES"] = "main, admin"
+    is_expected.to eq %w[main admin]
   end
 end

--- a/spec/unit/hanami/configuration/slices_spec.rb
+++ b/spec/unit/hanami/configuration/slices_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "dry/inflector"
+require "hanami/configuration"
+require "hanami/slice_name"
+
+RSpec.describe Hanami::Configuration, "#slices" do
+  subject(:config) { described_class.new(app_name: app_name, env: :development) }
+  let(:app_name) { Hanami::SliceName.new(double(name: "MyApp::App"), inflector: Dry::Inflector.new) }
+
+  describe "#load_slices" do
+    subject(:load_slices) { config.slices.load_slices }
+
+    before do
+      @orig_env = ENV.to_h
+    end
+
+    after do
+      ENV.replace(@orig_env)
+    end
+
+    it "is nil by default" do
+      is_expected.to be nil
+    end
+
+    it "defaults to the HANAMI_LOAD_SLICES env var, separated by commas" do
+      ENV["HANAMI_LOAD_SLICES"] = "main,admin"
+      is_expected.to eq %w[main admin]
+    end
+
+    it "strips spaces from HANAMI_LOAD_SLICES env var entries" do
+      ENV["HANAMI_LOAD_SLICES"] = "main, admin"
+      is_expected.to eq %w[main admin]
+    end
+  end
+
+  describe "#skip_slices" do
+    subject(:skip_slices) { config.slices.skip_slices }
+
+    before do
+      @orig_env = ENV.to_h
+    end
+
+    after do
+      ENV.replace(@orig_env)
+    end
+
+    it "is nil by default" do
+      is_expected.to be nil
+    end
+
+    it "defaults to the HANAMI_LOAD_SLICES env var, separated by commas" do
+      ENV["HANAMI_SKIP_SLICES"] = "main,admin"
+      is_expected.to eq %w[main admin]
+    end
+
+    it "strips spaces from HANAMI_LOAD_SLICES env var entries" do
+      ENV["HANAMI_SKIP_SLICES"] = "main, admin"
+      is_expected.to eq %w[main admin]
+    end
+  end
+end


### PR DESCRIPTION
Enable conditional slice loading via a new `config.slices` setting.

For example, given this app class:

```ruby
module TestApp
  class App < Hanami::App
    config.slices = %w[admin]
  end
end
```

And the presence of both `slices/admin/` and `slices/main/`, when the app is prepared (or booted), only the admin slice will be loaded:

```ruby
require "hanami/prepare"

Hanami.app.slices.keys # => [:admin]

Admin::Slice # exists, as expected
Main         # raises NameError, since it was never loaded
```

When slices are skipped from loading, they're _completely ignored_ — their slice classes are not loaded, nor are any of their source files. This is valuable because it can keep the app's memory profile as low as possible for any configured set of slices.

Since loading/skipping particular slices is likely to be common adjustment for different deployment modes (e.g. deploying just the admin slice to a different set of containers, or running just a subset of slices for a background worker), we make it easy to specify this config via an `HANAMI_SLICES` env var. When using this, specify the slices as comma-separated:

```
HANAMI_SLICES="main,shop"
```

Lastly, the `config.slices` setting also supports arbitrarily nested slices. For example, if have an "admin" slice with its own child "shop" and "editorial" slices, you can specify `config.slices.load_slices = ["admin.shop"]` to load only its nested shop slice.

---

One caveat about this feature is that it's not "smart" — if one slice e.g. imports another (or expects another slice to be available for any other reason), and if that other slice is skipped, you'll receive errors. It's entirely the responsibility of the user to make sure that the appropriate set of slices is loaded when configuring `load_slices`/`skip_slices`.

I took this approach in order to keep the implementation simple and the feature easy to understand. If I tried to make it smarter I think we'd over-complicate the implementation and probably still end up with a range of cases where the system just can't automatically infer what it needs.

Does this trade off seem reasonable to you?

---

Implementation-wise, this was a fairly well-contained change.

The conditional loading logic is kept entirely within `SliceRegistrar`. There is a new private `#filter_slice_names` method that is given an array of slice names, and (based on the parent slice's `config.slices`) returns the subset of those slices that is permissible to load. Then the rest of the slice registration continues as always, just on this subset of slices only.

This slice name filtering is done in both `SliceRegistrar`'s explicit `#register` method (which is called when slices are registered explicitly using `Slice.register_slice`) as well as its `#load_slices` method (which is used when running `Slice.prepare` and detecting slices kept in a `slices/` directory), so it works consistently across both cases.

The only other change is in `SliceRegistrar#configure_slice`, which is called just before a slice is registered on a parent. Here we look for dot-delimited nested slice names in  `config.slices` and adapt them for the about-to-be-registered slice. So if we had a `config.slices` of `["admin.shop"]` and we were registering the `"admin"` slice, then _its_ `config.slices` would become `["shop"]`. This is how the nested slice support works, by making sure the list is relevant for each slice.

Lastly, to support the new env vars, we have a new private `#load_from_env` method on `Hanami::Configuration`, which is called during its `#initialize`, and simply does this:

```ruby
def load_from_env
  self.slices = ENV["HANAMI_SLICES"]&.split(",")&.map(&:strip)
end
```

This may be a useful hook for other settings we want to have loaded from corresponding env vars in the future.

---

_This change was originally built with separate (and mutually exclusive) `load_slices` and `skip_slices` settings, which we've reduced to a single `slices` setting for simplicity. The original description is below, for reference._

<details>
<summary>Original description using both <code>load_slices</code> and <code>skip_slices</code></summary>

Enable conditional slice loading via two new settings: `slices.load_slices` and `slices.skip_slices`.

For example, given this app class with `config.slices.load_slices`:

```ruby
module TestApp
  class App < Hanami::App
    config.slices.load_slices = %w[admin]
  end
end
```

And the presence of both `slices/admin/` and `slices/main/`, when the app is prepared (or booted), only the admin slice will be loaded:

```ruby
require "hanami/prepare"

Hanami.app.slices.keys # => [:admin]

Admin::Slice # exists, as expected
Main         # raises NameError, since it was never loaded
```

These `load_slices` and `skip_slices` are settings are mutually exclusive: if `load_slices` is configured, then only those slices will be loaded, and `skip_slices` will be ignored. If `load_slices` is not configured, however, then `skip_slices` will be checked and the configured slices will be skipped from loading.

When slices are skipped via either of these two settings, they're _completely_ ignored — their slice classes are not loaded, nor are any of their source files. This is valuable because it can keep the app's memory profile as low as possible for any configured set of slices.

Since loading or skipping certain slices is likely to be common adjustment made for different deployment modes (e.g. deploying just the admin slice to a different set of containers, or running just a subset of slices for a background worker), we make it easy to specify this config via `HANAMI_LOAD_SLICES` and `HANAMI_SKIP_SLICES` env vars. When using these, specify the slices as comma-separated:

```
HANAMI_LOAD_SLICES="main,shop"
# or
HANAMI_SKIP_SLICES="admin"
```

Lastly, the `load_slices` and `skip_slices` settings also support arbitrarily nested slices. For example, if have an "admin" slice with its own child "shop" and "editorial" slices, you can specify `config.slices.load_slices = ["admin.shop"]` to load only its nested shop slice.

---

One caveat about this feature is that it's not "smart" — if one slice e.g. imports another (or expects another slice to be available for any other reason), and if that other slice is skipped, you'll receive errors. It's entirely the responsibility of the user to make sure that the appropriate set of slices is loaded when configuring `load_slices`/`skip_slices`.

I took this approach in order to keep the implementation simple and the feature easy to understand. If I tried to make it smarter I think we'd over-complicate the implementation and probably still end up with a range of cases where the system just can't automatically infer what it needs.

Does this trade off seem reasonable to you?

---

Implementation-wise, this was a fairly well-contained change.

The conditional loading logic is kept entirely within `SliceRegistrar`. There is a new private `#filter_slice_names` method that is given an array of slice names, and (based on the parent slice's `load_slices` or `skip_slices` config) returns the subset of those slices that is permissible to load. Then the rest of the slice registration continues as always, just on this subset of slices only.

This slice name filtering is done in both `SliceRegistrar`'s explicit `#register` method (which is called when slices are registered explicitly using `Slice.register_slice`) as well as its `#load_slices` method (which is used when running `Slice.prepare` and detecting slices kept in a `slices/` directory), so it works consistently across both cases.

The only other change is in `SliceRegistrar#configure_slice`, which is called just before a slice is registered on a parent. Here we look for dot-delimited nested slice names in the `load_slices` or `skip_slices` config and adapt them for the about-to-be-registered slice. So if we had a `load_slices` of `["admin.shop"]` and we were registering the `"admin"` slice, then _its_ `load_slices` would simply become `["shop"]`. This is how the nested slice support works, by making sure the list is relevant for each slice.

Lastly, to support the new env vars, we have a new private `#load_from_env` method on `Hanami::Configuration`, which is called during its `#initialize`, and simply does this:

```ruby
    def load_from_env
      slices.load_slices = ENV["HANAMI_LOAD_SLICES"]&.split(",")&.map(&:strip)
      slices.skip_slices = ENV["HANAMI_SKIP_SLICES"]&.split(",")&.map(&:strip)
    end
```

This may be a useful hook for other settings we want to have loaded from corresponding env vars in the future.
</details>