### PR TITLE
Remove check for slices root

### DIFF
--- a/lib/hanami/slice_registrar.rb
+++ b/lib/hanami/slice_registrar.rb
@@ -44,8 +44,6 @@ module Hanami
     end
 
     def load_slices
-      return self unless root
-
       slice_configs = Dir[root.join(CONFIG_DIR, SLICES_DIR, "*#{RB_EXT}")]
         .map { |file| File.basename(file, RB_EXT) }
 


### PR DESCRIPTION
We're no longer allowing slices with no associated root, so we were
checking for a condition that is never met.
