### PR TITLE
Ensure `Content-Security-Policy` HTTP response header to be returned as a single line

### DIFF
--- a/lib/hanami/config/actions/content_security_policy.rb
+++ b/lib/hanami/config/actions/content_security_policy.rb
@@ -102,7 +102,7 @@ module Hanami
         def to_s
           @policy.map do |key, value|
             "#{dasherize(key)} #{value}"
-          end.join(";\n")
+          end.join(";")
         end
 
         private

--- a/spec/unit/hanami/config/actions/content_security_policy_spec.rb
+++ b/spec/unit/hanami/config/actions/content_security_policy_spec.rb
@@ -13,21 +13,21 @@ RSpec.describe Hanami::Config::Actions, "#content_security_policy" do
         expect(content_security_policy[:base_uri]).to eq("'self'")
 
         expected = [
-          %(base-uri 'self';),
-          %(child-src 'self';),
-          %(connect-src 'self';),
-          %(default-src 'none';),
-          %(font-src 'self';),
-          %(form-action 'self';),
-          %(frame-ancestors 'self';),
-          %(frame-src 'self';),
-          %(img-src 'self' https: data:;),
-          %(media-src 'self';),
-          %(object-src 'none';),
-          %(plugin-types application/pdf;),
-          %(script-src 'self';),
+          %(base-uri 'self'),
+          %(child-src 'self'),
+          %(connect-src 'self'),
+          %(default-src 'none'),
+          %(font-src 'self'),
+          %(form-action 'self'),
+          %(frame-ancestors 'self'),
+          %(frame-src 'self'),
+          %(img-src 'self' https: data:),
+          %(media-src 'self'),
+          %(object-src 'none'),
+          %(plugin-types application/pdf),
+          %(script-src 'self'),
           %(style-src 'self' 'unsafe-inline' https:)
-        ].join("\n")
+        ].join(";")
 
         expect(content_security_policy.to_s).to eq(expected)
       end


### PR DESCRIPTION
## Before

```shell
⚡ curl -i http://localhost:2300
HTTP/1.1 200 OK
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Content-Security-Policy: base-uri 'self';
Content-Security-Policy: child-src 'self';
Content-Security-Policy: connect-src 'self';
Content-Security-Policy: default-src 'none';
Content-Security-Policy: font-src 'self';
Content-Security-Policy: form-action 'self';
Content-Security-Policy: frame-ancestors 'self';
Content-Security-Policy: frame-src 'self';
Content-Security-Policy: img-src 'self' https: data:;
Content-Security-Policy: media-src 'self';
Content-Security-Policy: object-src 'none';
Content-Security-Policy: plugin-types application/pdf;
Content-Security-Policy: script-src 'self';
Content-Security-Policy: style-src 'self' 'unsafe-inline' https:
Content-Type: application/octet-stream; charset=utf-8
Content-Length: 31
```

## After

```
⚡ curl -i http://localhost:2300
HTTP/1.1 200 OK
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Content-Security-Policy: base-uri 'self';child-src 'self';connect-src 'self';default-src 'none';font-src 'self';form-action 'self';frame-ancestors 'self';frame-src 'self';img-src 'self' https: data:;media-src 'self';object-src 'none';plugin-types application/pdf;script-src 'self';style-src 'self' 'unsafe-inline' https:
Content-Type: application/octet-stream; charset=utf-8
Content-Length: 31
```