### PR TITLE
Rely on auto-loadable dry-system

### DIFF
--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-configurable", "~> 0.16", ">= 0.16.0"
   spec.add_dependency "dry-core",         "~> 0.9", ">= 0.9"
   spec.add_dependency "dry-inflector",    "~> 0.2", ">= 0.2.1"
-  spec.add_dependency "dry-system",       "~> 0.26", ">= 0.26.0"
+  spec.add_dependency "dry-system",       "~> 0.27", ">= 0.27.0"
   spec.add_dependency "dry-monitor",      "~> 0.7", ">= 0.7"
   spec.add_dependency "hanami-cli",       "~> 2.0.beta"
   spec.add_dependency "hanami-utils",     "~> 2.0.beta"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-configurable", "~> 0.16", ">= 0.16.0"
   spec.add_dependency "dry-core",         "~> 0.9", ">= 0.9"
   spec.add_dependency "dry-inflector",    "~> 0.2", ">= 0.2.1"
-  spec.add_dependency "dry-system",       "~> 0.27", ">= 0.27.0"
+  spec.add_dependency "dry-system",       "~> 0.27", ">= 0.27.1"
   spec.add_dependency "dry-monitor",      "~> 0.7", ">= 0.7"
   spec.add_dependency "hanami-cli",       "~> 2.0.beta"
   spec.add_dependency "hanami-utils",     "~> 2.0.beta"

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -113,8 +113,7 @@ module Hanami
   def self.bundled?(gem_name)
     @_mutex.synchronize do
       @_bundled[gem_name] ||= begin
-        gem(gem_name)
-        true
+        Bundler.gem(gem_name)
       rescue Gem::LoadError
         false
       end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require "dry/system/container"
 require "zeitwerk"
+require "dry/system"
+
 require_relative "../hanami"
 require_relative "constants"
 require_relative "errors"

--- a/spec/integration/container/prepare_container_spec.rb
+++ b/spec/integration/container/prepare_container_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe "Container / prepare_container", :app_integration do
 
     # The prepare_container block is called when the slice is prepared
     slice.prepare
+
+    autoloaders_teardown!
   end
 
   describe "in app", :in_prepare_container do


### PR DESCRIPTION
# TODO

- [x] `./spec/unit/hanami/config/router_spec.rb` this spec is now unstable due to how `bundled?` is implemented (I think) so it's something to address