### PR TITLE
Streamline action format setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 gem "hanami-utils",      github: "hanami/utils",      branch: "main"
 gem "hanami-router",     github: "hanami/router",     branch: "main"
-gem "hanami-controller", github: "hanami/controller", branch: "main"
+gem "hanami-controller", github: "hanami/controller", branch: "format-macro"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
 gem "hanami-view",       github: "hanami/view",       branch: "main"
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 gem "hanami-utils",      github: "hanami/utils",      branch: "main"
 gem "hanami-router",     github: "hanami/router",     branch: "main"
-gem "hanami-controller", github: "hanami/controller", branch: "format-macro"
+gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
 gem "hanami-view",       github: "hanami/view",       branch: "main"
 

--- a/lib/hanami/config/actions.rb
+++ b/lib/hanami/config/actions.rb
@@ -136,8 +136,7 @@ module Hanami
 
       # Apply defaults for base config
       def configure_defaults
-        self.default_request_format = :html
-        self.default_response_format = :html
+        base_config.format :html
 
         self.default_headers = {
           "X-Frame-Options" => "DENY",

--- a/lib/hanami/extensions/action/slice_configured_action.rb
+++ b/lib/hanami/extensions/action/slice_configured_action.rb
@@ -60,7 +60,7 @@ module Hanami
             #
             #   module MyApp
             #     class Action < Hanami::Action
-            #       config.default_response_format = :json
+            #       config.format :json
             #     end
             #   end
             #
@@ -91,7 +91,10 @@ module Hanami
 
             next if slice.parent && slice_value == parent_value
 
-            action_class.config.public_send(:"#{setting.name}=", slice_value)
+            action_class.config.public_send(
+              :"#{setting.name}=",
+              setting.mutable? ? slice_value.dup : slice_value
+            )
           end
         end
 

--- a/lib/hanami/extensions/view/slice_configured_view.rb
+++ b/lib/hanami/extensions/view/slice_configured_view.rb
@@ -77,7 +77,10 @@ module Hanami
 
             next if slice.parent && slice_value == parent_value
 
-            view_class.config.public_send(:"#{setting.name}=", slice_value)
+            view_class.config.public_send(
+              :"#{setting.name}=",
+              setting.mutable? ? slice_value.dup : slice_value
+            )
           end
 
           view_class.config.inflector = inflector

--- a/spec/integration/action/format_config_spec.rb
+++ b/spec/integration/action/format_config_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "json"
+require "rack/test"
+
+RSpec.describe "App action / Format config", :app_integration do
+  include Rack::Test::Methods
+
+  let(:app) { Hanami.app }
+
+  around do |example|
+    with_tmp_directory(Dir.mktmpdir, &example)
+  end
+
+  it "adds a body parser middleware for the accepted formats from the action config" do
+    write "config/app.rb", <<~RUBY
+      require "hanami"
+
+      module TestApp
+        class App < Hanami::App
+          config.logger.stream = StringIO.new
+
+          config.actions.format :json
+        end
+      end
+    RUBY
+
+    write "config/routes.rb", <<~RUBY
+      module TestApp
+        class Routes < Hanami::Routes
+          post "/users", to: "users.create"
+        end
+      end
+    RUBY
+
+    write "app/action.rb", <<~RUBY
+      # auto_register: false
+
+      module TestApp
+        class Action < Hanami::Action
+        end
+      end
+    RUBY
+
+    write "app/actions/users/create.rb", <<~RUBY
+      module TestApp
+        module Actions
+          module Users
+            class Create < TestApp::Action
+              def handle(req, res)
+                res.body = req.params[:users].join("-")
+              end
+            end
+          end
+        end
+      end
+    RUBY
+
+    require "hanami/boot"
+
+    post(
+      "/users",
+      JSON.generate("users" => %w[jane john jade joe]),
+      "CONTENT_TYPE" => "application/json"
+    )
+
+    expect(last_response).to be_successful
+    expect(last_response.body).to eql("jane-john-jade-joe")
+  end
+
+  specify "adds a body parser middleware configured to parse any custom content type for the accepted formats" do
+    write "config/app.rb", <<~RUBY
+      require "hanami"
+
+      module TestApp
+        class App < Hanami::App
+          config.logger.stream = StringIO.new
+
+          config.actions.formats.add :json, ["application/json+scim", "application/json"]
+        end
+      end
+    RUBY
+
+    write "config/routes.rb", <<~RUBY
+      module TestApp
+        class Routes < Hanami::Routes
+          post "/users", to: "users.create"
+        end
+      end
+    RUBY
+
+    write "app/action.rb", <<~RUBY
+      # auto_register: false
+
+      module TestApp
+        class Action < Hanami::Action
+        end
+      end
+    RUBY
+
+    write "app/actions/users/create.rb", <<~RUBY
+      module TestApp
+        module Actions
+          module Users
+            class Create < TestApp::Action
+              def handle(req, res)
+                res.body = req.params[:users].join("-")
+              end
+            end
+          end
+        end
+      end
+    RUBY
+
+    require "hanami/boot"
+
+    post(
+      "/users",
+      JSON.generate("users" => %w[jane john jade joe]),
+      "CONTENT_TYPE" => "application/json+scim"
+    )
+
+    expect(last_response).to be_successful
+    expect(last_response.body).to eql("jane-john-jade-joe")
+
+    post(
+      "/users",
+      JSON.generate("users" => %w[jane john jade joe]),
+      "CONTENT_TYPE" => "application/json"
+    )
+
+    expect(last_response).to be_successful
+    expect(last_response.body).to eql("jane-john-jade-joe")
+  end
+
+  it "does not add a body parser middleware if one is already added" do
+    write "config/app.rb", <<~RUBY
+      require "hanami"
+
+      module TestApp
+        class App < Hanami::App
+          config.logger.stream = StringIO.new
+
+          config.actions.format :json
+          config.middleware.use :body_parser, [json: "application/json+custom"]
+        end
+      end
+    RUBY
+
+    write "config/routes.rb", <<~RUBY
+      module TestApp
+        class Routes < Hanami::Routes
+          post "/users", to: "users.create"
+        end
+      end
+    RUBY
+
+    write "app/action.rb", <<~RUBY
+      # auto_register: false
+
+      module TestApp
+        class Action < Hanami::Action
+        end
+      end
+    RUBY
+
+    write "app/actions/users/create.rb", <<~RUBY
+      module TestApp
+        module Actions
+          module Users
+            class Create < TestApp::Action
+              config.formats.clear
+
+              def handle(req, res)
+                res.body = req.params[:users].join("-")
+              end
+            end
+          end
+        end
+      end
+    RUBY
+
+    require "hanami/boot"
+
+    post(
+      "/users",
+      JSON.generate("users" => %w[jane john jade joe]),
+      "CONTENT_TYPE" => "application/json+custom"
+    )
+
+    expect(last_response).to be_successful
+    expect(last_response.body).to eql("jane-john-jade-joe")
+  end
+end

--- a/spec/integration/action/slice_configuration_spec.rb
+++ b/spec/integration/action/slice_configuration_spec.rb
@@ -34,24 +34,25 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(TestApp::Action.config.default_request_format).to eq :html
-        expect(TestApp::Action.config.default_response_format).to eq :html
+        expect(TestApp::Action.config.formats.values).to eq [:html]
       end
 
       it "applies actions config from the app" do
-        Hanami.app.config.actions.default_response_format = :json
+        Hanami.app.config.actions.format :json
 
         prepare_app
 
-        expect(TestApp::Action.config.default_response_format).to eq :json
+        expect(TestApp::Action.config.formats.values).to eq [:json]
       end
 
       it "does not override config in the base class" do
-        Hanami.app.config.actions.default_response_format = :csv
+        Hanami.app.config.actions.format :csv
 
         prepare_app
 
-        TestApp::Action.config.default_response_format = :json
+        TestApp::Action.config.format :json
+
+        expect(TestApp::Action.config.formats.values).to eq [:json]
       end
     end
 
@@ -74,24 +75,23 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(TestApp::Actions::Articles::Index.config.default_request_format).to eq :html
-        expect(TestApp::Actions::Articles::Index.config.default_response_format).to eq :html
+        expect(TestApp::Actions::Articles::Index.config.formats.values).to eq [:html]
       end
 
       it "applies actions config from the app" do
-        Hanami.app.config.actions.default_response_format = :json
+        Hanami.app.config.actions.format :json
 
         prepare_app
 
-        expect(TestApp::Actions::Articles::Index.config.default_response_format).to eq :json
+        expect(TestApp::Actions::Articles::Index.config.formats.values).to eq [:json]
       end
 
       it "applies config from the base class" do
         prepare_app
 
-        TestApp::Action.config.default_response_format = :json
+        TestApp::Action.config.format :json
 
-        expect(TestApp::Actions::Articles::Index.config.default_response_format).to eq :json
+        expect(TestApp::Actions::Articles::Index.config.formats.values).to eq [:json]
       end
     end
 
@@ -114,24 +114,23 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(Admin::Actions::Articles::Index.config.default_request_format).to eq :html
-        expect(Admin::Actions::Articles::Index.config.default_response_format).to eq :html
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:html]
       end
 
       it "applies actions config from the app" do
-        Hanami.app.config.actions.default_response_format = :json
+        Hanami.app.config.actions.format :json
 
         prepare_app
 
-        expect(Admin::Actions::Articles::Index.config.default_response_format).to eq :json
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:json]
       end
 
       it "applies config from the base class" do
         prepare_app
 
-        TestApp::Action.config.default_response_format = :json
+        TestApp::Action.config.format :json
 
-        expect(Admin::Actions::Articles::Index.config.default_response_format).to eq :json
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:json]
       end
     end
   end
@@ -152,24 +151,23 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(Admin::Action.config.default_request_format).to eq :html
-        expect(Admin::Action.config.default_response_format).to eq :html
+        expect(Admin::Action.config.formats.values).to eq [:html]
       end
 
       it "applies actions config from the app" do
-        Hanami.app.config.actions.default_response_format = :json
+        Hanami.app.config.actions.format :json
 
         prepare_app
 
-        expect(Admin::Action.config.default_response_format).to eq :json
+        expect(Admin::Action.config.formats.values).to eq [:json]
       end
 
       it "applies config from the app base class" do
         prepare_app
 
-        TestApp::Action.config.default_response_format = :json
+        TestApp::Action.config.format :json
 
-        expect(Admin::Action.config.default_response_format).to eq :json
+        expect(Admin::Action.config.formats.values).to eq [:json]
       end
 
       context "slice actions config present" do
@@ -178,7 +176,7 @@ RSpec.describe "App action / Slice configuration", :app_integration do
             write "config/slices/admin.rb", <<~'RUBY'
               module Admin
                 class Slice < Hanami::Slice
-                  config.actions.default_response_format = :csv
+                  config.actions.format :csv
                 end
               end
             RUBY
@@ -188,24 +186,24 @@ RSpec.describe "App action / Slice configuration", :app_integration do
         it "applies actions config from the slice" do
           prepare_app
 
-          expect(Admin::Action.config.default_response_format).to eq :csv
+          expect(Admin::Action.config.formats.values).to eq [:csv]
         end
 
         it "prefers actions config from the slice over config from the app-level base class" do
           prepare_app
 
-          TestApp::Action.config.default_response_format = :json
+          TestApp::Action.config.format :json
 
-          expect(Admin::Action.config.default_response_format).to eq :csv
+          expect(Admin::Action.config.formats.values).to eq [:csv]
         end
 
         it "prefers config from the base class over actions config from the slice" do
           prepare_app
 
-          TestApp::Action.config.default_response_format = :csv
-          Admin::Action.config.default_response_format = :json
+          TestApp::Action.config.format :csv
+          Admin::Action.config.format :json
 
-          expect(Admin::Action.config.default_response_format).to eq :json
+          expect(Admin::Action.config.formats.values).to eq [:json]
         end
       end
     end
@@ -229,16 +227,15 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(Admin::Actions::Articles::Index.config.default_request_format).to eq :html
-        expect(Admin::Actions::Articles::Index.config.default_response_format).to eq :html
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:html]
       end
 
       it "applies actions config from the app" do
-        Hanami.app.config.actions.default_response_format = :json
+        Hanami.app.config.actions.format :json
 
         prepare_app
 
-        expect(Admin::Actions::Articles::Index.config.default_response_format).to eq :json
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:json]
       end
 
       it "applies actions config from the slice" do
@@ -246,7 +243,7 @@ RSpec.describe "App action / Slice configuration", :app_integration do
           write "config/slices/admin.rb", <<~'RUBY'
             module Admin
               class Slice < Hanami::Slice
-                config.actions.default_response_format = :json
+                config.actions.format :json
               end
             end
           RUBY
@@ -254,15 +251,15 @@ RSpec.describe "App action / Slice configuration", :app_integration do
 
         prepare_app
 
-        expect(Admin::Actions::Articles::Index.config.default_response_format).to eq :json
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:json]
       end
 
       it "applies config from the slice base class" do
         prepare_app
 
-        Admin::Action.config.default_response_format = :json
+        Admin::Action.config.format :json
 
-        expect(Admin::Actions::Articles::Index.config.default_response_format).to eq :json
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:json]
       end
 
       it "prefers config from the slice base class over actions config from the slice" do
@@ -270,7 +267,7 @@ RSpec.describe "App action / Slice configuration", :app_integration do
           write "config/slices/admin.rb", <<~'RUBY'
             module Admin
               class Slice < Hanami::Slice
-                config.actions.default_response_format = :csv
+                config.actions.format :csv
               end
             end
           RUBY
@@ -278,9 +275,9 @@ RSpec.describe "App action / Slice configuration", :app_integration do
 
         prepare_app
 
-        Admin::Action.config.default_response_format = :json
+        Admin::Action.config.format :json
 
-        expect(Admin::Actions::Articles::Index.config.default_response_format).to eq :json
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:json]
       end
     end
   end

--- a/spec/integration/rack_app/body_parser_spec.rb
+++ b/spec/integration/rack_app/body_parser_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Hanami web app", :app_integration do
 
       module TestApp
         class App < Hanami::App
+          config.actions.format :json
           config.middleware.use :body_parser, :json
           config.logger.stream = StringIO.new
         end
@@ -37,8 +38,6 @@ RSpec.describe "Hanami web app", :app_integration do
         module Actions
           module Users
             class Create < Hanami::Action
-              accept :json
-
               def handle(req, res)
                 res.body = req.params[:users].join("-")
               end
@@ -66,7 +65,7 @@ RSpec.describe "Hanami web app", :app_integration do
 
       module TestApp
         class App < Hanami::App
-          config.actions.formats["application/json+scim"] = :json
+          config.actions.formats.add :json, ["application/json+scim"]
           config.middleware.use :body_parser, [json: "application/json+scim"]
           config.logger.stream = StringIO.new
         end
@@ -86,8 +85,6 @@ RSpec.describe "Hanami web app", :app_integration do
         module Actions
           module Users
             class Create < Hanami::Action
-              accept :json
-
               def handle(req, res)
                 res.body = req.params[:users].join("-")
               end

--- a/spec/integration/rack_app/rack_app_spec.rb
+++ b/spec/integration/rack_app/rack_app_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Hanami web app", :app_integration do
 
         module TestApp
           class App < Hanami::App
+            config.actions.format :json
             config.logger.options = {colorize: true}
             config.logger.stream = config.root.join("test.log")
           end
@@ -98,7 +99,7 @@ RSpec.describe "Hanami web app", :app_integration do
 
       expect(logs.()).to match %r{GET 200 \d+(µs|ms) 127.0.0.1 /}
 
-      post "/users", {name: "jane", password: "secret"}, {"Content-Type" => "application/json"}
+      post "/users", JSON.generate(name: "jane", password: "secret"), {"CONTENT_TYPE" => "application/json"}
 
       expect(logs.()).to match %r{POST 200 \d+(µs|ms) 127.0.0.1 /}
 

--- a/spec/unit/hanami/config/actions/default_values_spec.rb
+++ b/spec/unit/hanami/config/actions/default_values_spec.rb
@@ -26,12 +26,8 @@ RSpec.describe Hanami::Config::Actions, "default values" do
   end
 
   describe "new default values applied to base action settings" do
-    describe "default_request_format" do
-      specify { expect(config.default_request_format).to eq :html }
-    end
-
-    describe "default_response_format" do
-      specify { expect(config.default_response_format).to eq :html }
+    describe "formats" do
+      specify { expect(config.formats.values).to eq [:html] }
     end
 
     describe "content_security_policy" do

--- a/spec/unit/hanami/config/actions_spec.rb
+++ b/spec/unit/hanami/config/actions_spec.rb
@@ -13,22 +13,19 @@ RSpec.describe Hanami::Config, "#actions" do
     it "is a full actions config" do
       is_expected.to be_an_instance_of(Hanami::Config::Actions)
 
-      is_expected.to respond_to(:default_response_format)
-      is_expected.to respond_to(:default_response_format=)
+      is_expected.to respond_to(:format)
     end
 
     it "configures base action settings" do
-      expect { actions.default_request_format = :json }
-        .to change { actions.default_request_format }
-        .to :json
+      expect { actions.public_directory = "pub" }
+        .to change { actions.public_directory }
+        .to end_with("pub")
     end
 
     it "configures base actions settings using custom methods" do
-      actions.formats = {}
-
-      expect { actions.format json: "app/json" }
-        .to change { actions.formats }
-        .to("app/json" => :json)
+      expect { actions.formats.add(:json, "app/json") }
+        .to change { actions.formats.mapping }
+        .to include("app/json" => :json)
     end
 
     it "can be finalized" do


### PR DESCRIPTION
The PR goes along with https://github.com/hanami/controller/pull/403 and makes it much more streamlined to set up action formats within full Hanami apps.

Before, it was this (aka “yo dawg, I heard you like `:json`”):

```ruby
config.actions.accepted_formats = [:json]
config.actions.default_request_format = :json
config.actions.default_response_format = :json
config.middleware.use :body_parser, :json
```

Now it's just this:

```ruby
config.actions.use_format :json
```

The first three lines of the "before" scenario are handled by the hanami-controller PR. This PR here deals with the last one.

Here we add some behavior to `Config#finalize` such that if `config.actions.accepted_formats` is set, then we automatically use the body_parser middleware with the appropriate arguments for the configured formats.

I've made sure that this will not disturb existing setups - if anyone manually configures a body_parser middleware, then we will not do anything extra.