### PR TITLE
Raise more helpful errors in view context extension

### DIFF
--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -76,10 +76,6 @@ module Hanami
 
             attr_reader :settings
 
-            attr_reader :routes
-
-            attr_reader :request
-
             # @see SliceConfiguredContext#define_new
             def initialize( # rubocop:disable Metrics/ParameterLists
               inflector: nil,
@@ -120,10 +116,26 @@ module Hanami
 
             def assets
               unless @assets
-                raise Hanami::ComponentLoadError, "hanami-assets gem is required to access assets"
+                raise Hanami::ComponentLoadError, "the hanami-assets gem is required to access assets"
               end
 
               @assets
+            end
+
+            def request
+              unless @request
+                raise Hanami::ComponentLoadError, "only views rendered from Hanami::Action instances have a request"
+              end
+
+              @request
+            end
+
+            def routes
+              unless @routes
+                raise Hanami::ComponentLoadError, "the hanami-router gem is required to access routes"
+              end
+
+              @routes
             end
 
             def content_for(key, value = nil)

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -97,9 +97,12 @@ module Hanami
             end
 
             def initialize_copy(source)
+              # The standard implementation of initialize_copy will make shallow copies of all
+              # instance variables from the source. This is fine for most of our ivars.
               super
 
-              # Dup objects that may be mutated over a given rendering
+              # Dup any objects that will be mutated over a given rendering to ensure no leakage of
+              # state across distinct view renderings.
               @content_for = source.instance_variable_get(:@content_for).dup
             end
 

--- a/spec/unit/hanami/extensions/view/context_spec.rb
+++ b/spec/unit/hanami/extensions/view/context_spec.rb
@@ -1,0 +1,59 @@
+require "hanami/view"
+require "hanami/view/context"
+require "hanami/extensions/view/context"
+
+RSpec.describe(Hanami::View::Context) do
+  subject(:context) { described_class.new(**args) }
+  let(:args) { {} }
+
+  describe "#assets" do
+    context "assets given" do
+      let(:args) { {assets: assets} }
+      let(:assets) { double(:assets) }
+
+      it "returns the assets" do
+        expect(context.assets).to be assets
+      end
+    end
+
+    context "no assets given" do
+      it "raises a Hanami::ComponentLoadError" do
+        expect { context.assets }.to raise_error Hanami::ComponentLoadError
+      end
+    end
+  end
+
+  describe "#request" do
+    context "request given" do
+      let(:args) { {request: request} }
+      let(:request) { double(:request) }
+
+      it "returns the request" do
+        expect(context.request).to be request
+      end
+    end
+
+    context "no request given" do
+      it "raises a Hanami::ComponentLoadError" do
+        expect { context.request }.to raise_error Hanami::ComponentLoadError
+      end
+    end
+  end
+
+  describe "#routes" do
+    context "routes given" do
+      let(:args) { {routes: routes} }
+      let(:routes) { double(:routes) }
+
+      it "returns the routes" do
+        expect(context.routes).to be routes
+      end
+    end
+
+    context "no routes given" do
+      it "raises a Hanami::ComponentLoadError" do
+        expect { context.routes }.to raise_error Hanami::ComponentLoadError
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follow the existing pattern we have of raising a ComponentLoadError when `@assets` is missing, and do the same for `@request` and `@routes`.

These error and messages should be enough to help the user identify the reason for the missing value and make corrections as required.