### PR TITLE
Update app view context for view gem changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "hanami-utils",      github: "hanami/utils",      branch: "main"
 gem "hanami-router",     github: "hanami/router",     branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
-gem "hanami-view",       github: "hanami/view",       branch: "main"
+gem "hanami-view",       github: "hanami/view",       branch: "simplify-3"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 

--- a/lib/hanami/extensions/action.rb
+++ b/lib/hanami/extensions/action.rb
@@ -101,13 +101,13 @@ module Hanami
         end
 
         # @api private
-        def view_options(req, res)
-          {context: view_context&.with(**view_context_options(req, res))}.compact
+        def view_options(request, response)
+          {context: view_context&.with(**view_context_options(request, response))}.compact
         end
 
         # @api private
-        def view_context_options(req, res)
-          {request: req, response: res}
+        def view_context_options(request, response) # rubocop:disable Lint:UnusedMethodArgument
+          {request: request}
         end
 
         # Returns true if a view should automatically be rendered onto the response body.

--- a/spec/integration/action/view_integration_spec.rb
+++ b/spec/integration/action/view_integration_spec.rb
@@ -91,9 +91,9 @@ RSpec.describe "App action / View integration", :app_integration do
   end
 
   describe "#view_options" do
-    subject(:view_options) { action.send(:view_options, req, res) }
-    let(:req) { double(:req) }
-    let(:res) { double(:res) }
+    subject(:view_options) { action.send(:view_options, request, response) }
+    let(:request) { double(:request) }
+    let(:response) { double(:response) }
 
     context "without view context" do
       it "is an empty hash" do
@@ -109,10 +109,9 @@ RSpec.describe "App action / View integration", :app_integration do
         let(:request_view_context) { double(:request_view_context) }
 
         before do
-          allow(initial_view_context).to receive(:with).with(
-            request: req,
-            response: res,
-          ) { request_view_context }
+          allow(initial_view_context).to receive(:with).with(request: request) {
+            request_view_context
+          }
         end
 
         it "is the view context with the request and response provided" do
@@ -125,7 +124,7 @@ RSpec.describe "App action / View integration", :app_integration do
 
         before do
           action_class.class_eval do
-            def view_context_options(req, res)
+            def view_context_options(_request, _response)
               {custom_option: "custom option"}
             end
           end
@@ -144,13 +143,12 @@ RSpec.describe "App action / View integration", :app_integration do
         let(:request_view_context) { double(:request_view_context) }
 
         before do
-          allow(initial_view_context).to receive(:with).with(
-            request: req,
-            response: res,
-          ) { request_view_context }
+          allow(initial_view_context).to receive(:with).with(request: request) {
+            request_view_context
+          }
 
           action_class.class_eval do
-            def view_options(req, res)
+            def view_options(_request, _response)
               super.merge(extra_option: "extra option")
             end
           end

--- a/spec/integration/action/view_rendering_spec.rb
+++ b/spec/integration/action/view_rendering_spec.rb
@@ -38,13 +38,6 @@ RSpec.describe "App action / View rendering", :app_integration do
         module TestApp
           module Views
             class Context < Hanami::View::Context
-              def request
-                _options.fetch(:request)
-              end
-
-              def response
-                _options.fetch(:response)
-              end
             end
           end
         end

--- a/spec/integration/view/context/request_spec.rb
+++ b/spec/integration/view/context/request_spec.rb
@@ -20,14 +20,10 @@ RSpec.describe "App view / Context / Request", :app_integration do
   let(:context_class) { TestApp::Views::Context }
 
   subject(:context) {
-    context_class.new(
-      request: request,
-      response: response,
-    )
+    context_class.new(request: request)
   }
 
   let(:request) { double(:request) }
-  let(:response) { double(:response) }
 
   describe "#request" do
     it "is the provided request" do
@@ -51,10 +47,10 @@ RSpec.describe "App view / Context / Request", :app_integration do
     let(:flash) { double(:flash) }
 
     before do
-      allow(response).to receive(:flash) { flash }
+      allow(request).to receive(:flash) { flash }
     end
 
-    it "is the response's flash" do
+    it "is the request's flash" do
       expect(context.flash).to be flash
     end
   end


### PR DESCRIPTION
Prepare for the changes to `Hanami::View::Context` in https://github.com/hanami/view/pull/223:

- Keep separate ivars for each context attribute (these are no longer captured by the superclass in an `_options` hash)
- Provide a custom `#initialize_copy` to ensure objects that may be mutated over the course of a rendering are duped (in this case, the `@content_for` hash)
- Provide a `#with` method that allows the request to be provided to an already initialized context
- Stop passing the response to the context before rendering, since `#flash` is now available on the request too