### PR TITLE
`config.actions.sessions` to be accessed only when `hanami-controller` is bundled

### DIFF
--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -957,7 +957,9 @@ module Hanami
           **config.router.options
         ) do
           use(rack_monitor)
-          use(*config.actions.sessions.middleware) if config.actions.sessions.enabled?
+          if Hanami.bundled?("hanami-controller")
+            use(*config.actions.sessions.middleware) if config.actions.sessions.enabled?
+          end
 
           middleware_stack.update(config.middleware_stack)
         end


### PR DESCRIPTION
Fixes https://github.com/hanami/hanami/issues/1248
https://trello.com/c/RRVtK310