### PR TITLE
Add favicon helper alias for favicon_link_tag

### DIFF
--- a/lib/hanami/helpers/assets_helper.rb
+++ b/lib/hanami/helpers/assets_helper.rb
@@ -417,6 +417,10 @@ module Hanami
         tag.link(**attributes)
       end
 
+      # @api public
+      # @since 2.1.0
+      alias_method :favicon, :favicon_link_tag
+
       # Generate `video` tag for given source
       #
       # It accepts one string representing the name of the asset, if it comes

--- a/spec/unit/hanami/helpers/assets_helper/favicon_link_tag_spec.rb
+++ b/spec/unit/hanami/helpers/assets_helper/favicon_link_tag_spec.rb
@@ -50,9 +50,13 @@ RSpec.describe Hanami::Helpers::AssetsHelper, "#favicon_link_tag", :app_integrat
     end
   end
 
-  it "returns an instance of HtmlBuilder" do
+  it "returns an instance of SafeString" do
     actual = favicon_link_tag
     expect(actual).to be_instance_of(::Hanami::View::HTML::SafeString)
+  end
+
+  it "is aliased as `favicon`" do
+    expect(subject.favicon).to eq favicon_link_tag
   end
 
   it "renders <link> tag" do

--- a/spec/unit/hanami/helpers/assets_helper/javascript_tag_spec.rb
+++ b/spec/unit/hanami/helpers/assets_helper/javascript_tag_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe Hanami::Helpers::AssetsHelper, "#javascript_tag", :app_integratio
     expect(actual).to be_instance_of(::Hanami::View::HTML::SafeString)
   end
 
+  it "is aliased as `js`" do
+    expect(subject.js("feature-a")).to eq javascript_tag("feature-a")
+  end
+
   it "renders <script> tag" do
     actual = javascript_tag("feature-a")
     expect(actual).to eq(%(<script src="/assets/feature-a.js" type="text/javascript"></script>))

--- a/spec/unit/hanami/helpers/assets_helper/stylesheet_link_tag_spec.rb
+++ b/spec/unit/hanami/helpers/assets_helper/stylesheet_link_tag_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe Hanami::Helpers::AssetsHelper, "#stylesheet_link_tag", :app_integ
     expect(actual).to be_instance_of(::Hanami::View::HTML::SafeString)
   end
 
+  it "is aliased as `css`" do
+    expect(subject.css("main")).to eq stylesheet_link_tag("main")
+  end
+
   it "renders <link> tag" do
     actual = stylesheet_link_tag("main")
     expect(actual).to eq(%(<link href="/assets/main.css" type="text/css" rel="stylesheet">))


### PR DESCRIPTION
Make sure we have a helper that will work for the standard layout we'll be generating in https://github.com/hanami/cli/pull/99.