### PR TITLE
Use dry-logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem "hanami-view",       github: "hanami/view",       branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
+gem "dry-logger", github: "dry-rb/dry-logger", branch: "main"
+
 # This is needed for settings specs to pass
 gem "dry-types"
 

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-inflector",    "~> 1.0", "< 2"
   spec.add_dependency "dry-monitor",      "~> 1.0", "< 2"
   spec.add_dependency "dry-system",       "~> 1.0.0.rc1"
+  spec.add_dependency "dry-logger",       "~> 1.0.0.rc1"
   spec.add_dependency "hanami-cli",       "~> 2.0.0.rc1"
   spec.add_dependency "hanami-utils",     "~> 2.0.0.rc1"
   spec.add_dependency "zeitwerk",         "~> 2.6"

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -164,7 +164,7 @@ module Hanami
   #     end
   #   end
   #
-  # @return [Hanami::Logger]
+  # @return [Dry::Logger::Dispatcher]
   #
   # @api public
   # @since 1.0.0

--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -329,7 +329,7 @@ module Hanami
 
     # Returns the logger config.
     #
-    # Use this to configure various options for the default `Hanami::Logger` logger instance.
+    # Use this to configure various options for the default `Dry::Logger::Dispatcher` logger instance.
     #
     # @example
     #   config.logger.level = :debug
@@ -346,7 +346,7 @@ module Hanami
 
     # Sets the app's logger instance.
     #
-    # This entirely replaces the default `Hanami::Logger` instance that would have been
+    # This entirely replaces the default `Dry::Logger::Dispatcher` instance that would have been
     #
     # @see #logger_instance
     #
@@ -360,14 +360,14 @@ module Hanami
 
     # Returns the configured logger instance.
     #
-    # Unless you've replaced the logger with {#logger=}, this returns an `Hanami::Logger` configured
+    # Unless you've replaced the logger with {#logger=}, this returns a `Dry::Logger::Dispatcher` configured
     # with the options configured through {#logger}.
     #
     # This configured logger is registered in all app and slice containers as `"logger"`. For
     # typical usage, you should access the logger via this component, not directly from config.
     #
     # @example Accessing the logger component
-    #   Hanami.app["logger"] # => #<Hanami::Logger>
+    #   Hanami.app["logger"] # => #<Dry::Logger::Dispatcher>
     #
     # @example Injecting the logger as a dependency
     #   module MyApp
@@ -380,7 +380,7 @@ module Hanami
     #     end
     #   end
     #
-    # @return [Hanami::Logger]
+    # @return [Dry::Logger::Dispatcher]
     #
     # @see #logger
     # @see Hanami::Config::Logger

--- a/lib/hanami/config/logger.rb
+++ b/lib/hanami/config/logger.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/configurable"
-require "hanami/logger"
+require "dry/logger"
 
 module Hanami
   class Config
@@ -45,14 +45,13 @@ module Hanami
       # @!attribute [rw] formatter
       #   Sets or returns the logger's formatter.
       #
-      #   This may be a name that matches a formatter registered with `Hanami::Logger`, which
-      #   includes `:default` and `:json`.
+      #   This may be a name that matches a formatter registered with `Dry::Logger`, which includes
+      #   `:string`, `:rack` and `:json`.
       #
       #   This may also be an instance of Ruby's built-in `::Logger::Formatter` or any compatible
       #   object.
       #
-      #   Defaults to `:json` for the production environment, and `nil` for all others. A `nil`
-      #   value will result in a plain `::Logger::Formatter` instance.
+      #   Defaults to `:json` for the production environment, and `:rack` for all others.
       #
       #   @return [Symbol, ::Logger::Formatter]
       #
@@ -60,8 +59,8 @@ module Hanami
       #   @since 2.0.0
       setting :formatter
 
-      # @!attribute [rw] colors
-      #   Sets or returns whether log lines should be colorized.
+      # @!attribute [rw] template
+      #   Sets or returns log entry string template
       #
       #   Defaults to `false`.
       #
@@ -69,7 +68,7 @@ module Hanami
       #
       #   @api public
       #   @since 2.0.0
-      setting :colors, default: false
+      setting :template, default: "[%<progname>s] [%<severity>s] [%<time>s] %<message>s"
 
       # @!attribute [rw] filters
       #   Sets or returns an array of attribute names to filter from logs.
@@ -83,29 +82,26 @@ module Hanami
       #   @since 2.0.0
       setting :filters, default: %w[_csrf password password_confirmation].freeze
 
-      # @!attribute [rw] logger_class
-      #   Sets or returns the class to use for the logger.
+      # @!attribute [rw] logger_constructor
+      #   Sets or returns the constructor proc to use for the logger instantiation.
       #
-      #   This should be compatible with the arguments passed to the logger class' `.new` method in
-      #   {#instance}.
-      #
-      #   Defaults to `Hanami::Logger`.
+      #   Defaults to `Dry.method(:Logger)`.
       #
       #   @api public
       #   @since 2.0.0
-      setting :logger_class, default: Hanami::Logger
+      setting :logger_constructor, default: Dry.method(:Logger)
 
       # @!attribute [rw] options
-      #   Sets or returns an array of positional arguments to pass to the {logger_class} when
-      #   initializing the logger.
+      #   Sets or returns a hash of options to pass to the {logger_constructor} when initializing
+      #   the logger.
       #
       #   Defaults to `[]`
       #
-      #   @return [Array<Object>]
+      #   @return [Hash]
       #
       #   @api public
       #   @since 2.0.0
-      setting :options, default: [], constructor: ->(value) { Array(value).flatten }
+      setting :options, default: {}
 
       # Returns a new `Logger` config.
       #
@@ -135,6 +131,8 @@ module Hanami
         config.formatter = case env
                            when :production
                              :json
+                           else
+                             :rack
                            end
       end
 
@@ -145,19 +143,22 @@ module Hanami
       # @api public
       # @since 2.0.0
       def instance
-        logger_class.new(
-          app_name.name,
-          *options,
-          stream: stream,
-          level: level,
-          formatter: formatter,
-          filter: filters,
-          colorizer: colors
-        )
+        logger_constructor.call(app_name.name, **logger_constructor_opts)
       end
 
       private
 
+      # @api private
+      def logger_constructor_opts
+        {stream: stream,
+          level: level,
+          formatter: formatter,
+          filters: filters,
+          template: template,
+          **options}
+      end
+
+      # @api private
       def method_missing(name, *args, &block)
         if config.respond_to?(name)
           config.public_send(name, *args, &block)
@@ -166,6 +167,7 @@ module Hanami
         end
       end
 
+      # @api private
       def respond_to_missing?(name, _incude_all = false)
         config.respond_to?(name) || super
       end

--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -57,8 +57,7 @@ module Hanami
           ip: env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR],
           path: env[SCRIPT_NAME] + env[PATH_INFO].to_s,
           length: extract_content_length(env),
-          params: env[ROUTER_PARAMS],
-          time: Time.now,
+          params: env[ROUTER_PARAMS]
         }
 
         logger.info(data)

--- a/spec/integration/container/standard_bootable_components_spec.rb
+++ b/spec/integration/container/standard_bootable_components_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Container / Standard bootable components", :app_integration do
 
       expect(Hanami.app.key?(:settings)).to be false
       expect(Hanami.app["inflector"]).to eql Hanami.app.inflector
-      expect(Hanami.app["logger"]).to be_a_kind_of(Hanami::Logger)
+      expect(Hanami.app["logger"]).to be_a_kind_of(Dry::Logger::Dispatcher)
       expect(Hanami.app["rack.monitor"]).to be_a_kind_of(Dry::Monitor::Rack::Middleware)
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe "Container / Standard bootable components", :app_integration do
 
       expect(Hanami.app.key?(:settings)).to be false
       expect(Hanami.app["inflector"]).to eql Hanami.app.inflector
-      expect(Hanami.app["logger"]).to be_a_kind_of(Hanami::Logger)
+      expect(Hanami.app["logger"]).to be_a_kind_of(Dry::Logger::Dispatcher)
       expect(Hanami.app["rack.monitor"]).to be_a_kind_of(Dry::Monitor::Rack::Middleware)
     end
   end

--- a/spec/isolation/hanami/boot/success_spec.rb
+++ b/spec/isolation/hanami/boot/success_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hanami do
       Hanami.boot
       expect(Hanami.app.ancestors).to include(Hanami::Application)
       expect(Hanami.app.root).to eq(Dir.pwd)
-      expect(Hanami.logger).to be_kind_of(Hanami::Logger)
+      expect(Hanami.logger).to be_kind_of(Dry::Logger::Dispatcher)
     end
   end
 end

--- a/spec/unit/hanami/config/logger_spec.rb
+++ b/spec/unit/hanami/config/logger_spec.rb
@@ -7,23 +7,15 @@ require "logger"
 require "stringio"
 
 RSpec.describe Hanami::Config::Logger do
-  subject { described_class.new(app_name: app_name, env: env) }
-  let(:app_name) { Hanami::SliceName.new(double(name: "MyApp::app"), inflector: -> { Dry::Inflector.new }) }
-  let(:env) { :development }
-
-  describe "#logger_class" do
-    it "defaults to Hanami::Logger" do
-      expect(subject.logger_class).to eql Hanami::Logger
-    end
-
-    it "can be changed to another class" do
-      another_class = Class.new
-
-      expect { subject.logger_class = another_class }
-        .to change { subject.logger_class }
-        .to(another_class)
-    end
+  subject do
+    described_class.new(app_name: app_name, env: env)
   end
+
+  let(:app_name) do
+    Hanami::SliceName.new(double(name: "MyApp::app"), inflector: -> { Dry::Inflector.new })
+  end
+
+  let(:env) { :development }
 
   describe "#level" do
     it "defaults to :debug" do
@@ -80,8 +72,8 @@ RSpec.describe Hanami::Config::Logger do
   end
 
   describe "#formatter" do
-    it "defaults to nil" do
-      expect(subject.formatter).to eq(nil)
+    it "defaults to :rack" do
+      expect(subject.formatter).to eq(:rack)
     end
 
     context "when :production environment" do
@@ -101,17 +93,17 @@ RSpec.describe Hanami::Config::Logger do
     end
   end
 
-  describe "#colors" do
+  describe "#template" do
     it "defaults to false" do
-      expect(subject.colors).to eq(false)
+      expect(subject.template).to eq("[%<progname>s] [%<severity>s] [%<time>s] %<message>s")
     end
   end
 
-  describe "#colors=" do
+  describe "#template=" do
     it "accepts a value" do
-      expect { subject.colors = true }
-        .to change { subject.colors }
-        .to(true)
+      expect { subject.template = "%<message>s" }
+        .to change { subject.template }
+        .to("%<message>s")
     end
   end
 
@@ -138,20 +130,14 @@ RSpec.describe Hanami::Config::Logger do
   end
 
   describe "#options" do
-    it "defaults to empty array" do
-      expect(subject.options).to eq([])
+    it "defaults to empty hash" do
+      expect(subject.options).to eq({})
     end
   end
 
   describe "#options=" do
     it "accepts value" do
-      subject.options = expected = "daily"
-
-      expect(subject.options).to eq([expected])
-    end
-
-    it "accepts values" do
-      subject.options = expected = [0, 1048576]
+      subject.options = expected = {rotate: "daily"}
 
       expect(subject.options).to eq(expected)
     end
@@ -160,7 +146,11 @@ end
 
 RSpec.describe Hanami::Config do
   subject(:config) { described_class.new(app_name: app_name, env: env) }
-  let(:app_name) { Hanami::SliceName.new(double(name: "SOS::app"), inflector: -> { Dry::Inflector.new }) }
+
+  let(:app_name) do
+    Hanami::SliceName.new(double(name: "SOS::app"), inflector: -> { Dry::Inflector.new })
+  end
+
   let(:env) { :development }
 
   describe "#logger" do
@@ -180,8 +170,8 @@ RSpec.describe Hanami::Config do
   end
 
   describe "#logger_instance" do
-    it "defaults to an Hanami::Logger instance, based on the default logger settings" do
-      expect(config.logger_instance).to be_an_instance_of config.logger.logger_class
+    it "defaults to using Dry::Logger, based on the default logger settings" do
+      expect(config.logger_instance).to be_a(Dry::Logger::Dispatcher)
       expect(config.logger_instance.level).to eq Logger::DEBUG
     end
 

--- a/spec/unit/hanami/web/rack_logger_spec.rb
+++ b/spec/unit/hanami/web/rack_logger_spec.rb
@@ -1,13 +1,24 @@
 # frozen_string_literal: true
 
 require "hanami/web/rack_logger"
-require "hanami/logger"
+require "dry/logger"
 require "stringio"
 require "rack/mock"
 
 RSpec.describe Hanami::Web::RackLogger do
   subject { described_class.new(logger) }
-  let(:logger) { Hanami::Logger.new(app_name, stream: stream, level: Hanami::Logger::DEBUG, filter: filters) }
+
+  let(:logger) do
+    Dry.Logger(
+      app_name,
+      stream: stream,
+      level: :debug,
+      filters: filters,
+      formatter: :rack,
+      template: "[%<progname>s] [%<severity>s] [%<time>s] %<message>s"
+    )
+  end
+
   let(:stream) { StringIO.new }
   let(:filters) { ["user.password"] }
   let(:app_name) { "my_app" }


### PR DESCRIPTION
There are three changes in behavior:

- `filters` are now passed as `filters` to the logger constructor
- `logger_constructor` option was added for more flexibility
- `logger.template` is configured to include progname by default (previously known as the application formatter)