### PR TITLE
Fix an issue where the rack app was being re-initialised for every re…

### DIFF
--- a/lib/hanami/application.rb
+++ b/lib/hanami/application.rb
@@ -150,7 +150,7 @@ module Hanami
     # @api private
     def initialize
       @renderer   = RenderingPolicy.new(configuration)
-      @middleware = configuration.middleware
+      @middleware = configuration.middleware.to_app
     end
 
     # Process a request.

--- a/lib/hanami/middleware_stack.rb
+++ b/lib/hanami/middleware_stack.rb
@@ -39,17 +39,11 @@ module Hanami
       self
     end
 
-    # Process a request.
-    # This method makes the middleware stack compatible with the Rack protocol.
+    # Return the rack application.
     #
-    # @param env [Hash] a Rack env
-    #
-    # @return [Array] a serialized Rack response
-    #
-    # @since 0.1.0
     # @api private
-    def call(env)
-      builder.call(env)
+    def to_app
+      builder.to_app
     end
 
     # Append a middleware to the stack.


### PR DESCRIPTION
…quest

This took me a while to track down, but when we switched over to using memcached based seasions using the dalli gem we noticed that we were leaking memcache connections:

The culprit was this bit of code: https://github.com/petergoldstein/dalli/blob/main/lib/rack/session/dalli.rb#L70

As Hanami was re-initalising the app on every single request:

https://github.com/hanami/hanami/blob/1.3.x/lib/hanami/middleware_stack.rb#L52

Because the call method on for the rack builder was calling `to_app` on every request:

https://github.com/rack/rack/blob/da03bfab6497ab05e9ed795f5d3c033e47927483/lib/rack/builder.rb#L276

I am not sure if this is the correct way to fix this? or it was intended that the rack app should be re-initalised on every request?

Also I am not sure if this is present in Hanami v2 either

