### PR TITLE
Simplify and clarify usage of Config#environment

### DIFF
--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -287,13 +287,15 @@ module Hanami
     # If the given `env_name` matches {Hanami.env}, then the block will be evaluated in the context
     # of `self` via `instance_eval`.
     #
+    # If the env does not match, then the block is not evaluated at all.
+    #
     # @example
     #   config.environment(:test) do |env|
     #     env.logger.level = :info
     #   end
     #
     # @param env_name [Symbol] the environment name
-    # @yieldparam env [self] the config object
+    # @yieldparam c [self] the config object
     #
     # @return [self]
     #

--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -149,6 +149,8 @@ module Hanami
     #
     # @return [Symbol]
     #
+    # @see #environment
+    #
     # @api private
     # @since 2.0.0
     attr_reader :env
@@ -280,18 +282,20 @@ module Hanami
       super
     end
 
-    # Applies config for a given app environment.
+    # Applies config for a given app environment only.
     #
-    # The given block will be evaluated in the context of `self` via `instance_eval`.
+    # If the given `env_name` matches {Hanami.env}, then the block will be evaluated in the context
+    # of `self` via `instance_eval`.
     #
     # @example
-    #   config.environment(:test) do
-    #     config.logger.level = :info
+    #   config.environment(:test) do |env|
+    #     env.logger.level = :info
     #   end
     #
     # @param env_name [Symbol] the environment name
+    # @yieldparam env [self] the config object
     #
-    # @return [Hanami::Config]
+    # @return [self]
     #
     # @see Hanami.env
     #

--- a/spec/unit/hanami/config_spec.rb
+++ b/spec/unit/hanami/config_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Hanami::Config do
     end
 
     before do
-      config.environment :production do |c|
-        c.logger.level = :info__set_for_production_env
+      config.environment :production do |env|
+        env.logger.level = :info__set_for_production_env
       end
     end
 

--- a/spec/unit/hanami/config_spec.rb
+++ b/spec/unit/hanami/config_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Hanami::Config do
     end
 
     before do
-      config.environment :production do |env|
-        env.logger.level = :info__set_for_production_env
+      config.environment :production do |c|
+        c.logger.level = :info__set_for_production_env
       end
     end
 


### PR DESCRIPTION
Since https://github.com/hanami/hanami/pull/1153, the `env` cannot be changed for an `Hanami::Config`. This means we do not need to store the environment-specific config blocks, and can instead evaluate them immediately. This is simpler for the user to understand and makes for a much simpler internal implementation too.

Also update the docs to make it clearer that the argument yielded to the `#environment` block should be the object used to set the config. Using this yielded argument is safer than relying on the implicit `self`, since because `Config#config` exists, a user may call `config` inside the block (with implicit self) and receive the internal `Dry::Configurable::Config` when they actually expect `Hanami::Config`.