### PR TITLE
Fix action/view integration when hanami-view is not bundled

### DIFF
--- a/lib/hanami/extensions/action/slice_configured_action.rb
+++ b/lib/hanami/extensions/action/slice_configured_action.rb
@@ -121,9 +121,11 @@ module Hanami
             slice: slice,
           )
 
-          view_identifiers.detect do |identifier|
-            break slice[identifier] if slice.key?(identifier)
+          view_identifiers.each do |identifier|
+            return slice[identifier] if slice.key?(identifier)
           end
+
+          nil
         end
 
         def resolve_view_context

--- a/lib/hanami/extensions/action/slice_configured_action.rb
+++ b/lib/hanami/extensions/action/slice_configured_action.rb
@@ -129,9 +129,19 @@ module Hanami
         end
 
         def resolve_view_context
-          return unless Extensions.const_defined?(:View)
+          if Hanami.bundled?("hanami-view")
+            return Extensions::View::Context.context_class(slice).new
+          end
 
-          Extensions::View::Context.context_class(slice).new
+          # If hanami-view isn't bundled, try and find a possible third party context class with the
+          # same `Views::Context` name (but don't fall back to automatically defining one).
+          if slice.namespace.const_defined?(:Views)
+            views_namespace = slice.namespace.const_get(:Views)
+
+            if views_namespace.const_defined?(:Context)
+              views_namespace.const_get(:Context).new
+            end
+          end
         end
 
         def resolve_routes


### PR DESCRIPTION
In our action integration, we should have been checking explicitly for whether hanami-view was bundled, rather than checking for the presence of the `Extensions::Views` const, which is automatically made available via Zeitwerk, and led to a `LoadError` when hanami-view was not bundled.

The only need we had for our action extension to reach into the view extension was for the shared code for loading the view context. Instead, we now explicitly check to see if hanami-view is bundled before using that code.

In addition, we add a fallback to look for a same-named context class in the conventional location, which would be useful if a 3rd party view layer was to be used.