### PR TITLE
Improved middleware setup

### DIFF
--- a/lib/hanami/errors.rb
+++ b/lib/hanami/errors.rb
@@ -12,4 +12,7 @@ module Hanami
 
   # @since 2.0.0
   ComponentLoadError = Class.new(Error)
+
+  # @since 2.0.0
+  UnsupportedMiddlewareSpecError = Class.new(Error)
 end

--- a/spec/integration/rack_app/body_parser_spec.rb
+++ b/spec/integration/rack_app/body_parser_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+RSpec.describe "Hanami web app", :app_integration do
+  include Rack::Test::Methods
+
+  let(:app) { Hanami.app }
+
+  around do |example|
+    with_tmp_directory(Dir.mktmpdir, &example)
+  end
+
+  specify "Setting middlewares in the config" do
+    write "config/app.rb", <<~RUBY
+      require "hanami"
+
+      module TestApp
+        class App < Hanami::App
+        end
+      end
+    RUBY
+
+    write "config/routes.rb", <<~RUBY
+      require "hanami/middleware/body_parser"
+
+      module TestApp
+        class Routes < Hanami::Routes
+          use Hanami::Middleware::BodyParser, :json
+          post "/users", to: "users.create"
+        end
+      end
+    RUBY
+
+    write "app/actions/users/create.rb", <<~RUBY
+      module TestApp
+        module Actions
+          module Users
+            class Create < Hanami::Action
+              accept :json
+
+              def handle(req, res)
+                res.body = req.params[:users].join("-")
+              end
+            end
+          end
+        end
+      end
+    RUBY
+
+    require "hanami/boot"
+
+    post(
+      "/users",
+      JSON.dump("users" => %w[jane john jade joe]),
+      "CONTENT_TYPE" => "application/json"
+    )
+
+    expect(last_response).to be_successful
+    expect(last_response.body).to eql("jane-john-jade-joe")
+  end
+end

--- a/spec/integration/rack_app/body_parser_spec.rb
+++ b/spec/integration/rack_app/body_parser_spec.rb
@@ -17,16 +17,14 @@ RSpec.describe "Hanami web app", :app_integration do
 
       module TestApp
         class App < Hanami::App
+          config.middleware.use :body_parser, :json
         end
       end
     RUBY
 
     write "config/routes.rb", <<~RUBY
-      require "hanami/middleware/body_parser"
-
       module TestApp
         class Routes < Hanami::Routes
-          use Hanami::Middleware::BodyParser, :json
           post "/users", to: "users.create"
         end
       end

--- a/spec/integration/rack_app/middleware_spec.rb
+++ b/spec/integration/rack_app/middleware_spec.rb
@@ -206,4 +206,23 @@ RSpec.describe "Hanami web app", :app_integration do
     expect(last_response).to be_successful
     expect(last_response.body).to eql("yes")
   end
+
+  context "Setting an unsupported middleware" do
+    it "raises meaningful error when an unsupported middleware spec was passed" do
+      expect {
+        Class.new(Hanami::App) do
+          config.middleware.use("oops")
+        end
+      }.to raise_error(Hanami::UnsupportedMiddlewareSpecError)
+    end
+
+    it "raises meaningful error when corresponding file failed to load" do
+      expect {
+        Class.new(Hanami::App) do
+          config.middleware.namespaces.delete(Hanami::Middleware)
+          config.middleware.use(:body_parser)
+        end
+      }.to raise_error(Hanami::UnsupportedMiddlewareSpecError)
+    end
+  end
 end


### PR DESCRIPTION
This improves how loading middlewares work:

- You can pass a symbol now and it'll be resolved automatically ie `config.middleware.use(:body_parser, :json)`
- You can configure custom namespaces that define middlewares ie `config.middleware.namespaces = [Hanami::Middleware, MyStuff::Middlewares]` - the first one with a given constant wins
- We try to require `hanami/middleware/#{middleware_identifier}` automatically for better DX

Overall, this helps because you don't have to deal with requires, you don't need to know where hanami defines its middlewares etc.