### PR TITLE
Rake task for hanami-assets: `bundle exec rake assets:precompile`

### DIFF
--- a/lib/hanami/config/null_config.rb
+++ b/lib/hanami/config/null_config.rb
@@ -9,6 +9,9 @@ module Hanami
     # loaded)
     class NullConfig
       include Dry::Configurable
+
+      def finalize!(*)
+      end
     end
   end
 end

--- a/lib/hanami/rake_tasks.rb
+++ b/lib/hanami/rake_tasks.rb
@@ -10,7 +10,7 @@ Hanami::CLI::RakeTasks.register_tasks do
 
   # Ruby ecosystem compatibility
   #
-  # Most of the SaaS automatic tasks are designed after Ruby on Rails.
+  # Most of the hosting SaaS automatic tasks are designed after Ruby on Rails.
   # They expect the following Rake tasks to be present:
   #
   #   * db:migrate
@@ -20,31 +20,32 @@ Hanami::CLI::RakeTasks.register_tasks do
   #
   # ===
   #
-  # These Rake tasks aren't listed when someone runs `rake -T`, because we
-  # want to encourage developers to use `hanami` commands.
+  # These Rake tasks are **NOT** listed when someone runs `rake -T`, because we
+  # want to encourage developers to use `hanami` CLI commands.
   #
-  # In order to migrate the database or precompile assets a developer should
-  # use:
+  # In order to migrate the database or compile assets a developer should use:
   #
   #   * hanami db migrate
-  #   * hanami assets precompile
+  #   * hanami assets compile
   #
   # This is the preferred way to run Hanami command line tasks.
   # Please use them when you're in control of your deployment environment.
   #
   # If you're not in control and your deployment requires these "standard"
   # Rake tasks, they are here to solve this only specific problem.
-  namespace :db do
-    task :migrate do
-      # TODO(@jodosha): Enable when we'll integrate with ROM
-      # run_hanami_command("db migrate")
-    end
-  end
+  #
+  # namespace :db do
+  #   task :migrate do
+  #     # TODO(@jodosha): Enable when we'll integrate with ROM
+  #     # run_hanami_command("db migrate")
+  #   end
+  # end
 
-  namespace :assets do
-    task :precompile do
-      # TODO(@jodosha): Enable when we'll integrate with hanami-assets
-      # run_hanami_command("assets precompile")
+  if Hanami.bundled?("hanami-assets")
+    namespace :assets do
+      task :precompile do
+        run_hanami_command("assets compile")
+      end
     end
   end
 
@@ -53,7 +54,7 @@ Hanami::CLI::RakeTasks.register_tasks do
   @_hanami_cli_bundler = Hanami::CLI::Bundler.new
 
   def run_hanami_command(command)
-    @_hanami_cli_bundler.exec(command)
+    @_hanami_cli_bundler.hanami_exec(command)
   end
 end
 

--- a/spec/integration/rake_tasks_spec.rb
+++ b/spec/integration/rake_tasks_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rake"
+require "hanami/cli"
+
+RSpec.describe "Rake tasks", :app_integration do
+  describe "assets:precompile" do
+    before do
+      allow(Hanami).to receive(:bundled?)
+      allow(Hanami).to receive(:bundled?).with("hanami-assets").and_return(hanami_assets_bundled)
+    end
+
+    context "when hanami-assets is bundled" do
+      let(:hanami_assets_bundled) { true }
+
+      xit "compiles assets" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+              end
+            end
+          RUBY
+
+          write "Rakefile", <<~RUBY
+            # frozen_string_literal: true
+
+            require "hanami/rake_tasks"
+          RUBY
+
+          write "app/assets/js/app.js", <<~JS
+            console.log("Hello from index.js");
+          JS
+
+          before_prepare if respond_to?(:before_prepare)
+          require "hanami/prepare"
+
+          expect_any_instance_of(Hanami::CLI::Bundler).to receive(:hanami_exec).with("assets compile").and_return(true)
+
+          Rake::Task["assets:precompile"].invoke
+        end
+      end
+
+      it "doesn't list the task" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+              end
+            end
+          RUBY
+
+          write "Rakefile", <<~RUBY
+            # frozen_string_literal: true
+
+            require "hanami/rake_tasks"
+          RUBY
+
+          before_prepare if respond_to?(:before_prepare)
+          require "hanami/prepare"
+
+          output = `bundle exec rake -T`
+          expect(output).to_not include("assets:precompile")
+        end
+      end
+    end
+
+    context "when hanami-assets is not bundled" do
+      let(:hanami_assets_bundled) { false }
+    end
+  end
+end

--- a/spec/integration/rake_tasks_spec.rb
+++ b/spec/integration/rake_tasks_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rake"
-require "hanami/cli"
+require "hanami/cli/bundler"
 
 RSpec.describe "Rake tasks", :app_integration do
   describe "assets:precompile" do
@@ -71,6 +71,37 @@ RSpec.describe "Rake tasks", :app_integration do
 
     context "when hanami-assets is not bundled" do
       let(:hanami_assets_bundled) { false }
+
+      it "raises error" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+              end
+            end
+          RUBY
+
+          write "Rakefile", <<~RUBY
+            # frozen_string_literal: true
+
+            require "hanami/rake_tasks"
+          RUBY
+
+          write "app/assets/js/app.js", <<~JS
+            console.log("Hello from index.js");
+          JS
+
+          before_prepare if respond_to?(:before_prepare)
+          require "hanami/prepare"
+
+          expect { Rake::Task["assets:precompile"].invoke }.to raise_error do |exception|
+            expect(exception).to be_a(RuntimeError)
+            expect(exception.message).to match(/Don't know how to build task 'assets:precompile'/)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/hanami/hanami/issues/1335

---

⚠️ Note for the reviewers: if you try to list the Rake tasks in a Hanami app (`rake -T`), this Rake task will NOT show on purpose.

We want to encourage developers to use the `hanami` CLI. In this case to use `bundle exec hanami assets compile`.
This Rake task is here only for compatibility with the most common Ruby hosting, that expect this Rake task to be present, because of Ruby on Rails.