### PR TITLE
Only load rack provider when rack is bundled

### DIFF
--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -188,8 +188,10 @@ module Hanami
           register_provider(:logger, source: Hanami::Providers::Logger)
         end
 
-        require_relative "providers/rack"
-        register_provider(:rack, source: Hanami::Providers::Rack, namespace: true)
+        if Hanami.bundled?("rack")
+          require_relative "providers/rack"
+          register_provider(:rack, source: Hanami::Providers::Rack, namespace: true)
+        end
       end
 
       def prepare_autoloader

--- a/spec/integration/container/standard_providers/rack_provider_spec.rb
+++ b/spec/integration/container/standard_providers/rack_provider_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Container / Standard providers / Rack", :app_integration do
+  specify "Rack provider is loaded when rack is bundled" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "slices/main/.keep", ""
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["rack.monitor"]).to be_a_kind_of(Dry::Monitor::Rack::Middleware)
+      expect(Main::Slice["rack.monitor"]).to be_a_kind_of(Dry::Monitor::Rack::Middleware)
+    end
+  end
+
+  specify "Rack provider is not loaded when rack is not bundled" do
+    allow(Hanami).to receive(:bundled?).and_call_original
+    allow(Hanami).to receive(:bundled?).with("rack").and_return false
+
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "slices/main/.keep", ""
+
+      require "hanami/prepare"
+
+      expect(Hanami.app.key?("rack.monitor")).to be false
+      expect(Main::Slice.key?("rack.monitor")).to be false
+    end
+  end
+end

--- a/spec/integration/container/standard_providers_spec.rb
+++ b/spec/integration/container/standard_providers_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Container / Standard bootable components", :app_integration do
+RSpec.describe "Container / Standard providers", :app_integration do
   specify "Standard components are available on booted container" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/app.rb", <<~RUBY


### PR DESCRIPTION
This ensures we're consistent in deactivating web-specific features if the relevant gems are removed from the bundle.