### PR TITLE
Allow rack provider to be replaced by custom provider.

### DIFF
--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -151,15 +151,17 @@ module Hanami
         require_relative "providers/inflector"
         register_provider(:inflector, source: Hanami::Providers::Inflector)
 
-        # Allow logger to be replaced by users with a manual provider, for advanced cases
+        # Allow logger and rack to be replaced by users with manual providers, for advanced cases
         unless container.providers.find_and_load_provider(:logger)
           require_relative "providers/logger"
           register_provider(:logger, source: Hanami::Providers::Logger)
         end
 
         if Hanami.bundled?("rack")
-          require_relative "providers/rack"
-          register_provider(:rack, source: Hanami::Providers::Rack, namespace: true)
+          unless container.providers.find_and_load_provider(:rack)
+            require_relative "providers/rack"
+            register_provider(:rack, source: Hanami::Providers::Rack, namespace: true)
+          end
         end
       end
 

--- a/spec/integration/container/standard_providers_spec.rb
+++ b/spec/integration/container/standard_providers_spec.rb
@@ -89,10 +89,19 @@ RSpec.describe "Container / Standard providers", :app_integration do
         end
       RUBY
 
+      write "config/providers/rack.rb", <<~RUBY
+        Hanami.app.register_provider :rack do
+          start do
+            register "rack.monitor", "custom rack monitor"
+          end
+        end
+      RUBY
+
       require "hanami/setup"
       Hanami.boot
 
       expect(Hanami.app[:logger]).to eq "custom logger"
+      expect(Hanami.app["rack.monitor"]).to eq "custom rack monitor"
     end
   end
 
@@ -115,10 +124,19 @@ RSpec.describe "Container / Standard providers", :app_integration do
         end
       RUBY
 
+      write "config/providers/rack.rb", <<~RUBY
+        Hanami.app.register_provider :rack do
+          start do
+            register "rack.monitor", "custom rack monitor"
+          end
+        end
+      RUBY
+
       require "hanami/setup"
       Hanami.prepare
 
       expect(Hanami.app[:logger]).to eq "custom logger"
+      expect(Hanami.app["rack.monitor"]).to eq "custom rack monitor"
     end
   end
 end


### PR DESCRIPTION
To use a custom logger in several applications, we currently replace the default `logger` provider by placing our own at `config/providers/logger.rb` (use the mechanism [mentioned here](https://github.com/hanami/hanami/issues/1294#issuecomment-1451823937) by @timriley).

This works well, but as part of our logging story, we'd also like to replace Hanami's rack logger with our own custom rack logger, so that we have control over rack request logging too.

Hanami's rack logger is [initialized here](https://github.com/hanami/hanami/blob/main/lib/hanami/providers/rack.rb#L40) in the rack provider. 

This PR allows framework users to replace that rack provider with a custom one of their own making, should they so choose, by placing a custom implementation at `config/providers/rack.rb`.

This is just one way we could achieve this - there might be an alternative option that allows the rack logger Hanami will use to be decided via configuration?
