### PR TITLE
Ensure to mount Rack Middleware in routes using kwargs

### DIFF
--- a/spec/integration/rack_app/middleware_spec.rb
+++ b/spec/integration/rack_app/middleware_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe "Hanami web app", :app_integration do
             @app.call(env)
           end
         end
+
+        class AppendSession < Core
+          def initialize(app, options = {})
+            super()
+            @app = app
+            @options = options
+          end
+
+          def call(env)
+            env["session"] << @options.fetch(:secret, "no secret")
+            @app.call(env)
+          end
+        end
       end
     end
   end
@@ -56,6 +69,7 @@ RSpec.describe "Hanami web app", :app_integration do
           config.middleware.use Middlewares::AppendOne
           config.middleware.use Middlewares::Prepare, before: Middlewares::AppendOne
           config.middleware.use Middlewares::AppendTwo, after: Middlewares::AppendOne
+          config.middleware.use Middlewares::AppendSession, secret: "abc"
         end
       end
     RUBY


### PR DESCRIPTION
## Problem

Given the following route scope with a middleware that accepts kwargs:

```ruby
    scope "/sidekiq" do
      use Rack::Session::Cookie,
          key: "_my_app.session",
          secret: Hanami.app.settings.session_secret,
          expire_after: 60 * 60 * 24 * 365

      mount Sidekiq::Web, at: "/sidekiq"
    end
```

The app crashes with the following:

```shell
    ArgumentError:
       unknown keyword: :secret
     # ./lib/hanami/slice/routing/middleware/stack.rb:94:in `use'
```