### PR TITLE
Refactor `SliceRegistrar#load_slice` to avoid an exception

### DIFF
--- a/lib/hanami/slice_registrar.rb
+++ b/lib/hanami/slice_registrar.rb
@@ -101,11 +101,12 @@ module Hanami
     # at `slices/[slice_name]`. Attempts to require the slice class, if defined, before registering
     # the slice. If a slice class is not found, registering the slice will generate the slice class.
     def load_slice(slice_name)
-      slice_require_path = root.join(CONFIG_DIR, SLICES_DIR, slice_name).to_s
+      slice_require_path = root.join(CONFIG_DIR, SLICES_DIR, slice_name)
+
       begin
-        require(slice_require_path)
+        require(slice_require_path.to_s) if slice_require_path.sub_ext(RB_EXT).file?
       rescue LoadError => e
-        raise e unless e.path == slice_require_path
+        raise e unless e.path == slice_require_path.to_s
       end
 
       slice_class =

--- a/lib/hanami/slice_registrar.rb
+++ b/lib/hanami/slice_registrar.rb
@@ -102,12 +102,7 @@ module Hanami
     # the slice. If a slice class is not found, registering the slice will generate the slice class.
     def load_slice(slice_name)
       slice_require_path = root.join(CONFIG_DIR, SLICES_DIR, slice_name)
-
-      begin
-        require(slice_require_path.to_s) if slice_require_path.sub_ext(RB_EXT).file?
-      rescue LoadError => e
-        raise e unless e.path == slice_require_path.to_s
-      end
+      require(slice_require_path.to_s) if slice_require_path.sub_ext(RB_EXT).file?
 
       slice_class =
         begin


### PR DESCRIPTION
Currently we are trying to require a file that we aren't sure exists and
rescuing the `LoadError` that we get if it doesn't. 

We can completely avoid an exception per slice for the knowable case
where this file doesn't exist by first checking using `Pathname#sub_ext`
to add the `RB_EXT` extension to the path and then making use of
`Pathname#file?` on the resulting path.