### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -611,8 +611,6 @@ The web, with simplicity.
 - [Marc Busqué] App settings are defined within a concrete class rather than an anonymous block, to allow for users to leverage the typical behavior of Ruby classes, such as for defining their own types module to use for coercing setting values. This class also relies on dry-configurable for its settings implementation, so the standard dry-configurable `setting` API is available, such as the `constructor:` and `default:` options.
 
   ```ruby
-  # frozen_string_literal: true
-
   require "dry/types"
   require "hanami/application/settings"
 
@@ -632,8 +630,6 @@ The web, with simplicity.
 - [Marc Busqué] Routes are defined within a concrete class rather than an anonymous block, to provide consistency with the settings (noted above), as well a place for additional behavior (in future releases):
 
   ```ruby
-  # frozen_string_literal: true
-
   require "hanami/application/routes"
 
   module MyApp
@@ -659,8 +655,6 @@ The web, with simplicity.
 - [Tim Riley] Dynamically create an auto-injection mixin (e.g. `Bookshelf::Deps`)
 
   ```ruby
-  # frozen_string_literal: true
-
   module Bookshelf
     class CreateThing
       include Deps[service_client: "some_service.client"]
@@ -723,8 +717,6 @@ The web, with simplicity.
 - [Luca Guidi] Main routes must be configured at `config/routes.rb`:
 
 ```ruby
-# frozen_string_literal: true
-
 Hanami.application.routes do
   mount :web, at: "/" do
     root to: "home#index"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "hanami/version"

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 require "zeitwerk"
 require_relative "hanami/constants"

--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "constants"
 require_relative "env"
 

--- a/lib/hanami/assets/app_config.rb
+++ b/lib/hanami/assets/app_config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 
 module Hanami

--- a/lib/hanami/assets/config.rb
+++ b/lib/hanami/assets/config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 
 module Hanami

--- a/lib/hanami/boot.rb
+++ b/lib/hanami/boot.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "setup"
 
 Hanami.boot

--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "uri"
 require "pathname"
 require "dry/configurable"

--- a/lib/hanami/config/actions.rb
+++ b/lib/hanami/config/actions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 
 module Hanami

--- a/lib/hanami/config/actions/content_security_policy.rb
+++ b/lib/hanami/config/actions/content_security_policy.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Config
     class Actions

--- a/lib/hanami/config/actions/cookies.rb
+++ b/lib/hanami/config/actions/cookies.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Config
     class Actions

--- a/lib/hanami/config/actions/sessions.rb
+++ b/lib/hanami/config/actions/sessions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/string"
 require "hanami/utils/class"
 

--- a/lib/hanami/config/logger.rb
+++ b/lib/hanami/config/logger.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 require "dry/logger"
 

--- a/lib/hanami/config/null_config.rb
+++ b/lib/hanami/config/null_config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 
 module Hanami

--- a/lib/hanami/config/router.rb
+++ b/lib/hanami/config/router.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 
 module Hanami

--- a/lib/hanami/config/views.rb
+++ b/lib/hanami/config/views.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 require "hanami/view"
 

--- a/lib/hanami/constants.rb
+++ b/lib/hanami/constants.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # @api private
   CONTAINER_KEY_DELIMITER = "."

--- a/lib/hanami/env.rb
+++ b/lib/hanami/env.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Env
     # @since 2.0.1

--- a/lib/hanami/errors.rb
+++ b/lib/hanami/errors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # Base class for all Hanami errors.
   #

--- a/lib/hanami/extensions.rb
+++ b/lib/hanami/extensions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if Hanami.bundled?("hanami-controller")
   require_relative "extensions/action"
 end

--- a/lib/hanami/extensions/action.rb
+++ b/lib/hanami/extensions/action.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/action"
 
 module Hanami

--- a/lib/hanami/extensions/action/slice_configured_action.rb
+++ b/lib/hanami/extensions/action/slice_configured_action.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Extensions
     module Action

--- a/lib/hanami/extensions/view.rb
+++ b/lib/hanami/extensions/view.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/view"
 
 module Hanami

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../errors"
 
 module Hanami

--- a/lib/hanami/extensions/view/part.rb
+++ b/lib/hanami/extensions/view/part.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Extensions
     module View

--- a/lib/hanami/extensions/view/scope.rb
+++ b/lib/hanami/extensions/view/scope.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Extensions
     module View

--- a/lib/hanami/extensions/view/slice_configured_context.rb
+++ b/lib/hanami/extensions/view/slice_configured_context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Extensions
     module View

--- a/lib/hanami/extensions/view/slice_configured_helpers.rb
+++ b/lib/hanami/extensions/view/slice_configured_helpers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Extensions
     module View

--- a/lib/hanami/extensions/view/slice_configured_view.rb
+++ b/lib/hanami/extensions/view/slice_configured_view.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Extensions
     module View

--- a/lib/hanami/extensions/view/standard_helpers.rb
+++ b/lib/hanami/extensions/view/standard_helpers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Extensions
     module View

--- a/lib/hanami/helpers/form_helper.rb
+++ b/lib/hanami/helpers/form_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/view"
 
 module Hanami

--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/view"
 require_relative "values"
 

--- a/lib/hanami/helpers/form_helper/values.rb
+++ b/lib/hanami/helpers/form_helper/values.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Helpers
     module FormHelper

--- a/lib/hanami/port.rb
+++ b/lib/hanami/port.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # @since 2.0.1
   # @api private

--- a/lib/hanami/prepare.rb
+++ b/lib/hanami/prepare.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "setup"
 
 Hanami.prepare

--- a/lib/hanami/providers/inflector.rb
+++ b/lib/hanami/providers/inflector.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # @api private
   module Providers

--- a/lib/hanami/providers/logger.rb
+++ b/lib/hanami/providers/logger.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # @api private
   module Providers

--- a/lib/hanami/providers/rack.rb
+++ b/lib/hanami/providers/rack.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # @api private
   module Providers

--- a/lib/hanami/providers/routes.rb
+++ b/lib/hanami/providers/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # @api private
   module Providers

--- a/lib/hanami/rake_tasks.rb
+++ b/lib/hanami/rake_tasks.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/cli"
 
 Hanami::CLI::RakeTasks.register_tasks do

--- a/lib/hanami/routes.rb
+++ b/lib/hanami/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "constants"
 require_relative "errors"
 
@@ -11,8 +9,6 @@ module Hanami
   #
   # @example
   #   # config/routes.rb
-  #   # frozen_string_literal: true
-  #
   #   require "hanami/routes"
   #
   #   module MyApp

--- a/lib/hanami/settings.rb
+++ b/lib/hanami/settings.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/constants"
 require "dry/configurable"
 require_relative "errors"
@@ -18,8 +16,6 @@ module Hanami
   #
   # @example
   #   # config/settings.rb
-  #   # frozen_string_literal: true
-  #
   #   module MyApp
   #     class Settings < Hanami::Settings
   #       Secret = Types::String.constrained(min_size: 20)

--- a/lib/hanami/settings/env_store.rb
+++ b/lib/hanami/settings/env_store.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/constants"
 
 module Hanami

--- a/lib/hanami/setup.rb
+++ b/lib/hanami/setup.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami"
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "zeitwerk"
 require "dry/system"
 

--- a/lib/hanami/slice/router.rb
+++ b/lib/hanami/slice/router.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router"
 
 module Hanami

--- a/lib/hanami/slice/routes_helper.rb
+++ b/lib/hanami/slice/routes_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Slice
     # Hanami app routes helpers

--- a/lib/hanami/slice/routing/middleware/stack.rb
+++ b/lib/hanami/slice/routing/middleware/stack.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router"
 require "hanami/middleware"
 require "hanami/middleware/app"

--- a/lib/hanami/slice/routing/resolver.rb
+++ b/lib/hanami/slice/routing/resolver.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../routes"
 
 module Hanami

--- a/lib/hanami/slice/view_name_inferrer.rb
+++ b/lib/hanami/slice/view_name_inferrer.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../constants"
 
 module Hanami

--- a/lib/hanami/slice_configurable.rb
+++ b/lib/hanami/slice_configurable.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "constants"
 require_relative "errors"
 

--- a/lib/hanami/slice_name.rb
+++ b/lib/hanami/slice_name.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "constants"
 
 module Hanami

--- a/lib/hanami/slice_registrar.rb
+++ b/lib/hanami/slice_registrar.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "constants"
 
 module Hanami

--- a/lib/hanami/version.rb
+++ b/lib/hanami/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # Hanami version
   #

--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # @api private
   module Web

--- a/spec/integration/action/cookies_spec.rb
+++ b/spec/integration/action/cookies_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App action / Cookies", :app_integration do
   before do
     module TestApp

--- a/spec/integration/action/csrf_protection_spec.rb
+++ b/spec/integration/action/csrf_protection_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App action / CSRF protection", :app_integration do
   before do
     module TestApp

--- a/spec/integration/action/format_config_spec.rb
+++ b/spec/integration/action/format_config_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "json"
 require "rack/test"
 

--- a/spec/integration/action/routes_spec.rb
+++ b/spec/integration/action/routes_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App action / Routes", :app_integration do
   specify "Access app routes from an action" do
     with_tmp_directory(Dir.mktmpdir) do

--- a/spec/integration/action/sessions_spec.rb
+++ b/spec/integration/action/sessions_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App action / Sessions", :app_integration do
   before do
     module TestApp

--- a/spec/integration/action/slice_configuration_spec.rb
+++ b/spec/integration/action/slice_configuration_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App action / Slice configuration", :app_integration do
   before do
     with_directory(@dir = make_tmp_directory) do

--- a/spec/integration/action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/action/view_rendering/automatic_rendering_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App action / View rendering / Automatic rendering", :app_integration do
   it "Renders a view automatically, passing all params and exposures" do
     within_app do

--- a/spec/integration/action/view_rendering/paired_view_inference_spec.rb
+++ b/spec/integration/action/view_rendering/paired_view_inference_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 RSpec.describe "App action / View rendering / Paired view inference", :app_integration do

--- a/spec/integration/action/view_rendering/view_context_spec.rb
+++ b/spec/integration/action/view_rendering/view_context_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App action / View rendering / View context", :app_integration do
   subject(:context) {
     # We capture the context during rendering via our view spies; see the view classes below

--- a/spec/integration/action/view_rendering_spec.rb
+++ b/spec/integration/action/view_rendering_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App action / View rendering", :app_integration do
   specify "Views render with a request-specific context object" do
     with_tmp_directory(Dir.mktmpdir) do

--- a/spec/integration/code_loading/loading_from_app_spec.rb
+++ b/spec/integration/code_loading/loading_from_app_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Code loading / Loading from app directory", :app_integration do
   before :context do
     with_directory(@dir = make_tmp_directory) do

--- a/spec/integration/code_loading/loading_from_lib_spec.rb
+++ b/spec/integration/code_loading/loading_from_lib_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Code loading / Loading from lib directory", :app_integration do
   describe "default root" do
     before :context do

--- a/spec/integration/code_loading/loading_from_slice_spec.rb
+++ b/spec/integration/code_loading/loading_from_slice_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Code loading / Loading from slice directory", :app_integration do
   before :context do
     with_directory(@dir = make_tmp_directory) do

--- a/spec/integration/container/application_routes_helper_spec.rb
+++ b/spec/integration/container/application_routes_helper_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "stringio"
 
 RSpec.describe "App routes helper", :app_integration do

--- a/spec/integration/container/auto_injection_spec.rb
+++ b/spec/integration/container/auto_injection_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Container auto-injection (aka \"Deps\") mixin", :app_integration do
   # rubocop:disable Metrics/MethodLength
   def with_app

--- a/spec/integration/container/auto_registration_spec.rb
+++ b/spec/integration/container/auto_registration_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Container auto-registration", :app_integration do
   specify "Auto-registering files in slice source directories" do
     with_tmp_directory(Dir.mktmpdir) do

--- a/spec/integration/container/imports_spec.rb
+++ b/spec/integration/container/imports_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Container imports", :app_integration do
   xspecify "App container is imported into slice containers by default" do
     with_tmp_directory(Dir.mktmpdir) do

--- a/spec/integration/container/prepare_container_spec.rb
+++ b/spec/integration/container/prepare_container_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Container / prepare_container", :app_integration do
   # (Most of) the examples below make their expectations on a `container_to_prepare`,
   # which is the container yielded to the `Slice.prepare_container` block _at the moment

--- a/spec/integration/container/provider_lifecycle_spec.rb
+++ b/spec/integration/container/provider_lifecycle_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Container / Provider lifecycle", :app_integration do
   let!(:slice) {
     module TestApp

--- a/spec/integration/container/shutdown_spec.rb
+++ b/spec/integration/container/shutdown_spec.rb
@@ -1,11 +1,7 @@
-# frozen_string_literal: true
-
 RSpec.describe "App shutdown", :app_integration do
   specify "App shutdown stops providers in both the app and slices" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/app.rb", <<~RUBY
-        # frozen_string_literal: true
-
         require "hanami"
 
         module TestApp
@@ -15,8 +11,6 @@ RSpec.describe "App shutdown", :app_integration do
       RUBY
 
       write "config/providers/connection.rb", <<~RUBY
-        # frozen_string_literal: true
-
         Hanami.app.register_provider :connection do
           prepare do
             module TestApp
@@ -45,8 +39,6 @@ RSpec.describe "App shutdown", :app_integration do
       RUBY
 
       write "slices/main/config/providers/connection.rb", <<~RUBY
-        # frozen_string_literal: true
-
         Main::Slice.register_provider :connection do
           prepare do
             module Main

--- a/spec/integration/dotenv_loading_spec.rb
+++ b/spec/integration/dotenv_loading_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # rubocop:disable Style/FetchEnvVar
 
 RSpec.describe "Dotenv loading", :app_integration do

--- a/spec/integration/rack_app/body_parser_spec.rb
+++ b/spec/integration/rack_app/body_parser_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "stringio"
 

--- a/spec/integration/rack_app/middleware_spec.rb
+++ b/spec/integration/rack_app/middleware_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "stringio"
 

--- a/spec/integration/rack_app/non_booted_rack_app_spec.rb
+++ b/spec/integration/rack_app/non_booted_rack_app_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "stringio"
 

--- a/spec/integration/rack_app/rack_app_spec.rb
+++ b/spec/integration/rack_app/rack_app_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "stringio"
 

--- a/spec/integration/settings/access_in_slice_class_body_spec.rb
+++ b/spec/integration/settings/access_in_slice_class_body_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Settings / Access within slice class bodies", :app_integration do
   before do
     @env = ENV.to_h

--- a/spec/integration/settings/access_to_constants_spec.rb
+++ b/spec/integration/settings/access_to_constants_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Settings / Access to constants", :app_integration do
   before do
     @env = ENV.to_h

--- a/spec/integration/settings/loading_from_env_spec.rb
+++ b/spec/integration/settings/loading_from_env_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Settings / Access to constants", :app_integration do
   before do
     @env = ENV.to_h

--- a/spec/integration/settings/settings_component_loading_spec.rb
+++ b/spec/integration/settings/settings_component_loading_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Settings / Component loading", :app_integration do
   describe "Settings are loaded from a class defined in config/settings.rb" do
     specify "in app" do

--- a/spec/integration/settings/slice_registration_spec.rb
+++ b/spec/integration/settings/slice_registration_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Settings / Slice registration", :app_integration do
   specify "Settings are registered for each slice with a settings file" do
     with_tmp_directory(Dir.mktmpdir) do
@@ -16,8 +14,6 @@ RSpec.describe "Settings / Slice registration", :app_integration do
 
       # The main slice has settings
       write "slices/main/config/settings.rb", <<~RUBY
-        # frozen_string_literal: true
-
         require "hanami/settings"
 
         module Main
@@ -53,8 +49,6 @@ RSpec.describe "Settings / Slice registration", :app_integration do
           RUBY
 
           write "config/settings.rb", <<~'RUBY'
-            # frozen_string_literal: true
-
             require "hanami/settings"
 
             module TestApp
@@ -65,8 +59,6 @@ RSpec.describe "Settings / Slice registration", :app_integration do
           RUBY
 
           write "slices/main/config/settings.rb", <<~RUBY
-            # frozen_string_literal: true
-
             require "hanami/settings"
 
             module Main
@@ -104,8 +96,6 @@ RSpec.describe "Settings / Slice registration", :app_integration do
           RUBY
 
           write "config/settings.rb", <<~'RUBY'
-            # frozen_string_literal: true
-
             require "hanami/settings"
 
             module TestApp
@@ -116,8 +106,6 @@ RSpec.describe "Settings / Slice registration", :app_integration do
           RUBY
 
           write "slices/main/config/settings.rb", <<~RUBY
-            # frozen_string_literal: true
-
             require "hanami/settings"
 
             module Main

--- a/spec/integration/settings/using_types_spec.rb
+++ b/spec/integration/settings/using_types_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/settings"
 
 RSpec.describe "Settings / Using types", :app_integration do

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami setup", :app_integration do
   describe "Hanami.setup" do
     shared_examples "hanami setup" do

--- a/spec/integration/slices/external_slice_spec.rb
+++ b/spec/integration/slices/external_slice_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "stringio"
 

--- a/spec/integration/slices/slice_configuration_spec.rb
+++ b/spec/integration/slices/slice_configuration_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "stringio"
 
 RSpec.describe "Slices / Slice configuration", :app_integration do

--- a/spec/integration/slices/slice_loading_spec.rb
+++ b/spec/integration/slices/slice_loading_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 
 RSpec.describe "Slices / Slice loading", :app_integration, :aggregate_failures do

--- a/spec/integration/slices/slice_registrations_spec.rb
+++ b/spec/integration/slices/slice_registrations_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Slice Registrations", :app_integration do
   matcher :have_key do |name, value|
     match do |slice|

--- a/spec/integration/slices/slice_routing_spec.rb
+++ b/spec/integration/slices/slice_routing_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "stringio"
 

--- a/spec/integration/slices_spec.rb
+++ b/spec/integration/slices_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Slices", :app_integration do
   it "Loading a slice uses a defined slice class" do
     with_tmp_directory(Dir.mktmpdir) do

--- a/spec/integration/view/config/default_context_spec.rb
+++ b/spec/integration/view/config/default_context_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App view / Config / Default context", :app_integration do
   before do
     with_directory(@dir = make_tmp_directory) do

--- a/spec/integration/view/config/inflector_spec.rb
+++ b/spec/integration/view/config/inflector_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 RSpec.describe "App view / Config / Inflector", :app_integration do

--- a/spec/integration/view/config/part_class_spec.rb
+++ b/spec/integration/view/config/part_class_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App view / Config / Part class", :app_integration do
   before do
     with_directory(make_tmp_directory) do

--- a/spec/integration/view/config/part_namespace_spec.rb
+++ b/spec/integration/view/config/part_namespace_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 RSpec.describe "App view / Config / Part namespace", :app_integration do

--- a/spec/integration/view/config/paths_spec.rb
+++ b/spec/integration/view/config/paths_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 RSpec.describe "App view / Config / Paths", :app_integration do

--- a/spec/integration/view/config/scope_class_spec.rb
+++ b/spec/integration/view/config/scope_class_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App view / Config / Scope class", :app_integration do
   before do
     with_directory(@dir = make_tmp_directory) do

--- a/spec/integration/view/config/scope_namespace_spec.rb
+++ b/spec/integration/view/config/scope_namespace_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 RSpec.describe "App view / Config / Scope namespace", :app_integration do

--- a/spec/integration/view/config/template_spec.rb
+++ b/spec/integration/view/config/template_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 RSpec.describe "App view / Config / Template", :app_integration do

--- a/spec/integration/view/context/assets_spec.rb
+++ b/spec/integration/view/context/assets_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 RSpec.describe "App view / Context / Assets", :app_integration do

--- a/spec/integration/view/context/routes_spec.rb
+++ b/spec/integration/view/context/routes_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 RSpec.describe "App view / Context / Routes", :app_integration do

--- a/spec/integration/view/context/settings_spec.rb
+++ b/spec/integration/view/context/settings_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 require "hanami/settings"
 

--- a/spec/integration/view/helpers/form_helper_spec.rb
+++ b/spec/integration/view/helpers/form_helper_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 require "stringio"
 

--- a/spec/integration/view/helpers/part_helpers_spec.rb
+++ b/spec/integration/view/helpers/part_helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "ostruct"
 
 # rubocop:disable Style/OpenStructUse

--- a/spec/integration/view/helpers/scope_helpers_spec.rb
+++ b/spec/integration/view/helpers/scope_helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App view / Helpers / Scope helpers", :app_integration do
   before do
     with_directory(make_tmp_directory) do

--- a/spec/integration/view/helpers/user_defined_helpers/part_helpers_spec.rb
+++ b/spec/integration/view/helpers/user_defined_helpers/part_helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "ostruct"
 
 # rubocop:disable Style/OpenStructUse

--- a/spec/integration/view/helpers/user_defined_helpers/scope_helpers_spec.rb
+++ b/spec/integration/view/helpers/user_defined_helpers/scope_helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App view / Helpers / User-defined helpers / Scope helpers", :app_integration do
   before do
     with_directory(make_tmp_directory) do

--- a/spec/integration/view/slice_configuration_spec.rb
+++ b/spec/integration/view/slice_configuration_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "App view / Slice configuration", :app_integration do
   before do
     with_directory(@dir = make_tmp_directory) do

--- a/spec/integration/view/views_spec.rb
+++ b/spec/integration/view/views_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami view integration", :app_integration do
   specify "Views take their configuration from their slice in which they are defined" do
     with_tmp_directory(Dir.mktmpdir) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 
 SPEC_ROOT = File.expand_path(__dir__).freeze

--- a/spec/support/app_integration.rb
+++ b/spec/support/app_integration.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/integration/files"
 require "hanami/devtools/integration/with_tmp_directory"
 require "tmpdir"

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module RSpec
   module Support
     module Matchers

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/shared_examples/cli/generate/app.rb
+++ b/spec/support/shared_examples/cli/generate/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/string"
 
 RSpec.shared_examples "a new app" do

--- a/spec/support/shared_examples/cli/generate/migration.rb
+++ b/spec/support/shared_examples/cli/generate/migration.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/string"
 
 RSpec.shared_examples "a new migration" do

--- a/spec/support/shared_examples/cli/generate/model.rb
+++ b/spec/support/shared_examples/cli/generate/model.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/string"
 
 RSpec.shared_examples "a new model" do

--- a/spec/support/shared_examples/cli/new.rb
+++ b/spec/support/shared_examples/cli/new.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/string"
 
 RSpec.shared_examples "a new project" do

--- a/spec/unit/hanami/config/actions/content_security_policy_spec.rb
+++ b/spec/unit/hanami/config/actions/content_security_policy_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config/actions"
 
 RSpec.describe Hanami::Config::Actions, "#content_security_policy" do

--- a/spec/unit/hanami/config/actions/cookies_spec.rb
+++ b/spec/unit/hanami/config/actions/cookies_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config/actions"
 
 RSpec.describe Hanami::Config::Actions, "#cookies" do

--- a/spec/unit/hanami/config/actions/csrf_protection_spec.rb
+++ b/spec/unit/hanami/config/actions/csrf_protection_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config/actions"
 
 RSpec.describe Hanami::Config::Actions, "#csrf_protection" do

--- a/spec/unit/hanami/config/actions/default_values_spec.rb
+++ b/spec/unit/hanami/config/actions/default_values_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config/actions"
 
 RSpec.describe Hanami::Config::Actions, "default values" do

--- a/spec/unit/hanami/config/actions/sessions_spec.rb
+++ b/spec/unit/hanami/config/actions/sessions_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config/actions"
 
 RSpec.describe Hanami::Config::Actions, "#sessions" do

--- a/spec/unit/hanami/config/actions_spec.rb
+++ b/spec/unit/hanami/config/actions_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config"
 require "hanami/action"
 

--- a/spec/unit/hanami/config/base_url_spec.rb
+++ b/spec/unit/hanami/config/base_url_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config"
 require "uri"
 

--- a/spec/unit/hanami/config/inflector_spec.rb
+++ b/spec/unit/hanami/config/inflector_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config"
 
 RSpec.describe Hanami::Config do

--- a/spec/unit/hanami/config/logger_spec.rb
+++ b/spec/unit/hanami/config/logger_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config/logger"
 require "hanami/slice_name"
 require "dry/inflector"

--- a/spec/unit/hanami/config/router_spec.rb
+++ b/spec/unit/hanami/config/router_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config"
 
 RSpec.describe Hanami::Config, "#router" do

--- a/spec/unit/hanami/config/slices_spec.rb
+++ b/spec/unit/hanami/config/slices_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/inflector"
 require "hanami/config"
 require "hanami/slice_name"

--- a/spec/unit/hanami/config/views_spec.rb
+++ b/spec/unit/hanami/config/views_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/config"
 require "saharspec/matchers/dont"
 

--- a/spec/unit/hanami/env_spec.rb
+++ b/spec/unit/hanami/env_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami, ".env" do
   subject(:env) { described_class.env }
 

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/helpers/form_helper"
 require "hanami/view/erb/template"
 

--- a/spec/unit/hanami/port_spec.rb
+++ b/spec/unit/hanami/port_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/port"
 
 RSpec.describe Hanami::Port do

--- a/spec/unit/hanami/settings/env_store_spec.rb
+++ b/spec/unit/hanami/settings/env_store_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/settings/env_store"
 
 RSpec.describe Hanami::Settings::EnvStore do

--- a/spec/unit/hanami/settings_spec.rb
+++ b/spec/unit/hanami/settings_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/settings"
 
 RSpec.describe Hanami::Settings do

--- a/spec/unit/hanami/slice_configurable_spec.rb
+++ b/spec/unit/hanami/slice_configurable_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/app"
 require "hanami/slice_configurable"
 

--- a/spec/unit/hanami/slice_name_spec.rb
+++ b/spec/unit/hanami/slice_name_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/slice_name"
 
 require "dry/inflector"

--- a/spec/unit/hanami/version_spec.rb
+++ b/spec/unit/hanami/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami::VERSION" do
   it "returns current version" do
     expect(Hanami::VERSION).to eq("2.0.3")

--- a/spec/unit/hanami/web/rack_logger_spec.rb
+++ b/spec/unit/hanami/web/rack_logger_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/web/rack_logger"
 require "dry/logger"
 require "stringio"


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.