### PR TITLE
Make router configuration optional

### DIFF
--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -105,22 +105,22 @@ module Hanami
 
       config.logger = Configuration::Logger.new(env: env, app_name: app_name)
 
-      @assets = load_dependent_config("hanami/assets/app_configuration") {
-        Hanami::Assets::AppConfiguration.new
-      }
+      # TODO: Make assets configuration dependent
+      require "hanami/assets/app_configuration"
+      @assets = Hanami::Assets::AppConfiguration.new
 
-      @actions = load_dependent_config("hanami/action") {
+      @actions = load_dependent_config("hanami-controller") {
         require_relative "configuration/actions"
         Actions.new
       }
 
-      @router = load_dependent_config("hanami/router") {
+      @router = load_dependent_config("hanami-router") {
         require_relative "configuration/router"
         @middleware = Slice::Routing::Middleware::Stack.new
         Router.new(self)
       }
 
-      @views = load_dependent_config("hanami/view") {
+      @views = load_dependent_config("hanami-view") {
         require_relative "configuration/views"
         Views.new
       }
@@ -210,14 +210,13 @@ module Hanami
     end
 
     # @api private
-    def load_dependent_config(require_path)
-      require require_path
-      yield
-    rescue LoadError => e
-      raise e unless e.path == require_path
-
-      require_relative "configuration/null_configuration"
-      NullConfiguration.new
+    def load_dependent_config(gem_name)
+      if Hanami.bundled?(gem_name)
+        yield
+      else
+        require_relative "configuration/null_configuration"
+        NullConfiguration.new
+      end
     end
 
     def method_missing(name, *args, &block)

--- a/lib/hanami/configuration.rb
+++ b/lib/hanami/configuration.rb
@@ -9,7 +9,6 @@ require "pathname"
 
 require_relative "constants"
 require_relative "configuration/logger"
-require_relative "configuration/router"
 require_relative "configuration/sessions"
 require_relative "settings/env_store"
 require_relative "slice/routing/middleware/stack"
@@ -115,9 +114,11 @@ module Hanami
         Actions.new
       }
 
-      @middleware = Slice::Routing::Middleware::Stack.new
-
-      @router = Router.new(self)
+      @router = load_dependent_config("hanami/router") {
+        require_relative "configuration/router"
+        @middleware = Slice::Routing::Middleware::Stack.new
+        Router.new(self)
+      }
 
       @views = load_dependent_config("hanami/view") {
         require_relative "configuration/views"

--- a/lib/hanami/configuration/null_configuration.rb
+++ b/lib/hanami/configuration/null_configuration.rb
@@ -5,8 +5,8 @@ require "dry/configurable"
 module Hanami
   class Configuration
     # NullConfiguration can serve as a fallback configuration object when out-of-gem
-    # configuration objects are not available (specifically, when the hanami-controller or
-    # hanami-view gems are not loaded)
+    # configuration objects are not available (specifically, when the
+    # hanami-controller, hanami-router or hanami-view gems are not loaded)
     class NullConfiguration
       include Dry::Configurable
     end

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -55,6 +55,26 @@ RSpec.describe "Hanami setup", :app_integration do
 
         expect { setup }.not_to raise_error
       end
+
+      %w[hanami-view hanami-actions hanami-router].each do |gem_name|
+        it "works when #{gem_name} gem is not bundled" do
+          allow(Hanami).to receive(:bundled?).and_call_original
+          expect(Hanami).to receive(:bundled?).with("hanami-router").and_return(false)
+
+          with_tmp_directory(Dir.mktmpdir) do
+            write "config/app.rb", <<~RUBY
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+              end
+            end
+            RUBY
+
+            expect { setup }.to change { Hanami.app? }.to true
+          end
+        end
+      end
     end
 
     describe "using hanami/setup require" do

--- a/spec/unit/hanami/configuration/actions_spec.rb
+++ b/spec/unit/hanami/configuration/actions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hanami::Configuration, "#actions" do
 
   subject(:actions) { configuration.actions }
 
-  context "Hanami::Action available" do
+  context "hanami-controller is bundled" do
     it "is a full actions configuration" do
       is_expected.to be_an_instance_of(Hanami::Configuration::Actions)
 
@@ -48,21 +48,10 @@ RSpec.describe Hanami::Configuration, "#actions" do
     end
   end
 
-  context "Hanami::Action not available" do
+  context "hanami-controller is not bundled" do
     before do
-      load_error = LoadError.new.tap do |error|
-        error.instance_variable_set :@path, "hanami/action"
-      end
-
-      allow_any_instance_of(described_class)
-        .to receive(:require)
-        .with(anything)
-        .and_call_original
-
-      allow_any_instance_of(described_class)
-        .to receive(:require)
-        .with("hanami/action")
-        .and_raise load_error
+      allow(Hanami).to receive(:bundled?).and_call_original
+      expect(Hanami).to receive(:bundled?).with("hanami-controller").and_return(false)
     end
 
     it "does not expose any settings" do

--- a/spec/unit/hanami/configuration/router_spec.rb
+++ b/spec/unit/hanami/configuration/router_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hanami::Configuration, "#router" do
 
   subject(:router) { configuration.router }
 
-  context "Hanami::Router available" do
+  context "hanami-router is bundled" do
     it "is a full router configuration" do
       is_expected.to be_an_instance_of(Hanami::Configuration::Router)
 
@@ -27,21 +27,10 @@ RSpec.describe Hanami::Configuration, "#router" do
     end
   end
 
-  context "Hanami::Router not available" do
+  context "hanami-router is not bundled" do
     before do
-      load_error = LoadError.new.tap do |error|
-        error.instance_variable_set :@path, "hanami/router"
-      end
-
-      allow_any_instance_of(described_class)
-        .to receive(:require)
-        .with(anything)
-        .and_call_original
-
-      allow_any_instance_of(described_class)
-        .to receive(:require)
-        .with("hanami/router")
-        .and_raise load_error
+      allow(Hanami).to receive(:bundled?).and_call_original
+      expect(Hanami).to receive(:bundled?).with("hanami-router").and_return(false)
     end
 
     it "does not expose any settings" do

--- a/spec/unit/hanami/configuration/router_spec.rb
+++ b/spec/unit/hanami/configuration/router_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "hanami/configuration"
+require "hanami/configuration/router"
+
+RSpec.describe Hanami::Configuration, "#router" do
+  let(:configuration) { described_class.new(app_name: app_name, env: :development) }
+  let(:app_name) { "MyApp::app" }
+
+  subject(:router) { configuration.router }
+
+  context "Hanami::Router available" do
+    it "is a full router configuration" do
+      is_expected.to be_an_instance_of(Hanami::Configuration::Router)
+
+      is_expected.to respond_to(:resolver)
+    end
+
+    it "loads the middleware stack" do
+      subject
+
+      expect(configuration.middleware_stack).not_to be_nil
+    end
+
+    it "can be finalized" do
+      is_expected.to respond_to(:finalize!)
+    end
+  end
+
+  context "Hanami::Router not available" do
+    before do
+      load_error = LoadError.new.tap do |error|
+        error.instance_variable_set :@path, "hanami/router"
+      end
+
+      allow_any_instance_of(described_class)
+        .to receive(:require)
+        .with(anything)
+        .and_call_original
+
+      allow_any_instance_of(described_class)
+        .to receive(:require)
+        .with("hanami/router")
+        .and_raise load_error
+    end
+
+    it "does not expose any settings" do
+      is_expected.not_to be_an_instance_of(Hanami::Configuration::Router)
+      is_expected.not_to respond_to(:resolver)
+    end
+
+    it "can be finalized" do
+      is_expected.to respond_to(:finalize!)
+    end
+  end
+end

--- a/spec/unit/hanami/configuration/views_spec.rb
+++ b/spec/unit/hanami/configuration/views_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hanami::Configuration, "#views" do
 
   subject(:views) { configuration.views }
 
-  context "Hanami::View available" do
+  context "hanami-view is bundled" do
     it "exposes Hanami::Views's app configuration" do
       is_expected.to be_an_instance_of(Hanami::Configuration::Views)
 
@@ -90,21 +90,10 @@ RSpec.describe Hanami::Configuration, "#views" do
     end
   end
 
-  context "Hanami::View not available" do
+  context "hanami-view is not bundled" do
     before do
-      load_error = LoadError.new.tap do |error|
-        error.instance_variable_set :@path, "hanami/view"
-      end
-
-      allow_any_instance_of(described_class)
-        .to receive(:require)
-        .with(anything)
-        .and_call_original
-
-      allow_any_instance_of(described_class)
-        .to receive(:require)
-        .with("hanami/view")
-        .and_raise load_error
+      allow(Hanami).to receive(:bundled?).and_call_original
+      expect(Hanami).to receive(:bundled?).with("hanami-view").and_return(false)
     end
 
     it "does not expose any settings" do


### PR DESCRIPTION
It restores #1204, which was reverted in https://github.com/hanami/hanami/commit/f627f2101475fb348d348bd5a2b4d5cf70005067, without the raising part. I.e., we're making the router configuration optional, but we keep using the null configuration pattern.

We're also adding integration tests to ensure that `Hanami.setup` works when the optional gems are unavailable.