### PR TITLE
API URL pointing to rdoc.info does not work properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can give back to Open Source, by supporting Hanami development via [GitHub S
 * Guides: https://guides.hanamirb.org
 * Snippets: https://snippets.hanamirb.org
 * Mailing List: http://hanamirb.org/mailing-list
-* API Doc: http://rdoc.info/gems/hanami
+* API Doc: https://gemdocs.org/gems/hanami/latest
 * Bugs/Issues: https://github.com/hanami/hanami/issues
 * Stack Overflow: http://stackoverflow.com/questions/tagged/hanami
 * Forum: https://discourse.hanamirb.org


### PR DESCRIPTION
Fixed this by pointing to the gemdocs.org instead
