### PR TITLE
Ensure rack events are on notifications

### DIFF
--- a/spec/integration/rack_app/rack_app_spec.rb
+++ b/spec/integration/rack_app/rack_app_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Hanami web app", :app_integration do
         end
       RUBY
 
-      require "hanami/boot"
+      require "hanami/prepare"
 
       expect(Hanami.app["rack.monitor"]).to be_instance_of(Dry::Monitor::Rack::Middleware)
 
@@ -114,7 +114,63 @@ RSpec.describe "Hanami web app", :app_integration do
     end
   end
 
-  describe "Request logging when using a slice" do
+  specify "Logging via the rack monitor even when notifications bus has already been used" do
+    dir = Dir.mktmpdir
+
+    with_tmp_directory(dir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.actions.format :json
+            config.logger.options = {colorize: true}
+            config.logger.stream = config.root.join("test.log")
+          end
+        end
+      RUBY
+
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Routes
+            post "/users", to: "users.create"
+          end
+        end
+      RUBY
+
+      write "app/actions/users/create.rb", <<~RUBY
+        module TestApp
+          module Actions
+            module Users
+              class Create < Hanami::Action
+                def handle(req, resp)
+                  resp.body = req.params.to_h.keys
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      # Simulate any component interacting with the notifications bus such that it creates its
+      # internal bus with a duplicate copy of all currently registered events. This means that the
+      # class-level Dry::Monitor::Notification events implicitly registered by the
+      # Dry::Monitor::Rack::Middleware activated via the rack provider are ignored, unless our
+      # provider explicitly re-registers them on _instance_ of the notifications bus.
+      #
+      # See Hanami::Providers::Rack for more detail.
+      Hanami.app["notifications"].instrument(:sql)
+
+      logs = -> { Pathname(dir).join("test.log").realpath.read }
+
+      post "/users", JSON.generate(name: "jane", password: "secret"), {"CONTENT_TYPE" => "application/json"}
+      expect(logs.()).to match %r{POST 200 \d+(µs|ms) 127.0.0.1 /}
+    end
+  end
+
+  describe "Request logging when using slice router" do
     let(:app) { Main::Slice.rack_app }
 
     specify "Has rack monitor preconfigured with default request logging (when used via a slice)" do
@@ -139,7 +195,7 @@ RSpec.describe "Hanami web app", :app_integration do
           end
         RUBY
 
-        require "hanami/boot"
+        require "hanami/prepare"
 
         get "/"
 


### PR DESCRIPTION
This fixes #1262, an issue where the rack events are not available if something interacts with our `notifications` bus before the rack provider is prepared.

This can happen in apps setting up rom-rb and using its sql instrumentation plugin, e.g.

```
rom_config.plugin(:sql, relations: :instrumentation) do |plugin_config|
  plugin_config.notifications = target["notifications"]
end
```

If rom-rb is set up in another provider, and that provider is started before the rack provider, then rack logging will crash with an error like this:

```
Dry::Events::InvalidSubscriberError:
  you are trying to subscribe to an event: `rack.request.stop` that has not been registered
```

With this change here, this will no longer happen, and rack logging will run correctly at all times.