### PR TITLE
Fix content-length key of request env

### DIFF
--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -29,7 +29,7 @@ module Hanami
       ROUTER_PARAMS = "router.params"
       private_constant :ROUTER_PARAMS
 
-      CONTENT_LENGTH = "Content-Length"
+      CONTENT_LENGTH = "CONTENT_LENGTH"
       private_constant :CONTENT_LENGTH
 
       MILISECOND = "ms"

--- a/spec/unit/hanami/web/rack_logger_spec.rb
+++ b/spec/unit/hanami/web/rack_logger_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Hanami::Web::RackLogger do
       verb = "POST"
 
       env = Rack::MockRequest.env_for(path, method: verb)
-      env["Content-Length"] = content_length
+      env["CONTENT_LENGTH"] = content_length
       env["REMOTE_ADDR"] = ip
 
       params = {"user" => {"password" => "secret"}}


### PR DESCRIPTION
Problem
Given the following logging setting:

```
# config/app.rb

module Bookshelf
  class App < Hanami::App
    environment(:development) do
      config.logger.level = :info
      config.logger.formatter = :json
    end
  end
end
```

The rack-logger logs the following:

```
{"progname":"progname","severity":"INFO","time":"2023-04-21T07:26:41Z","verb":"POST","status":201,"ip":"127.0.0.1","path":"/bookshelfs","length":"-","params":{"item":"380bd332-500b-4a82-8d34-b420ac458ead"},"elapsed":1330121,"elapsed_unit":"µs"}
```

Even when we have response body, `"length"` is always `"-"`.

I found that request env has `"CONTENT_LENGTH"` key, not `"Content-Length"`.