### PR TITLE
Configure part_class and scope_class for app views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "hanami-utils",      github: "hanami/utils",      branch: "main"
 gem "hanami-router",     github: "hanami/router",     branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
-gem "hanami-view",       github: "hanami/view",       branch: "main"
+gem "hanami-view",       github: "hanami/view",       branch: "configure-base-part-scope-classes"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "hanami-utils",      github: "hanami/utils",      branch: "main"
 gem "hanami-router",     github: "hanami/router",     branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
-gem "hanami-view",       github: "hanami/view",       branch: "configure-base-part-scope-classes"
+gem "hanami-view",       github: "hanami/view",       branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 

--- a/spec/integration/view/part_class_spec.rb
+++ b/spec/integration/view/part_class_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+RSpec.describe "App view / Part class", :app_integration do
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module TestApp
+          class View < Hanami::View
+          end
+        end
+      RUBY
+
+      before_app if respond_to?(:before_app)
+
+      require "hanami/prepare"
+    end
+  end
+
+  describe "app view" do
+    let(:view_class) { TestApp::View }
+
+    context "no concrete app part class defined" do
+      it "generates an app part class and configures it as the view's part_class" do
+        expect(view_class.config.part_class).to be TestApp::Views::Part
+        expect(view_class.config.part_class.superclass).to be Hanami::View::Part
+      end
+    end
+
+    context "concrete app part class defined" do
+      def before_app
+        write "app/views/part.rb", <<~RUBY
+          # auto_register: false
+
+          module TestApp
+            module Views
+              class Part < Hanami::View::Part
+                def self.concrete?
+                  true
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "configures the app part class as the view's part_class" do
+        expect(view_class.config.part_class).to be TestApp::Views::Part
+        expect(view_class.config.part_class).to be_concrete
+      end
+    end
+  end
+
+  describe "slice view" do
+    let(:view_class) { Main::View }
+
+    def before_app
+      write "slices/main/view.rb", <<~RUBY
+        # auto_register: false
+
+        module Main
+          class View < TestApp::View
+          end
+        end
+      RUBY
+    end
+
+    context "no concrete slice part class defined" do
+      it "generates a slice part class, inheriting from the app part class, and configures it as the view's part_class" do
+        expect(view_class.config.part_class).to be Main::Views::Part
+        expect(view_class.config.part_class.superclass).to be TestApp::Views::Part
+      end
+    end
+
+    context "concrete slice part class defined" do
+      def before_app
+        super
+
+        write "slices/main/views/part.rb", <<~RUBY
+          # auto_register: false
+
+          module Main
+            module Views
+              class Part < TestApp::Views::Part
+                def self.concrete?
+                  true
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "configures the slice part class as the view's part_class" do
+        expect(view_class.config.part_class).to be Main::Views::Part
+        expect(view_class.config.part_class).to be_concrete
+      end
+    end
+
+    context "view not inheriting from app view, no concrete part class" do
+      def before_app
+        write "slices/main/view.rb", <<~RUBY
+          # auto_register: false
+
+          module Main
+            class View < Hanami::View
+            end
+          end
+        RUBY
+      end
+
+      it "generates a slice part class, inheriting from the app part class, and configures it as the view's part_class" do
+        expect(view_class.config.part_class).to be Main::Views::Part
+        expect(view_class.config.part_class.superclass).to be TestApp::Views::Part
+      end
+    end
+
+    context "no app view class defined" do
+      def before_app
+        FileUtils.rm "app/view.rb"
+
+        write "slices/main/view.rb", <<~RUBY
+          # auto_register: false
+
+          module Main
+            class View < Hanami::View
+            end
+          end
+        RUBY
+      end
+
+      it "generates a slice part class, inheriting from Hanami::View::Part, and configures it as the view's part_class" do
+        expect(view_class.config.part_class).to be Main::Views::Part
+        expect(view_class.config.part_class.superclass).to be Hanami::View::Part
+      end
+    end
+  end
+end

--- a/spec/integration/view/scope_class_spec.rb
+++ b/spec/integration/view/scope_class_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+RSpec.describe "App view / Scope class", :app_integration do
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module TestApp
+          class View < Hanami::View
+          end
+        end
+      RUBY
+
+      before_app if respond_to?(:before_app)
+
+      require "hanami/prepare"
+    end
+  end
+
+  describe "app view" do
+    let(:view_class) { TestApp::View }
+
+    describe "no concrete app scope class defined" do
+      it "generates an app scope class and configures it as the view's scope_class" do
+        expect(view_class.config.scope_class).to be TestApp::Views::Scope
+        expect(view_class.config.scope_class.superclass).to be Hanami::View::Scope
+      end
+    end
+
+    describe "concrete app scope class defined" do
+      def before_app
+        write "app/views/scope.rb", <<~RUBY
+          # auto_register: false
+
+          module TestApp
+            module Views
+              class Scope < Hanami::View::Scope
+                def self.concrete?
+                  true
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "configures the app scope class as the view's scope_class" do
+        expect(view_class.config.scope_class).to be TestApp::Views::Scope
+        expect(view_class.config.scope_class).to be_concrete
+      end
+    end
+  end
+
+  describe "slice view" do
+    let(:view_class) { Main::View }
+
+    def before_app
+      write "slices/main/view.rb", <<~RUBY
+        # auto_register: false
+
+        module Main
+          class View < TestApp::View
+          end
+        end
+      RUBY
+    end
+
+    describe "no concrete app scope class defined" do
+      it "generates an app scope class and configures it as the view's scope_class" do
+        expect(view_class.config.scope_class).to be Main::Views::Scope
+        expect(view_class.config.scope_class.superclass).to be TestApp::Views::Scope
+      end
+    end
+
+    describe "concrete app scope class defined" do
+      def before_app
+        super
+
+        write "slices/main/views/scope.rb", <<~RUBY
+          # auto_register: false
+
+          module Main
+            module Views
+              class Scope < TestApp::Views::Scope
+                def self.concrete?
+                  true
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "configures the app scope class as the view's scope_class" do
+        expect(view_class.config.scope_class).to eq Main::Views::Scope
+        expect(view_class.config.scope_class).to be_concrete
+      end
+    end
+
+    context "view not inheriting from app view, no concrete scope class" do
+      def before_app
+        write "slices/main/view.rb", <<~RUBY
+          # auto_register: false
+
+          module Main
+            class View < Hanami::View
+            end
+          end
+        RUBY
+      end
+
+      it "generates a slice scope class, inheriting from the app scope class, and configures it as the view's scope_class" do
+        expect(view_class.config.scope_class).to be Main::Views::Scope
+        expect(view_class.config.scope_class.superclass).to be TestApp::Views::Scope
+      end
+    end
+
+    context "no app view class defined" do
+      def before_app
+        FileUtils.rm "app/view.rb"
+
+        write "slices/main/view.rb", <<~RUBY
+          # auto_register: false
+
+          module Main
+            class View < Hanami::View
+            end
+          end
+        RUBY
+      end
+
+      it "generates a slice scope class, inheriting from Hanami::View::Scope, and configures it as the view's scope_class" do
+        expect(view_class.config.scope_class).to be Main::Views::Scope
+        expect(view_class.config.scope_class.superclass).to be Hanami::View::Scope
+      end
+    end
+  end
+end


### PR DESCRIPTION
Update `SliceConfiguredView` to prepare part and scope classes for views.

This uses the `part_class` and `scope_class` view settings added in https://github.com/hanami/view/pull/227 and configures these with relevant classes for each slice.

If a concrete class is defined in `[root]/views/part.rb` or `[root]/views/scope.rb`, then these will be used. If not, these classes will be defined automatically and still configured.

For slices, if counterpart classes in the app exist, then they will be used as the superclasses (e.g. `Main::Views::Part` will inherit from `MyApp::Views::Part`, which itself would inherit from `Hanami::View::Part`).

Preparing dedicated part and scope classes here lays the groundwork for later on including a standard set of helper modules into these, to make Hanami helpers available everywhere across views.

