### PR TITLE
Improve logger setup

### DIFF
--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-inflector",    "~> 1.0", "< 2"
   spec.add_dependency "dry-monitor",      "~> 1.0", "< 2"
   spec.add_dependency "dry-system",       "~> 1.0.rc"
-  spec.add_dependency "dry-logger",       "~> 1.0.rc"
+  spec.add_dependency "dry-logger",       "~> 1.0", "< 2"
   spec.add_dependency "hanami-cli",       "~> 2.0.rc"
   spec.add_dependency "hanami-utils",     "~> 2.0.rc"
   spec.add_dependency "zeitwerk",         "~> 2.6"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-configurable", "~> 1.0", "< 2"
   spec.add_dependency "dry-core",         "~> 1.0", "< 2"
   spec.add_dependency "dry-inflector",    "~> 1.0", "< 2"
-  spec.add_dependency "dry-monitor",      "~> 1.0", "< 2"
+  spec.add_dependency "dry-monitor",      "~> 1.0", ">= 1.0.1", "< 2"
   spec.add_dependency "dry-system",       "~> 1.0.rc"
   spec.add_dependency "dry-logger",       "~> 1.0", "< 2"
   spec.add_dependency "hanami-cli",       "~> 2.0.rc"

--- a/lib/hanami/providers/rack.rb
+++ b/lib/hanami/providers/rack.rb
@@ -27,7 +27,8 @@ module Hanami
 
         notifications = target[:notifications]
 
-        monitor_middleware = Dry::Monitor::Rack::Middleware.new(notifications)
+        clock = Dry::Monitor::Clock.new(unit: :microsecond)
+        monitor_middleware = Dry::Monitor::Rack::Middleware.new(notifications, clock: clock)
 
         rack_logger = Hanami::Web::RackLogger.new(target[:logger])
         rack_logger.attach(monitor_middleware)

--- a/spec/unit/hanami/config/logger_spec.rb
+++ b/spec/unit/hanami/config/logger_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe Hanami::Config::Logger do
   end
 
   describe "#formatter" do
-    it "defaults to :rack" do
-      expect(subject.formatter).to eq(:rack)
+    it "defaults to :string" do
+      expect(subject.formatter).to eq(:string)
     end
 
     context "when :production environment" do
@@ -94,8 +94,8 @@ RSpec.describe Hanami::Config::Logger do
   end
 
   describe "#template" do
-    it "defaults to false" do
-      expect(subject.template).to eq("[%<progname>s] [%<severity>s] [%<time>s] %<message>s")
+    it "defaults to :details" do
+      expect(subject.template).to be(:details)
     end
   end
 

--- a/spec/unit/hanami/web/rack_logger_spec.rb
+++ b/spec/unit/hanami/web/rack_logger_spec.rb
@@ -53,7 +53,10 @@ RSpec.describe Hanami::Web::RackLogger do
       stream.rewind
       actual = stream.read
 
-      expect(actual).to include(%([#{app_name}] [INFO] [#{time}] #{verb} #{status} #{elapsed}ms #{ip} #{path} #{content_length} {"user"=>{"password"=>"[FILTERED]"}}))
+      expect(actual).to eql(<<~LOG)
+        [#{app_name}] [INFO] [#{time}] #{verb} #{status} #{elapsed}µs #{ip} #{path} #{content_length}
+          {"user"=>{"password"=>"[FILTERED]"}}
+      LOG
     end
 
     context "ip" do


### PR DESCRIPTION
Fixes dry-rb/dry-logger#19

- [x] Configure regular string-based logger in dev/test **by default** rather than a rack-specific logger
- [x] Configure a rack-specific logger only for logging rack requests
- [x] Make sure in production mode all logs go through the default JSON logger (we want to use just a single backend in prod after all)
- [x] Figure out a nice way of marking log entries as rack so that we don't have to check its payload. Maybe use tagged logs for that?
- [x] ~Figure out why elapsed time is not provided when logging exceptions coming from rack monitor~ it was provided but it was `0` in case of <1ms response times 😆 this is now address via configured dry-monitor's clock to use microseconds by default
