### PR TITLE
Return appropriate response statuses based on error type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
 gem "hanami-view",       github: "hanami/view",       branch: "main"
 gem "hanami-assets",     github: "hanami/assets",     branch: "main"
-gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
+gem "hanami-webconsole", github: "hanami/webconsole", branch: "correct-status-codes"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
 gem "hanami-view",       github: "hanami/view",       branch: "main"
 gem "hanami-assets",     github: "hanami/assets",     branch: "main"
-gem "hanami-webconsole", github: "hanami/webconsole", branch: "correct-status-codes"
+gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 

--- a/lib/hanami/middleware/render_errors.rb
+++ b/lib/hanami/middleware/render_errors.rb
@@ -56,18 +56,15 @@ module Hanami
       def call(env)
         @app.call(env)
       rescue Exception => exception
-        request = Rack::Request.new(env)
+        raise unless @config.render_errors
 
-        if @config.render_errors
-          render_exception(request, exception)
-        else
-          raise exception
-        end
+        render_exception(env, exception)
       end
 
       private
 
-      def render_exception(request, exception)
+      def render_exception(env, exception)
+        request = Rack::Request.new(env)
         renderable = RenderableException.new(exception, responses: @config.render_error_responses)
 
         status = renderable.status_code

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -952,8 +952,11 @@ module Hanami
         config = self.config
         rack_monitor = self["rack.monitor"]
 
+        render_errors = render_errors?
+        render_detailed_errors = render_detailed_errors?
+
         error_handlers = {}.tap do |hsh|
-          if render_errors?
+          if render_errors || render_detailed_errors
             hsh[:not_allowed] = ROUTER_NOT_ALLOWED_HANDLER
             hsh[:not_found] = ROUTER_NOT_FOUND_HANDLER
           end
@@ -974,7 +977,7 @@ module Hanami
             Hanami::Middleware::PublicErrorsApp.new(slice.root.join("public"))
           )
 
-          if config.render_detailed_errors && Hanami.bundled?("hanami-webconsole")
+          if render_detailed_errors
             require "hanami/webconsole"
             use(Hanami::Webconsole::Middleware, config)
           end
@@ -988,8 +991,11 @@ module Hanami
       end
 
       def render_errors?
-        config.render_errors ||
-          (config.render_detailed_errors && Hanami.bundled?("hanami-webconsole"))
+        config.render_errors
+      end
+
+      def render_detailed_errors?
+        config.render_detailed_errors && Hanami.bundled?("hanami-webconsole")
       end
 
       ROUTER_NOT_ALLOWED_HANDLER = -> env, allowed_http_methods {

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -976,7 +976,7 @@ module Hanami
 
           if config.render_detailed_errors && Hanami.bundled?("hanami-webconsole")
             require "hanami/webconsole"
-            use(Hanami::Webconsole::Middleware)
+            use(Hanami::Webconsole::Middleware, config)
           end
 
           if Hanami.bundled?("hanami-controller") && config.actions.sessions.enabled?

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -952,16 +952,18 @@ module Hanami
         config = self.config
         rack_monitor = self["rack.monitor"]
 
-        render_errors =
-          config.render_errors ||
-          (config.render_detailed_errors && Hanami.bundled?("hanami-webconsole"))
+        error_handlers = {}.tap do |hsh|
+          if render_errors?
+            hsh[:not_allowed] = ROUTER_NOT_ALLOWED_HANDLER
+            hsh[:not_found] = ROUTER_NOT_FOUND_HANDLER
+          end
+        end
 
         Slice::Router.new(
           inspector: inspector,
           routes: routes,
           resolver: config.router.resolver.new(slice: self),
-          not_allowed: ROUTER_NOT_ALLOWED_HANDLER.curry[render_errors],
-          not_found: ROUTER_NOT_FOUND_HANDLER.curry[render_errors],
+          **error_handlers,
           **config.router.options
         ) do
           use(rack_monitor)
@@ -985,21 +987,18 @@ module Hanami
         end
       end
 
-      ROUTER_NOT_ALLOWED_HANDLER = -> render_errors, env, allowed_http_methods {
-        if render_errors
-          raise Hanami::Router::NotAllowedError.new(env, allowed_http_methods)
-        end
+      def render_errors?
+        config.render_errors ||
+          (config.render_detailed_errors && Hanami.bundled?("hanami-webconsole"))
+      end
 
-        Hanami::Router::NOT_ALLOWED.call(env, allowed_http_methods)
+      ROUTER_NOT_ALLOWED_HANDLER = -> env, allowed_http_methods {
+        raise Hanami::Router::NotAllowedError.new(env, allowed_http_methods)
       }.freeze
       private_constant :ROUTER_NOT_ALLOWED_HANDLER
 
-      ROUTER_NOT_FOUND_HANDLER = -> render_errors, env {
-        if render_errors
-          raise Hanami::Router::NotFoundError.new(env)
-        end
-
-        Hanami::Router::NOT_FOUND.call(env)
+      ROUTER_NOT_FOUND_HANDLER = -> env {
+        raise Hanami::Router::NotFoundError.new(env)
       }.freeze
       private_constant :ROUTER_NOT_FOUND_HANDLER
 

--- a/spec/integration/rack_app/middleware_spec.rb
+++ b/spec/integration/rack_app/middleware_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe "Hanami web app", :app_integration do
     it "excludes not found routes in root scope" do
       get "/foo"
 
-      expect(last_response.status).to eq 500
+      expect(last_response.status).to eq 404
       expect(last_response.headers).to_not have_key("X-Auth-User-ID")
     end
 
@@ -333,7 +333,7 @@ RSpec.describe "Hanami web app", :app_integration do
       it "does not uses the Rack middleware for not found paths" do
         get "/admin/users"
 
-        expect(last_response.status).to eq 500
+        expect(last_response.status).to eq 404
         expect(last_response.headers).not_to have_key("X-Auth-User-ID")
       end
     end
@@ -600,7 +600,7 @@ RSpec.describe "Hanami web app", :app_integration do
     it "does not use Rack middleware for other paths" do
       get "/__not_found__"
 
-      expect(last_response.status).to eq 500
+      expect(last_response.status).to eq 404
       expect(last_response.headers).not_to have_key("X-Identifier-Root")
       expect(last_response.headers).not_to have_key("X-Elapsed")
       expect(last_response.headers).not_to have_key("X-Auth-User-ID")
@@ -623,7 +623,7 @@ RSpec.describe "Hanami web app", :app_integration do
       it "uses Rack middleware for other paths" do
         get "/admin/__not_found__"
 
-        expect(last_response.status).to eq 500
+        expect(last_response.status).to eq 404
         expect(last_response.headers).not_to have_key("X-Identifier-Admin")
         expect(last_response.headers).not_to have_key("X-Elapsed")
         expect(last_response.headers).not_to have_key("X-Elapsed")

--- a/spec/integration/web/render_detailed_errors_spec.rb
+++ b/spec/integration/web/render_detailed_errors_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe "Web / Rendering detailed errors", :app_integration do
       expect(html).to have_selector("header", text: "RuntimeError at /error")
       expect(html).to have_selector("ul.frames li.application", text: "app/actions/error.rb")
     end
+
+    it "renders a detailed HTML error page and returns a 404 status for a not found error" do
+      get "/__not_found__", {}, "HTTP_ACCEPT" => "text/html"
+
+      expect(last_response.status).to eq 404
+
+      html = Capybara.string(last_response.body)
+      expect(html).to have_selector("header", text: "Hanami::Router::NotFoundError at /__not_found__")
+    end
   end
 
   describe "Other request types" do
@@ -66,6 +75,14 @@ RSpec.describe "Web / Rendering detailed errors", :app_integration do
 
       expect(last_response.body).to include "RuntimeError at /error"
       expect(last_response.body).to match %r{App backtrace.+app/actions/error.rb}m
+    end
+
+    it "renders a detailed error page in text and returns a 404 status for a not found error" do
+      get "/__not_found__", {}, "HTTP_ACCEPT" => "text/html"
+
+      expect(last_response.status).to eq 404
+
+      expect(last_response.body).to include "Hanami::Router::NotFoundError at /__not_found__"
     end
   end
 

--- a/spec/integration/web/render_errors_spec.rb
+++ b/spec/integration/web/render_errors_spec.rb
@@ -225,12 +225,14 @@ RSpec.describe "Web / Rendering errors", :app_integration do
       HTML
     end
 
-    it "raises a Hanami::Router::NotFoundError for a 404" do
-      expect { get "/__not_found__" }.to raise_error(Hanami::Router::NotFoundError)
+    it "renders the hanami-router default 404 response for a not found error" do
+      get "/__not_found__"
+      expect(last_response.status).to eq 404
     end
 
-    it "raises a Hanami::Router::NotAllowedError for a 405" do
-      expect { post "/index" }.to raise_error(Hanami::Router::NotAllowedError)
+    it "renders the hanami-router default 405 response for a not allowed error" do
+      post "/index"
+      expect(last_response.status).to eq 405
     end
 
     it "raises the original error for a 500" do


### PR DESCRIPTION
Properly return 404 errors when the app is called with not found routes.

To do this, cover two scenarios:

- When hanami-webconsole **is not bundled**, or when `app.config.render_detailed_errors` is false, then do not provide our custom `not_allowed` and `not_found` procs to the slice's router instance. This means that the `Hanami::Router` default responses will be returned for these cases, which include the appropriate error codes.
- When hanami-webconsole **is bundled**, and when `app.config.render_detailed_errors` is true (which will be the default for all new Hanami 2.1 apps), then rely on the changes in https://github.com/hanami/webconsole/pull/7 to capture the error rescued by `BetterErrors::Middleware` and then re-apply an appropriate response code based on the `app.config.render_error_responses` setting that we already use to map exceptions to response types. This is a nice reuse of this existing setting (which was previously only used for the production-mode `render_errors` middleware) and provides greater consistency across both dev and production mode.

Resolves #1327.