### PR TITLE
Use exact slice module match in SliceConfigurable

### DIFF
--- a/lib/hanami/slice_configurable.rb
+++ b/lib/hanami/slice_configurable.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "constants"
 require_relative "errors"
 
 module Hanami
@@ -58,7 +59,7 @@ module Hanami
 
         slices = Hanami.app.slices.with_nested + [Hanami.app]
 
-        slices.detect { |slice| klass.name.include?(slice.namespace.to_s) }
+        slices.detect { |slice| klass.name.start_with?("#{slice.namespace}#{MODULE_DELIMITER}") }
       end
     end
 

--- a/spec/unit/hanami/slice_configurable_spec.rb
+++ b/spec/unit/hanami/slice_configurable_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe Hanami::SliceConfigurable, :app_integration do
     end
   end
 
+  context "subclass inside slice with name overlapping another slice" do
+    let(:app_modules) { super() << :ExternalAdmin }
+
+    before do
+      TestApp::App.register_slice :external_admin
+
+      module ExternalAdmin
+        class MySubclass < TestApp::BaseClass; end
+      end
+    end
+
+    subject(:subclass) { ExternalAdmin::MySubclass }
+
+    it "calls `configure_for_slice` with the correct matching slice" do
+      expect(subclass.traces).to eq [ExternalAdmin::Slice]
+    end
+  end
+
   context "class inside app" do
     before do
       module TestApp


### PR DESCRIPTION
This prevents issues in selecting the wrong slice when slice names overlap, e.g. the `Admin` slice being selected when a component inside the `ExternalAdmin` slice is loaded (due to the "Admin" being a substring of "ExternalAdmin").

Fixes #1299.