### PR TITLE
Remove usage of the private Zeitwerk::Registry.loaders

### DIFF
--- a/spec/support/app_integration.rb
+++ b/spec/support/app_integration.rb
@@ -24,19 +24,11 @@ RSpec.shared_context "Application integration" do
 end
 
 def autoloaders_teardown!
-  # Tear down Zeitwerk (from zeitwerk's own test/support/loader_test)
-  Zeitwerk::Registry.loaders.reject! do |loader|
-    test_loader = loader.dirs.any? { |dir|
+  ObjectSpace.each_object(Zeitwerk::Loader) do |loader|
+    loader.unregister if loader.dirs.any? { |dir|
       dir.include?("/spec/") || dir.include?(Dir.tmpdir) ||
         dir.include?("/slices/") || dir.include?("/app")
     }
-
-    if test_loader
-      loader.unregister
-      true
-    else
-      false
-    end
   end
 end
 


### PR DESCRIPTION
The module `Zeitwerk::Registry` is private, and so is the method `Zeitwerk::Registry.loaders`. This internal state cannot be accessed, much less mutated.

I am confident this usage is just an overlook, no problem! :) However, I have lately seen private interfaces in use in a bunch of places, and I am in the process of enforcing them. In particular, `loaders` is going to disappear soon.

I volunteer this patch so that your test suite does not break when the refactor ships.

If you are curious, https://github.com/dry-rb/dry-system/pull/260 has some background about the rationale.

Love that Hanami 2 uses Zeitwerk ❤️.