### PR TITLE
Add a new `Hanami::Slice::Routing::Endpoint` class to be used by the routing resolver

### DIFF
--- a/lib/hanami/slice/routing/endpoint.rb
+++ b/lib/hanami/slice/routing/endpoint.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Slice
+    # @api private
+    module Routing
+      class Endpoint
+        SLICE_ACTIONS_KEY_NAMESPACE = "actions"
+
+        attr_reader :slice, :action_key
+
+        def initialize(action_key, slice)
+          @action_key     = action_key
+          @slice          = slice
+          @resolvable_key = "#{SLICE_ACTIONS_KEY_NAMESPACE}.#{@action_key}"
+
+          ensure_action_in_slice
+        end
+
+        # Lazily resolve action from the slice to reduce router initialization time, and
+        # circumvent endless loops from the action requiring access to router-related
+        # concerns (which may not be fully loaded at the time of reading the routes)
+        def call(*args)
+          action = slice.resolve(resolvable_key) do
+            raise Routes::MissingActionError.new(resolvable_key, slice)
+          end
+
+          action.call(*args)
+        end
+
+        private
+
+        attr_reader :resolvable_key
+
+        def ensure_action_in_slice
+          return unless slice.booted?
+
+          raise Routes::MissingActionError.new(resolvable_key, slice) unless slice.key?(resolvable_key)
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/slice/routing/resolver.rb
+++ b/lib/hanami/slice/routing/resolver.rb
@@ -14,8 +14,6 @@ module Hanami
       # @api private
       # @since 2.0.0
       class Resolver
-        SLICE_ACTIONS_KEY_NAMESPACE = "actions"
-
         # @api private
         # @since 2.0.0
         def initialize(slice:)
@@ -40,7 +38,7 @@ module Hanami
           endpoint =
             case endpoint
             when String
-              resolve_slice_action(endpoint)
+              Endpoint.new(endpoint, slice)
             when Class
               endpoint.respond_to?(:call) ? endpoint : endpoint.new
             else
@@ -59,31 +57,6 @@ module Hanami
         # @api private
         # @since 2.0.0
         attr_reader :slice
-
-        # @api private
-        # @since 2.0.0
-        def resolve_slice_action(key)
-          action_key = "#{SLICE_ACTIONS_KEY_NAMESPACE}.#{key}"
-
-          ensure_action_in_slice(action_key)
-
-          # Lazily resolve action from the slice to reduce router initialization time, and
-          # circumvent endless loops from the action requiring access to router-related
-          # concerns (which may not be fully loaded at the time of reading the routes)
-          -> (*args) {
-            action = slice.resolve(action_key) do
-              raise Routes::MissingActionError.new(action_key, slice)
-            end
-
-            action.call(*args)
-          }
-        end
-
-        def ensure_action_in_slice(key)
-          return unless slice.booted?
-
-          raise Routes::MissingActionError.new(key, slice) unless slice.key?(key)
-        end
       end
     end
   end


### PR DESCRIPTION
Related to this thread in the hanami chat room: https://gitter.im/hanami/chat?at=63a06fbc69ce3c5338359379

The goal is to facilitate testing and debugging routes. Adding this `Endpoint` objects allows us to do this kind of tests:

```ruby
route = router.recognize("/books/23")
expect(route).to be_routable
expect(route.endpoint.slice).to be API::Slice
expect(route.endpoint.action_key).to eq "books.show"
```