### PR TITLE
Use an intermediary `helpers` object on view parts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "hanami-utils",      github: "hanami/utils",      branch: "main"
 gem "hanami-router",     github: "hanami/router",     branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
-gem "hanami-view",       github: "hanami/view",       branch: "main"
+gem "hanami-view",       github: "hanami/view",       branch: "remove-module-function-from-helpers"
 gem "hanami-assets",     github: "hanami/assets",     branch: "main"
 gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "hanami-utils",      github: "hanami/utils",      branch: "main"
 gem "hanami-router",     github: "hanami/router",     branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-cli",        github: "hanami/cli",        branch: "main"
-gem "hanami-view",       github: "hanami/view",       branch: "remove-module-function-from-helpers"
+gem "hanami-view",       github: "hanami/view",       branch: "main"
 gem "hanami-assets",     github: "hanami/assets",     branch: "main"
 gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 

--- a/lib/hanami/extensions/view/part.rb
+++ b/lib/hanami/extensions/view/part.rb
@@ -57,7 +57,7 @@ module Hanami
         attr_reader :_context
 
         # @api public
-        # @since 2.1.10
+        # @since 2.1.0
         alias_method :context, :_context
 
         # @api private

--- a/lib/hanami/extensions/view/part.rb
+++ b/lib/hanami/extensions/view/part.rb
@@ -4,19 +4,66 @@ module Hanami
   module Extensions
     module View
       # @api private
+      # @since 2.1.0
       module Part
         def self.included(part_class)
           super
 
           part_class.extend(Hanami::SliceConfigurable)
-          part_class.include(StandardHelpers)
           part_class.extend(ClassMethods)
         end
 
         module ClassMethods
           def configure_for_slice(slice)
-            extend SliceConfiguredHelpers.new(slice)
+            const_set :PartHelpers, Class.new(PartHelpers) { |klass|
+              klass.configure_for_slice(slice)
+            }
           end
+        end
+
+        # Returns an object including the default Hanami helpers as well as the user-defined helpers
+        # for the part's slice.
+        #
+        # Use this when you need to access helpers inside your part classes.
+        #
+        # @return PartHelpers
+        #
+        # @api public
+        # @since 2.1.0
+        def helpers
+          @helpers ||= self.class.const_get(:PartHelpers).new(context: _context)
+        end
+      end
+
+      # Standalone helpers class including both {StandardHelpers} as well as the user-defined
+      # helpers for the slice.
+      #
+      # Used used where helpers should be addressed via an intermediary object (i.e. in parts),
+      # rather than mixed into a class directly.
+      #
+      # @api private
+      # @since 2.1.0
+      class PartHelpers
+        extend Hanami::SliceConfigurable
+
+        include StandardHelpers
+
+        def self.configure_for_slice(slice)
+          extend SliceConfiguredHelpers.new(slice)
+        end
+
+        # @api public
+        # @since 2.1.0
+        attr_reader :_context
+
+        # @api public
+        # @since 2.1.10
+        alias_method :context, :_context
+
+        # @api private
+        # @since 2.1.0
+        def initialize(context:)
+          @_context = context
         end
       end
     end

--- a/spec/integration/view/helpers/part_helpers_spec.rb
+++ b/spec/integration/view/helpers/part_helpers_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "App view / Helpers / Part helpers", :app_integration do
             module Parts
               class Post < TestApp::Views::Part
                 def number
-                  format_number(value.number)
+                  helpers.format_number(value.number)
                 end
               end
             end
@@ -99,7 +99,7 @@ RSpec.describe "App view / Helpers / Part helpers", :app_integration do
             module Parts
               class Post < Main::Views::Part
                 def number
-                  format_number(value.number)
+                  helpers.format_number(value.number)
                 end
               end
             end

--- a/spec/integration/view/helpers/user_defined_helpers/part_helpers_spec.rb
+++ b/spec/integration/view/helpers/user_defined_helpers/part_helpers_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "App view / Helpers / User-defined helpers / Scope helpers", :app
           module Views
             module Helpers
               def exclaim_from_app(str)
-                tag.h1("#{str}! (app helper)")
+                tag.h1("#{str}! (app #{_context.inflector.pluralize('helper')})")
               end
             end
           end
@@ -65,7 +65,7 @@ RSpec.describe "App view / Helpers / User-defined helpers / Scope helpers", :app
             module Parts
               class Post < TestApp::Views::Part
                 def title
-                  exclaim_from_app(value.title)
+                  helpers.exclaim_from_app(value.title)
                 end
               end
             end
@@ -78,11 +78,11 @@ RSpec.describe "App view / Helpers / User-defined helpers / Scope helpers", :app
       ERB
     end
 
-    it "makes user-defined helpers available in parts" do
+    it "makes user-defined helpers available in parts via a `helpers` object" do
       post = OpenStruct.new(title: "Hello world")
       output = TestApp::App["views.posts.show"].call(post: post).to_s.strip
 
-      expect(output).to eq "<h1>Hello world! (app helper)</h1>"
+      expect(output).to eq "<h1>Hello world! (app helpers)</h1>"
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe "App view / Helpers / User-defined helpers / Scope helpers", :app
           module Views
             module Helpers
               def exclaim_from_slice(str)
-                tag.h1("#{str}! (slice helper)")
+                tag.h1("#{str}! (slice #{_context.inflector.pluralize('helper')})")
               end
             end
           end
@@ -129,11 +129,11 @@ RSpec.describe "App view / Helpers / User-defined helpers / Scope helpers", :app
             module Parts
               class Post < Main::Views::Part
                 def title
-                  exclaim_from_slice(value.title)
+                  helpers.exclaim_from_slice(value.title)
                 end
 
                 def title_from_app
-                  exclaim_from_app(value.title)
+                  helpers.exclaim_from_app(value.title)
                 end
               end
             end
@@ -147,13 +147,13 @@ RSpec.describe "App view / Helpers / User-defined helpers / Scope helpers", :app
       ERB
     end
 
-    it "makes user-defined helpers (from app as well as slice) available in parts" do
+    it "makes user-defined helpers (from app as well as slice) available in parts via a `helpers` object" do
       post = OpenStruct.new(title: "Hello world")
       output = Main::Slice["views.posts.show"].call(post: post).to_s
 
       expect(output).to eq <<~HTML
-        <h1>Hello world! (slice helper)</h1>
-        <h1>Hello world! (app helper)</h1>
+        <h1>Hello world! (slice helpers)</h1>
+        <h1>Hello world! (app helpers)</h1>
       HTML
     end
   end


### PR DESCRIPTION
Instead of mixing the standard helpers directly into part classes (which runs a high risk of naming collisions, given parts wrap all kinds of objects), instead create an intermediary `helpers` object that contains all the helper methods.

This relies on a small change to the standard helper module interfaces (to make their methods remain public when included) in https://github.com/hanami/view/pull/242.

Resolves #1348.