### PR TITLE
Automatically mount `Rack::MethodOverride`

### DIFF
--- a/lib/hanami/config/actions.rb
+++ b/lib/hanami/config/actions.rb
@@ -74,6 +74,20 @@ module Hanami
       # @since 2.0.0
       attr_accessor :content_security_policy
 
+      # @!attribute [rw] method_override
+      #   Sets or returns whether HTTP method override should be enabled for action classes.
+      #
+      #   Defaults to true. You can override this by explicitly setting a
+      #   true or false value.
+      #
+      #   When true, this will mount `Rack::MethodOverride` in the Rack middleware stack of the App.
+      #
+      #   @return [Boolean]
+      #
+      #   @api public
+      #   @since 2.1.0
+      setting :method_override, default: true
+
       # The following settings are for view and assets integration with actions, and are NOT
       # publicly released as of 2.0.0. We'll make full documentation available when these become
       # public in a subsequent release.

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -982,8 +982,15 @@ module Hanami
             use(Hanami::Webconsole::Middleware, config)
           end
 
-          if Hanami.bundled?("hanami-controller") && config.actions.sessions.enabled?
-            use(*config.actions.sessions.middleware)
+          if Hanami.bundled?("hanami-controller")
+            if config.actions.method_override
+              require "rack/method_override"
+              use(Rack::MethodOverride)
+            end
+
+            if config.actions.sessions.enabled?
+              use(*config.actions.sessions.middleware)
+            end
           end
 
           if Hanami.bundled?("hanami-assets") && config.assets.serve

--- a/spec/integration/rack_app/method_override_spec.rb
+++ b/spec/integration/rack_app/method_override_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rack/test"
+require "stringio"
+
+RSpec.describe "Hanami web app: Method Override", :app_integration do
+  include Rack::Test::Methods
+
+  let(:app) { Hanami.app }
+
+  around do |example|
+    with_tmp_directory(Dir.mktmpdir, &example)
+  end
+
+  context "enabled by default" do
+    before do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = StringIO.new
+          end
+        end
+      RUBY
+
+      generate_app_code
+    end
+
+    it "overrides the original HTTP method" do
+      post(
+        "/users/:id",
+        {"_method" => "PUT"},
+        "CONTENT_TYPE" => "multipart/form-data"
+      )
+
+      expect(last_response).to be_successful
+      expect(last_response.body).to eq("PUT")
+    end
+  end
+
+  context "when disabled" do
+    before do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = StringIO.new
+            config.actions.method_override = false
+          end
+        end
+      RUBY
+
+      generate_app_code
+    end
+
+    it "overrides the original HTTP method" do
+      post(
+        "/users/:id",
+        {"_method" => "PUT"},
+        "CONTENT_TYPE" => "multipart/form-data"
+      )
+
+      expect(last_response).to_not be_successful
+      expect(last_response.status).to be(404)
+    end
+  end
+
+  private
+
+  def generate_app_code
+    write "config/routes.rb", <<~RUBY
+      module TestApp
+        class Routes < Hanami::Routes
+          put "/users/:id", to: "users.update"
+        end
+      end
+    RUBY
+
+    write "app/actions/users/update.rb", <<~RUBY
+      module TestApp
+        module Actions
+          module Users
+            class Update < Hanami::Action
+              def handle(req, res)
+                res.body = req.env.fetch("REQUEST_METHOD")
+              end
+            end
+          end
+        end
+      end
+    RUBY
+
+    require "hanami/boot"
+  end
+end


### PR DESCRIPTION
## Enhancement

Enable by default _method override_ by mounting `Rack::MethodOverride` middleware.

Users can opt out via the following app setting (in `config/app.rb`):

```ruby
require "hanami"

module TestApp
  class App < Hanami::App
    config.actions.method_override = false
  end
end
```

---

Closes #1343 