### PR TITLE
Provide a fail-safe config for logger

### DIFF
--- a/lib/hanami/config/logger.rb
+++ b/lib/hanami/config/logger.rb
@@ -126,7 +126,7 @@ module Hanami
           config.level = :debug
           config.stream = File.join("log", "#{env}.log") if env == :test
           config.logger_constructor = method(:development_logger)
-        when :production
+        else
           config.level = :info
           config.formatter = :json
           config.logger_constructor = method(:production_logger)

--- a/spec/unit/hanami/config/logger_spec.rb
+++ b/spec/unit/hanami/config/logger_spec.rb
@@ -182,5 +182,14 @@ RSpec.describe Hanami::Config do
         .to change { config.logger_instance }
         .to logger_instance
     end
+
+    context "unrecognized :env" do
+      let(:env) { :staging }
+
+      it "provides a fail-safe configuration" do
+        expect { config.logger_instance }.to_not raise_error
+        expect(config.logger_instance).to be_a(Dry::Logger::Dispatcher)
+      end
+    end
   end
 end


### PR DESCRIPTION
If `Hanami.env` is not one of: `:development`, `:test`, `:production`, `Hanami::Config#logger_instance` would raise an exception.

There shouldn't be any need to officially support more than these environments, however if someone does need to do this it shouldn't break the system.