### PR TITLE
Fix flaky tests for config with non-bundled gems

### DIFF
--- a/spec/unit/hanami/config/actions_spec.rb
+++ b/spec/unit/hanami/config/actions_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Hanami::Config, "#actions" do
     end
 
     it "does not expose any settings" do
-      is_expected.not_to be_an_instance_of(Hanami::Config::Actions)
+      is_expected.to be_an_instance_of(Hanami::Config::NullConfig)
       is_expected.not_to respond_to(:default_response_format)
       is_expected.not_to respond_to(:default_response_format=)
     end

--- a/spec/unit/hanami/config/router_spec.rb
+++ b/spec/unit/hanami/config/router_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Hanami::Config, "#router" do
     end
 
     it "does not expose any settings" do
-      is_expected.not_to be_an_instance_of(Hanami::Config::Router)
+      is_expected.to be_an_instance_of(Hanami::Config::NullConfig)
       is_expected.not_to respond_to(:resolver)
     end
 

--- a/spec/unit/hanami/config/views_spec.rb
+++ b/spec/unit/hanami/config/views_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Hanami::Config, "#views" do
     end
 
     it "does not expose any settings" do
-      is_expected.not_to be_an_instance_of(Hanami::Config::Views)
+      is_expected.to be_an_instance_of(Hanami::Config::NullConfig)
       is_expected.not_to respond_to(:layouts_dir)
       is_expected.not_to respond_to(:layouts_dir=)
     end


### PR DESCRIPTION
In the cases of these gems not being bundled, we can’t count on their paritcular config classes being loaded.