### PR TITLE
Fix body parser middleware already in use check.

### DIFF
--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -434,7 +434,7 @@ module Hanami
       return unless Hanami.bundled?("hanami-controller")
 
       return if actions.formats.empty?
-      return if middleware.stack["/"].map(&:first).any? { |klass| klass == "Hanami::Middleware::BodyParser" }
+      return if middleware.stack["/"].map(&:first).any? { |klass| klass == Hanami::Middleware::BodyParser }
 
       parsers = SUPPORTED_MIDDLEWARE_PARSERS & actions.formats.values
       return if parsers.empty?


### PR DESCRIPTION
In an app that has multiple slices I noticed that `BodyParser` middleware added the same amount of times as the number of slices. After some investigation I ended up with this line that incorrectly checks for already added Body parser. 

Make sure we check for middleware's class name as a constant, not a string since that's what we have in middleware stack.