### PR TITLE
Provide default renderings to app/slice view parts

### DIFF
--- a/lib/hanami/extensions/view/part.rb
+++ b/lib/hanami/extensions/view/part.rb
@@ -15,6 +15,8 @@ module Hanami
 
         module ClassMethods
           def configure_for_slice(slice)
+            extend SliceConfiguredPart.new(slice)
+
             const_set :PartHelpers, Class.new(PartHelpers) { |klass|
               klass.configure_for_slice(slice)
             }

--- a/lib/hanami/extensions/view/slice_configured_part.rb
+++ b/lib/hanami/extensions/view/slice_configured_part.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Extensions
+    module View
+      # Provides slice-specific configuration and behavior for any view part class defined within a
+      # slice's module namespace.
+      #
+      # @api private
+      # @since 2.1.0
+      class SliceConfiguredPart < Module
+        attr_reader :slice
+
+        # @api private
+        # @since 2.1.0
+        def initialize(slice)
+          super()
+          @slice = slice
+        end
+
+        # @api private
+        # @since 2.1.0
+        def extended(klass)
+          define_new
+        end
+
+        # @api private
+        # @since 2.1.0
+        def inspect
+          "#<#{self.class.name}[#{slice.name}]>"
+        end
+
+        private
+
+        # Defines a `.new` method on the part class that provides a default `rendering:` argument of
+        # a rendering coming from a view configured for the slice. This means that any part can be
+        # initialized standalone (with a `value:` only) and still have access to all the integrated
+        # view facilities from the slice, such as helpers. This is helpful when unit testing parts.
+        #
+        # @example
+        #   module MyApp::Views::Parts
+        #     class Post < MyApp::View::Part
+        #       def title_tag
+        #         helpers.h1(value.title)
+        #       end
+        #     end
+        #   end
+        #
+        #   # Useful when unit testing parts
+        #   part = MyApp::Views::Parts::Post.new(value: hello_world_post)
+        #   part.title_tag # => "<h1>Hello world</h1>"
+        #
+        # @api private
+        # @since 2.1.0
+        def define_new
+          slice = self.slice
+
+          define_method(:new) do |**args|
+            return super(**args) if args.key?(:rendering)
+
+            slice_rendering = Class.new(Hanami::View)
+              .configure_for_slice(slice)
+              .new
+              .rendering
+
+            super(rendering: slice_rendering, **args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/extensions/view/slice_configured_view.rb
+++ b/lib/hanami/extensions/view/slice_configured_view.rb
@@ -108,7 +108,7 @@ module Hanami
           #   - We are a slice, and the view's inherited `paths` is identical to the parent's config
           #     (which would result in the view in a slice erroneously trying to find templates in
           #     the app)
-          if (!slice.parent && view_class.config.paths.empty?) ||
+          if view_class.config.paths.empty? ||
              (slice.parent && view_class.config.paths.map(&:dir) == [templates_path(slice.parent)])
             view_class.config.paths = templates_path(slice)
           end
@@ -178,7 +178,7 @@ module Hanami
             else
               views_namespace.const_set(:Part, Class.new(part_superclass).tap { |klass|
                 # Give the slice to `configure_for_slice`, since it cannot be inferred when it is
-                # called via `.inherited`, since the class is anonymous at this point
+                # called via `.inherited`, because the class is anonymous at this point
                 klass.configure_for_slice(slice)
               })
             end

--- a/spec/integration/view/parts/default_rendering_spec.rb
+++ b/spec/integration/view/parts/default_rendering_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+RSpec.describe "App view / Parts / Default rendering", :app_integration do
+  before do
+    with_directory(make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module TestApp
+          class View < Hanami::View
+            config.layout = nil
+          end
+        end
+      RUBY
+
+      write "app/views/part.rb", <<~RUBY
+        # auto_register: false
+
+        module TestApp
+          module Views
+            class Part < Hanami::View::Part
+            end
+          end
+        end
+      RUBY
+
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  describe "app part" do
+    def before_prepare
+      write "app/views/helpers.rb", <<~RUBY
+        # auto_register: false
+
+        module TestApp
+          module Views
+            module Helpers
+              def app_screaming_snake_case(str)
+                _context.inflector
+                  .underscore(str)
+                  .gsub(/\s+/, "_")
+                  .upcase + "!"
+              end
+            end
+          end
+        end
+      RUBY
+      write "app/views/parts/post.rb", <<~RUBY
+        # auto_register: false
+
+        module TestApp
+          module Views
+            module Parts
+              class Post < TestApp::Views::Part
+                def title_tag
+                  helpers.tag.h1(helpers.app_screaming_snake_case(value.title))
+                end
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "provides a default rendering from the app" do
+      post = Struct.new(:title).new("Hello world")
+      part = TestApp::Views::Parts::Post.new(value: post)
+
+      expect(part.title_tag).to eq "<h1>HELLO_WORLD!</h1>"
+    end
+  end
+
+  describe "slice part" do
+    def before_prepare
+      write "slices/main/views/helpers.rb", <<~RUBY
+        # auto_register: false
+
+        module Main
+          module Views
+            module Helpers
+              def slice_screaming_snake_case(str)
+                _context.inflector
+                  .underscore(str)
+                  .gsub(/\s+/, "_")
+                  .upcase + "!"
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/views/part.rb", <<~RUBY
+        # auto_register: false
+
+        module Main
+          module Views
+            class Part < TestApp::View::Part
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/views/parts/post.rb", <<~RUBY
+        # auto_register: false
+
+        module Main
+          module Views
+            module Parts
+              class Post < Main::Views::Part
+                def title_tag
+                  helpers.tag.h1(helpers.slice_screaming_snake_case(value.title))
+                end
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "provides a default rendering from the app" do
+      post = Struct.new(:title).new("Hello world")
+      part = Main::Views::Parts::Post.new(value: post)
+
+      expect(part.title_tag).to eq "<h1>HELLO_WORLD!</h1>"
+    end
+  end
+end


### PR DESCRIPTION
In response to the feedback in #1355, make it possible to directly initialize a part (whose class is inside an app/slice namespace) with a value only, and have a default rendering provided from the respective app/slice, ensuring the slice has access to all the integrated view facilities from the app/slice, such as helpers.

This helps reduce boilerplate with unit testing parts. Now, this is possible:

```ruby
RSpec.describe(TestApp::Views::Parts::Post) do
  subject(:part) { described_class.new(value:)

  let(:value) { Struct.new(:title).new("Hello world") }

  it "works" do
    # This title_tag method depends on helpers being present inside the part,
    # which only comes courtesy of the app's integrated views
    expect(part.title_tag).to eq "<h1>Hello world</h1>"
  end
end
```

So streamlined!