### PR TITLE
Render a welcome page when no routes are defined

### DIFF
--- a/lib/hanami/routes.rb
+++ b/lib/hanami/routes.rb
@@ -64,7 +64,7 @@ module Hanami
     # method that returns true if no routes were defined.
     #
     # This is useful when needing to determine behaviour based on the presence of user-defined
-    # routes, such as when determining to show the Hanami welcome page in {Slice#load_router}.
+    # routes, such as determining whether to show the Hanami welcome page in {Slice#load_router}.
     #
     # @api private
     # @since 2.1.0

--- a/lib/hanami/routes.rb
+++ b/lib/hanami/routes.rb
@@ -60,7 +60,7 @@ module Hanami
       end
     end
 
-    # Wrapper class for the (otherwise opqaque) proc returned from {.routes}, adding an `#empty?`
+    # Wrapper class for the (otherwise opaque) proc returned from {.routes}, adding an `#empty?`
     # method that returns true if no routes were defined.
     #
     # This is useful when needing to determine behaviour based on the presence of user-defined

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -952,6 +952,7 @@ module Hanami
         config = self.config
         rack_monitor = self["rack.monitor"]
 
+        show_welcome = Hanami.env?(:development) && routes.empty?
         render_errors = render_errors?
         render_detailed_errors = render_detailed_errors?
 
@@ -970,6 +971,8 @@ module Hanami
           **config.router.options
         ) do
           use(rack_monitor)
+
+          use(Hanami::Web::Welcome) if show_welcome
 
           use(
             Hanami::Middleware::RenderErrors,

--- a/lib/hanami/web/welcome.html.erb
+++ b/lib/hanami/web/welcome.html.erb
@@ -1,0 +1,5 @@
+<h1>Hello world from Hanami</h1>
+
+<p>Hanami version: <%= hanami_version %></p>
+
+<p>Ruby version: <%= ruby_version %></p>

--- a/lib/hanami/web/welcome.rb
+++ b/lib/hanami/web/welcome.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "erb"
+
+module Hanami
+  # @api private
+  module Web
+    # Middleware that renders a welcome view in fresh Hanami apps.
+    #
+    # @api private
+    # @since 2.1.0
+    class Welcome
+      # @api private
+      # @since 2.1.0
+      def initialize(app)
+        @app = app
+      end
+
+      # @api private
+      # @since 2.1.0
+      def call(env)
+        request_path = env["REQUEST_PATH"] || ""
+        request_host = env["HTTP_HOST"] || ""
+
+        template_path = File.join(__dir__, "welcome.html.erb")
+        body = [ERB.new(File.read(template_path)).result(binding)]
+
+        [200, {}, body]
+      end
+
+      private
+
+      # @api private
+      # @since 2.1.0
+      def hanami_version
+        Hanami::VERSION
+      end
+
+      # @api private
+      # @since 2.1.0
+      def ruby_version
+        RUBY_VERSION
+      end
+    end
+  end
+end

--- a/spec/integration/web/welcome_view_spec.rb
+++ b/spec/integration/web/welcome_view_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "json"
+require "rack/test"
+
+RSpec.describe "Web / Welcome view", :app_integration do
+  include Rack::Test::Methods
+
+  let(:app) { Hanami.app }
+
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Routes
+          end
+        end
+      RUBY
+
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  context "no routes defined" do
+    it "renders the welcome page" do
+      get "/"
+
+      body = last_response.body.strip
+      expect(body).to include "<h1>Hello world from Hanami</h1>"
+      expect(body).to include "Hanami version: #{Hanami::VERSION}"
+      expect(body).to include "Ruby version: #{RUBY_VERSION}"
+
+      expect(last_response.status).to eq 200
+    end
+  end
+
+  context "routes defined" do
+    def before_prepare
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Routes
+            root to: -> * { [200, {}, "Hello from a route"] }
+          end
+        end
+      RUBY
+    end
+
+    it "does not render the welcome page" do
+      get "/"
+
+      expect(last_response.body).to eq "Hello from a route"
+      expect(last_response.status).to eq 200
+    end
+  end
+
+  context "non-development env" do
+    def before_prepare
+      @hanami_env = ENV["HANAMI_ENV"]
+      ENV["HANAMI_ENV"] = "production"
+    end
+
+    after do
+      ENV["HANAMI_ENV"] = @hanami_env
+    end
+
+    it "does not render the welcome page" do
+      get "/"
+
+      expect(last_response.body).to eq "Not Found"
+      expect(last_response.status).to eq 404
+    end
+  end
+end


### PR DESCRIPTION
The page includes the current Hanami and Ruby versions. Design and content for this page will be added in a later change.

The page is rendered by a new `Hanami::Web::Welcome` middleware that is added as the first in the stack when (a) in development mode, and (b) when no routes are defined.

To support this introspection into the routes (which are passed to the router as an opaque block), wrap the routes in a `RoutesProc` class that adds an `#empty?` method, returning true when no routes are defined.

Resolves #1350.