### PR TITLE
Render nice errors

### DIFF
--- a/lib/hanami/extensions.rb
+++ b/lib/hanami/extensions.rb
@@ -10,3 +10,7 @@ if Hanami.bundled?("hanami-view")
   require_relative "extensions/view/part"
   require_relative "extensions/view/scope"
 end
+
+if Hanami.bundled?("hanami-router")
+  require_relative "extensions/router/errors"
+end

--- a/lib/hanami/extensions/router/errors.rb
+++ b/lib/hanami/extensions/router/errors.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "hanami/router"
+
+module Hanami
+  class Router
+    class NotFoundError < Hanami::Router::Error
+      def initialize(env)
+        @env = env
+        # TODO: generate helpful message
+        super()
+      end
+    end
+
+    class MethodNotAllowedError < Hanami::Router::Error
+    end
+  end
+end

--- a/lib/hanami/middleware/public_exceptions_app.rb
+++ b/lib/hanami/middleware/public_exceptions_app.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rack"
+
+module Hanami
+  module Middleware
+    class PublicExceptionsApp
+      attr_reader :public_path
+
+      def initialize(public_path)
+        @public_path = public_path
+      end
+
+      def call(env)
+        request = Rack::Request.new(env)
+        status = request.path_info[1..].to_i
+        content_type = request.get_header("HTTP_ACCEPT")
+
+        default_body = {
+          status: status,
+          error: Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500])
+        }
+
+        render(status, content_type, default_body)
+      end
+
+      private
+
+      def render(status, content_type, default_body)
+        body, rendered_content_type = render_content(status, content_type, default_body)
+
+        [
+          status,
+          {
+            "Content-Type" => "#{rendered_content_type}; charset=utf-8",
+            "Content-Length" => body.bytesize.to_s
+          },
+          [body]
+        ]
+      end
+
+      def render_content(status, content_type, default_body)
+        if content_type.to_s.start_with?("application/json")
+          require "json"
+          [JSON.generate(default_body), "application/json"]
+        else
+          [render_html_content(status, default_body), "text/html"]
+        end
+      end
+
+      def render_html_content(status, default_body)
+        path = "#{public_path}/#{status}.html"
+
+        if File.exist?(path)
+          File.read(path)
+        else
+          default_body[:error]
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/middleware/render_exceptions.rb
+++ b/lib/hanami/middleware/render_exceptions.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rack"
+
+# rubocop:disable Lint/RescueException
+
+module Hanami
+  module Middleware
+    class RenderExceptions
+      def initialize(app, exceptions_app)
+        @app = app
+        @exceptions_app = exceptions_app
+      end
+
+      def call(env)
+        @app.call(env)
+      rescue Exception => exception
+        request = Rack::Request.new(env)
+
+        if render_exceptions?(request)
+          render_exception(request, exception)
+        else
+          raise exception
+        end
+      end
+
+      private
+
+      def render_exceptions?(request)
+        # TODO: make configurable, store in request
+        true
+      end
+
+      def render_exception(request, exception)
+        wrapper = RenderableException.new(exception)
+
+        status = wrapper.status_code
+        request.path_info = "/#{status}"
+        request.set_header(Rack::REQUEST_METHOD, "GET")
+
+        @exceptions_app.call(request.env)
+      rescue Exception => failsafe_error
+        # rubocop:disable Style/StderrPuts
+        $stderr.puts "Error during exception rendering: #{failsafe_error}\n  #{failsafe_error.backtrace * "\n  "}"
+        # rubocop:enable Style/StderrPuts
+
+        [
+          500,
+          {"Content-Type" => "text/plain; charset=utf-8"},
+          ["Internal Server Error"]
+        ]
+      end
+    end
+  end
+end
+
+# rubocop:enable Lint/RescueException

--- a/lib/hanami/renderable_exception.rb
+++ b/lib/hanami/renderable_exception.rb
@@ -1,0 +1,35 @@
+require "rack"
+
+module Hanami
+  class RenderableException
+    extend Dry::Configurable
+
+    setting :rescue_responses, default: Hash.new(:internal_server_error).merge!(
+      "Hanami::Router::NotFoundError" => :not_found
+    )
+
+    def self.status_code_for_exception(class_name)
+      Rack::Utils.status_code(config.rescue_responses[class_name])
+    end
+
+    attr_reader :exception
+
+    def initialize(exception)
+      @exception = exception
+    end
+
+    def rescue_response?
+      config.rescue_responses.key?(exception.class.name)
+    end
+
+    def status_code
+      self.class.status_code_for_exception(exception.class.name)
+    end
+
+    private
+
+    def config
+      self.class.config
+    end
+  end
+end

--- a/spec/integration/web/render_errors_spec.rb
+++ b/spec/integration/web/render_errors_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "json"
+require "rack/test"
+
+RSpec.describe "Web / Rendering errors", :app_integration do
+  include Rack::Test::Methods
+
+  let(:app) { Hanami.app }
+
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File.new("/dev/null", "w")
+          end
+        end
+      RUBY
+
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Routes
+            get "error", to: "error"
+          end
+        end
+      RUBY
+
+      write "app/actions/error.rb", <<~RUBY
+        module TestApp
+          module Actions
+            class Error < Hanami::Action
+              def handle(*)
+                raise "oops"
+              end
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+    end
+  end
+
+  describe "HTML request" do
+    context "error pages present" do
+      before do
+        with_directory(@dir) do
+          write "public/404.html", <<~HTML
+            <h1>Not found</h1>
+          HTML
+
+          write "public/500.html", <<~HTML
+            <h1>Error</h1>
+          HTML
+        end
+      end
+
+      it "responds with the HTML for a 404" do
+        get "/foo"
+
+        expect(last_response.status).to eq 404
+        expect(last_response.body.strip).to eq "<h1>Not found</h1>"
+        expect(last_response.get_header("Content-Type")).to eq "text/html; charset=utf-8"
+        expect(last_response.get_header("Content-Length")).to eq "19"
+      end
+
+      it "responds with the HTML for a 500" do
+        get "/error"
+
+        expect(last_response.status).to eq 500
+        expect(last_response.body.strip).to eq "<h1>Error</h1>"
+        expect(last_response.get_header("Content-Type")).to eq "text/html; charset=utf-8"
+        expect(last_response.get_header("Content-Length")).to eq "15"
+      end
+    end
+
+    context "error pages missing" do
+      it "responds with default text for a 404" do
+        get "/foo"
+
+        expect(last_response.status).to eq 404
+        expect(last_response.body.strip).to eq "Not Found"
+        expect(last_response.get_header("Content-Type")).to eq "text/html; charset=utf-8"
+        expect(last_response.get_header("Content-Length")).to eq "9"
+      end
+
+      it "responds with default text for a 500" do
+        get "/error"
+
+        expect(last_response.status).to eq 500
+        expect(last_response.body.strip).to eq "Internal Server Error"
+        expect(last_response.get_header("Content-Type")).to eq "text/html; charset=utf-8"
+        expect(last_response.get_header("Content-Length")).to eq "21"
+      end
+    end
+  end
+
+  describe "JSON request" do
+    it "renders a JSON response for a 404" do
+      get "/foo", {}, "HTTP_ACCEPT" => "application/json"
+
+      expect(last_response.status).to eq 404
+      expect(last_response.body.strip).to eq %({"status":404,"error":"Not Found"})
+      expect(last_response.get_header("Content-Type")).to eq "application/json; charset=utf-8"
+      expect(last_response.get_header("Content-Length")).to eq "34"
+    end
+
+    it "renders a JSON response for a 500" do
+      get "/error", {}, "HTTP_ACCEPT" => "application/json"
+
+      expect(last_response.status).to eq 500
+      expect(last_response.body.strip).to eq %({"status":500,"error":"Internal Server Error"})
+      expect(last_response.get_header("Content-Type")).to eq "application/json; charset=utf-8"
+      expect(last_response.get_header("Content-Length")).to eq "46"
+    end
+  end
+end


### PR DESCRIPTION
TODO:

- [ ] `render_exceptions` config to turn this on/off; default to true in production mode
- [ ] Make `rescue_responses` from `RenderableException` configurable on the app too
- [ ] update hanami-router to handle `not_allowed` like `not_found`
- [ ] Figure out if we're happy with those extra hanami-router errors being here
- [ ] Inline docs
- [ ] A better fallback if there are no matching files in public/?