### PR TITLE
Remove default action format of :html

### DIFF
--- a/lib/hanami/config/actions.rb
+++ b/lib/hanami/config/actions.rb
@@ -136,8 +136,6 @@ module Hanami
 
       # Apply defaults for base config
       def configure_defaults
-        base_config.format :html
-
         self.default_headers = {
           "X-Frame-Options" => "DENY",
           "X-Content-Type-Options" => "nosniff",

--- a/spec/integration/action/slice_configuration_spec.rb
+++ b/spec/integration/action/slice_configuration_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(TestApp::Action.config.formats.values).to eq [:html]
+        expect(TestApp::Action.config.formats.values).to eq []
       end
 
       it "applies actions config from the app" do
@@ -75,7 +75,7 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(TestApp::Actions::Articles::Index.config.formats.values).to eq [:html]
+        expect(TestApp::Actions::Articles::Index.config.formats.values).to eq []
       end
 
       it "applies actions config from the app" do
@@ -114,7 +114,7 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:html]
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq []
       end
 
       it "applies actions config from the app" do
@@ -151,7 +151,7 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(Admin::Action.config.formats.values).to eq [:html]
+        expect(Admin::Action.config.formats.values).to eq []
       end
 
       it "applies actions config from the app" do
@@ -227,7 +227,7 @@ RSpec.describe "App action / Slice configuration", :app_integration do
       it "applies default actions config from the app", :aggregate_failures do
         prepare_app
 
-        expect(Admin::Actions::Articles::Index.config.formats.values).to eq [:html]
+        expect(Admin::Actions::Articles::Index.config.formats.values).to eq []
       end
 
       it "applies actions config from the app" do

--- a/spec/unit/hanami/config/actions/default_values_spec.rb
+++ b/spec/unit/hanami/config/actions/default_values_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe Hanami::Config::Actions, "default values" do
   end
 
   describe "new default values applied to base action settings" do
-    describe "formats" do
-      specify { expect(config.formats.values).to eq [:html] }
-    end
-
     describe "content_security_policy" do
       specify { expect(config.content_security_policy).to be_kind_of(Hanami::Config::Actions::ContentSecurityPolicy) }
     end


### PR DESCRIPTION
For maximal success with early adopters, leave the action format unspecified, meaning we accept all format types, and users can then opt into the format of their preference when they need to.

`:html` as a default format for our 2.0 release makes little sense since the gems we'll be releasing initially make the most sense for building APIs.

If we kept this as the default format, then anyone testing a request with an `Accept: application/json` header against a vanilla Hanami app would immediately receive a HTTP 406 error, which will be a jarring experience.