### PR TITLE
Use Rack production logger by default, unless app env is `development` or `test`.

### DIFF
--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -71,7 +71,7 @@ module Hanami
       # @since 2.0.0
       def initialize(logger, env: :development)
         @logger = logger
-        extend(env == :production ? Production : Development)
+        extend(%i[development test].include?(env) ? Development : Production)
       end
 
       # @api private


### PR DESCRIPTION
Always use the rack production logger UNLESS the app env is specifically 'development' or 'test'

This should allow for usage of custom envs such as `prod` or `stage` without using development logger by accident. As a caveat, using a custom test/dev env such as `dev` might result on unwanted usage of production rack logger.

---
Also related to: https://github.com/hanami/hanami/pull/1279, as that PR also adds better support of custom prod envs.