### PR TITLE
Include first-party helpers in view part scope classes

### DIFF
--- a/lib/hanami/extensions/view/slice_configured_view.rb
+++ b/lib/hanami/extensions/view/slice_configured_view.rb
@@ -21,6 +21,7 @@ module Hanami
         def extended(view_class)
           load_app_view
           configure_view(view_class)
+          include_helpers
           define_inherited
         end
 
@@ -109,6 +110,16 @@ module Hanami
           end
         end
         # rubocop:enable Metrics/AbcSize
+
+        def include_helpers
+          include_helpers_in(part_class)
+          include_helpers_in(scope_class)
+        end
+
+        def include_helpers_in(klass)
+          require "hanami/helpers/example_helper"
+          klass.include Helpers::ExampleHelper
+        end
 
         def define_inherited
           template_name = method(:template_name)

--- a/lib/hanami/helpers/example_helper.rb
+++ b/lib/hanami/helpers/example_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Helpers
+    # This is a temporary example helper module to demonstrate built-in helper integration.
+    #
+    # This will be removed when Hanami's proper first-party helpers are introduced.
+    #
+    # @api private
+    module ExampleHelper
+      module_function
+
+      # @api private
+      def exclaim(str)
+        "#{str}!"
+      end
+    end
+  end
+end

--- a/spec/integration/view/helpers/part_helpers_spec.rb
+++ b/spec/integration/view/helpers/part_helpers_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "ostruct"
+
+# rubocop:disable Style/OpenStructUse
+
+RSpec.describe "App view / Helpers / Part helpers", :app_integration do
+  before do
+    with_directory(make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module TestApp
+          class View < Hanami::View
+            config.layout = nil
+          end
+        end
+      RUBY
+
+      before_app if respond_to?(:before_app)
+
+      require "hanami/prepare"
+    end
+  end
+
+  describe "app view and parts" do
+    def before_app
+      write "app/views/posts/show.rb", <<~RUBY
+        module TestApp
+          module Views
+            module Posts
+              class Show < TestApp::View
+                expose :post
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/views/parts/post.rb", <<~RUBY
+        module TestApp
+          module Views
+            module Parts
+              class Post < TestApp::Views::Part
+                def title
+                  exclaim(value.title)
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/templates/posts/show.html.erb", <<~ERB
+        <h1><%= post.title %></h1>
+      ERB
+    end
+
+    it "makes default helpers available in templates" do
+      post = OpenStruct.new(title: "Hello world")
+      output = TestApp::App["views.posts.show"].call(post: post).to_s.strip
+
+      expect(output).to eq "<h1>Hello world!</h1>"
+    end
+  end
+
+  describe "slice view and parts" do
+    def before_app
+      write "slices/main/view.rb", <<~RUBY
+        module Main
+          class View < TestApp::View
+            # FIXME: base slice views should override paths from the base app view
+            config.paths = [File.join(File.expand_path(__dir__), "templates")]
+          end
+        end
+      RUBY
+
+      write "slices/main/views/posts/show.rb", <<~RUBY
+        module Main
+          module Views
+            module Posts
+              class Show < Main::View
+                expose :post
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/views/parts/post.rb", <<~RUBY
+        module Main
+          module Views
+            module Parts
+              class Post < Main::Views::Part
+                def title
+                  exclaim(value.title)
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/templates/posts/show.html.erb", <<~ERB
+        <h1><%= post.title %></h1>
+      ERB
+    end
+
+    it "makes default helpers available in templates" do
+      post = OpenStruct.new(title: "Hello world")
+      output = Main::Slice["views.posts.show"].call(post: post).to_s.strip
+
+      expect(output).to eq "<h1>Hello world!</h1>"
+    end
+  end
+end

--- a/spec/integration/view/helpers/scope_helpers_spec.rb
+++ b/spec/integration/view/helpers/scope_helpers_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe "App view / Helpers / Scope helpers", :app_integration do
+  before do
+    with_directory(make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module TestApp
+          class View < Hanami::View
+            config.layout = nil
+          end
+        end
+      RUBY
+
+      before_app if respond_to?(:before_app)
+
+      require "hanami/prepare"
+    end
+  end
+
+  describe "app view" do
+    def before_app
+      write "app/views/posts/show.rb", <<~RUBY
+        module TestApp
+          module Views
+            module Posts
+              class Show < TestApp::View
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/templates/posts/show.html.erb", <<~ERB
+        <h1><%= exclaim("Post") %></h1>
+      ERB
+    end
+
+    it "makes default helpers available in templates" do
+      output = TestApp::App["views.posts.show"].call.to_s.strip
+      expect(output).to eq "<h1>Post!</h1>"
+    end
+  end
+
+  describe "slice view" do
+    def before_app
+      write "slices/main/view.rb", <<~RUBY
+        module Main
+          class View < TestApp::View
+            # FIXME: base slice views should override paths from the base app view
+            config.paths = [File.join(File.expand_path(__dir__), "templates")]
+          end
+        end
+      RUBY
+
+      write "slices/main/views/posts/show.rb", <<~RUBY
+        module Main
+          module Views
+            module Posts
+              class Show < Main::View
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/templates/posts/show.html.erb", <<~ERB
+        <h1><%= exclaim("Post") %></h1>
+      ERB
+    end
+
+    it "makes default helpers available in templates" do
+      output = Main::Slice["views.posts.show"].call.to_s.strip
+      expect(output).to eq "<h1>Post!</h1>"
+    end
+  end
+end


### PR DESCRIPTION
Build on top of:

- https://github.com/hanami/view/pull/227, and
- https://github.com/hanami/hanami/pull/1303

and include (an example of) first-party helpers inside view part and scope classes, making those helpers available across every aspect of our views.