### PR TITLE
Fix double escaping of form values

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1289,7 +1289,6 @@ module Hanami
         # @api private
         # @since 2.0.0
         def _value(name)
-          # TODO: to_sym should not be necessary here
           values.get(*_split_input_name(name).map(&:to_sym))
         end
 

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1259,7 +1259,7 @@ module Hanami
             value: _value(name)
           }
           attrs.merge!(attributes)
-          attrs[:value] = escape_html(attrs[:value])
+          attrs[:value] = escape_html(attrs[:value]).html_safe
           attrs
         end
 

--- a/spec/integration/view/helpers/form_helper_spec.rb
+++ b/spec/integration/view/helpers/form_helper_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Helpers / FormHelper", :app_integration do
             module Posts
               class Edit < TestApp::View
                 expose :post do
-                  Struct.new(:title, :body).new("Hello world", "This is the post.")
+                  Struct.new(:title, :body).new("Hello <world>", "This is the post.")
                 end
               end
             end
@@ -132,7 +132,7 @@ RSpec.describe "Helpers / FormHelper", :app_integration do
     html = Capybara.string(last_response.body)
 
     title_field = html.find("input[name='post[title]']")
-    expect(title_field.value).to eq "Hello world"
+    expect(title_field.value).to eq "Hello <world>"
 
     body_field = html.find("textarea[name='post[body]']")
     expect(body_field.value).to eq "This is the post."

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2193,14 +2193,14 @@ RSpec.describe Hanami::Helpers::FormHelper do
 
     context "with values" do
       let(:values) { {book: Struct.new(:title).new(val)} }
-      let(:val)    { "PPoEA" }
+      let(:val)    { "Learn some <html>!" }
 
       it "renders with value" do
         html = form_for("/books", values: values) do |f|
           f.text_field "book.title"
         end
 
-        expect(html).to include %(<input type="text" name="book[title]" id="book-title" value="PPoEA">)
+        expect(html).to include %(<input type="text" name="book[title]" id="book-title" value="Learn some &lt;html&gt;!">)
       end
 
       it "allows to override 'value' attribute" do
@@ -2214,14 +2214,14 @@ RSpec.describe Hanami::Helpers::FormHelper do
 
     context "with filled params" do
       let(:params) { {book: {title: val}} }
-      let(:val)    { "PPoEA" }
+      let(:val)    { "Learn some <html>!" }
 
       it "renders with value" do
         html = form_for("/books") do |f|
           f.text_field "book.title"
         end
 
-        expect(html).to include %(<input type="text" name="book[title]" id="book-title" value="PPoEA">)
+        expect(html).to include %(<input type="text" name="book[title]" id="book-title" value="Learn some &lt;html&gt;!">)
       end
 
       it "allows to override 'value' attribute" do

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -537,8 +537,6 @@ RSpec.describe Hanami::Helpers::FormHelper do
 
   describe "#fieldset" do
     it "renders a fieldset" do
-      # TODO: work out whether to keep or remove fields_for here %>
-      # <% fields_for :author do %>
       html = render(<<~ERB)
         <%= form_for "/books" do |f| %>
           <%= f.fieldset do %>


### PR DESCRIPTION
While I was demoing our latest helpers to @andrewcroome, we noticed an issue where form values were being double-escaped, i.e. value of `"<hello>"` from the params or provided struct being turned into `"&amp;&lt;hello&amp;gt;"` instead of just `"&lt;hello&gt;"` (which will correctly render in the browser's field as `"<hello>"`).

This PR fixes that, while also removing a couple of stale "TODO" comments from the form helpers.

Here's what a corresponding form looks like now:

<img width="293" alt="Screenshot 2023-05-07 at 2 37 58 pm" src="https://user-images.githubusercontent.com/3134/236658915-eef7f726-b549-49ce-883a-4a7f5eb58c2a.png">
