### PR TITLE
Raise errors for missing settings

### DIFF
--- a/lib/hanami/settings.rb
+++ b/lib/hanami/settings.rb
@@ -139,6 +139,8 @@ module Hanami
       end
 
       raise InvalidSettingsError, errors if errors.any?
+
+      config.finalize!
     end
 
     def inspect

--- a/lib/hanami/settings.rb
+++ b/lib/hanami/settings.rb
@@ -125,9 +125,15 @@ module Hanami
     def initialize(store = EMPTY_STORE)
       errors = config._settings.map(&:name).each_with_object({}) do |name, errs|
         value = store.fetch(name, Undefined)
-        next if value.eql?(Undefined)
 
-        public_send("#{name}=", value)
+        if value.eql?(Undefined)
+          # When a key is missing entirely from the store, _read_ its value from the config instead,
+          # which ensures its setting constructor runs (with a `nil` argument given) and raises any
+          # necessary errors.
+          public_send(name)
+        else
+          public_send("#{name}=", value)
+        end
       rescue => e # rubocop:disable Style/RescueStandardError
         errs[name] = e
       end

--- a/spec/unit/hanami/settings_spec.rb
+++ b/spec/unit/hanami/settings_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Hanami::Settings do
       settings_class = Class.new(described_class) do
         setting :database_url, default: "postgres://localhost/test_app_development"
       end
-      store = { database_url: "mysql://localhost/test_app_development" }.freeze
+
+      store = {database_url: "mysql://localhost/test_app_development"}.freeze
 
       instance = settings_class.new(store)
 
@@ -19,6 +20,7 @@ RSpec.describe Hanami::Settings do
       settings_class = Class.new(described_class) do
         setting :database_url, default: "postgres://localhost/test_app_development"
       end
+
       store = {}.freeze
 
       instance = settings_class.new(store)
@@ -26,11 +28,12 @@ RSpec.describe Hanami::Settings do
       expect(instance.config.database_url).to eq("postgres://localhost/test_app_development")
     end
 
-    it "collects error for all failed settings" do
+    it "collects error for all setting values failing their constructors" do
       settings_class = Class.new(described_class) do
         setting :database_url, constructor: ->(_v) { raise "nope to database" }
         setting :redis_url, constructor: ->(_v) { raise "nope to redis" }
       end
+
       store = {
         database_url: "postgres://localhost/test_app_development",
         redis_url: "redis://localhost:6379"
@@ -39,6 +42,19 @@ RSpec.describe Hanami::Settings do
       expect { settings_class.new(store) }.to raise_error(
         described_class::InvalidSettingsError,
         /(database_url: nope to database).*(redis_url: nope to redis)/m,
+      )
+    end
+
+    it "collects errors for missing settings failing their constructors" do
+      settings_class = Class.new(described_class) do
+        setting :database_url, constructor: ->(_v) { raise "nope to database" }
+      end
+
+      store = {}
+
+      expect { settings_class.new(store) }.to raise_error(
+        described_class::InvalidSettingsError,
+        /database_url: nope to database/m,
       )
     end
   end

--- a/spec/unit/hanami/settings_spec.rb
+++ b/spec/unit/hanami/settings_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe Hanami::Settings do
         /database_url: nope to database/m,
       )
     end
+
+    it "finalizes the config" do
+      settings_class = Class.new(described_class) do
+        setting :database_url
+      end
+
+      store = {database_url: "postgres://localhost/test_app_development"}
+
+      settings = settings_class.new(store)
+
+      expect(settings.config).to be_frozen
+      expect { settings.database_url = "new" }.to raise_error(Dry::Configurable::FrozenConfig)
+    end
   end
 
   describe "#inspect" do


### PR DESCRIPTION
In https://github.com/hanami/hanami/pull/1216 (specifically, https://github.com/hanami/hanami/pull/1216/commits/d4c036b32a4471a13d70a15bc7f8cef9b5c4509f), we made a small tweak to our settings loading to adapt to changed handling of `Undefined` values in dry-configurable 0.16.0.

The change in dry-configurable is that `Undefined` values sent to config no longer implicitly fall back to using their default value; `Undefined` instead is accepted as the value itself (though not run through the constructor).

To work around this, we stopped setting values on our Settings config object if no such key existed in the store (i.e. if no ENV var existed at all).

However, this turned out to have the undesirable side effect of missing ENV vars no longer triggering exceptions from their constructors. That is, if a setting is required, but not defined in ENV at all, it would no longer halt the boot of the Hanami app and provide early feedback to the user.

This is critical behavior for Hanami, so here we restore it through attempting to _read_ the config value for any keys missing from ENV. This ensures the consrtuctor is run (as it is done for all config values read for the first time) and errors are appropriately raised.

Add a new unit test for this specific scenario at the same time.