### PR TITLE
Update app-level view context extensions to work in the same spirit as `Hanami::View::Context` itself

### DIFF
--- a/lib/hanami/extensions/action.rb
+++ b/lib/hanami/extensions/action.rb
@@ -40,7 +40,7 @@ module Hanami
         attr_reader :view
 
         # @api private
-        attr_reader :view_context
+        attr_reader :view_context_class
 
         # Returns the app or slice's {Hanami::Slice::RoutesHelper RoutesHelper} for use within
         # action instance methods.
@@ -70,9 +70,9 @@ module Hanami
         #
         #   @api public
         #   @since 2.0.0
-        def initialize(view: nil, view_context: nil, rack_monitor: nil, routes: nil, **kwargs)
+        def initialize(view: nil, view_context_class: nil, rack_monitor: nil, routes: nil, **kwargs)
           @view = view
-          @view_context = view_context
+          @view_context_class = view_context_class
           @routes = routes
           @rack_monitor = rack_monitor
 
@@ -104,7 +104,7 @@ module Hanami
 
         # @api private
         def view_options(request, response)
-          {context: view_context&.with(**view_context_options(request, response))}.compact
+          {context: view_context_class&.new(**view_context_options(request, response))}.compact
         end
 
         # @api private

--- a/lib/hanami/extensions/action/slice_configured_action.rb
+++ b/lib/hanami/extensions/action/slice_configured_action.rb
@@ -31,14 +31,14 @@ module Hanami
         # @see Hanami::Extensions::Action::InstanceMethods#initialize
         def define_new
           resolve_view = method(:resolve_paired_view)
-          resolve_view_context = method(:resolve_view_context)
+          view_context_class = method(:view_context_class)
           resolve_routes = method(:resolve_routes)
           resolve_rack_monitor = method(:resolve_rack_monitor)
 
           define_method(:new) do |**kwargs|
             super(
               view: kwargs.fetch(:view) { resolve_view.(self) },
-              view_context: kwargs.fetch(:view_context) { resolve_view_context.() },
+              view_context_class: kwargs.fetch(:view_context_class) { view_context_class.() },
               routes: kwargs.fetch(:routes) { resolve_routes.() },
               rack_monitor: kwargs.fetch(:rack_monitor) { resolve_rack_monitor.() },
               **kwargs,
@@ -128,9 +128,9 @@ module Hanami
           nil
         end
 
-        def resolve_view_context
+        def view_context_class
           if Hanami.bundled?("hanami-view")
-            return Extensions::View::Context.context_class(slice).new
+            return Extensions::View::Context.context_class(slice)
           end
 
           # If hanami-view isn't bundled, try and find a possible third party context class with the
@@ -139,7 +139,7 @@ module Hanami
             views_namespace = slice.namespace.const_get(:Views)
 
             if views_namespace.const_defined?(:Context)
-              views_namespace.const_get(:Context).new
+              views_namespace.const_get(:Context)
             end
           end
         end

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -104,17 +104,6 @@ module Hanami
               @content_for = source.instance_variable_get(:@content_for).dup
             end
 
-            def with(**args)
-              self.class.new(
-                inflector: @inflector,
-                settings: @settings,
-                assets: @assets,
-                routes: @routes,
-                request: @request,
-                **args
-              )
-            end
-
             def assets
               unless @assets
                 raise Hanami::ComponentLoadError, "the hanami-assets gem is required to access assets"

--- a/spec/integration/view/context/assets_spec.rb
+++ b/spec/integration/view/context/assets_spec.rb
@@ -47,14 +47,6 @@ RSpec.describe "App view / Context / Assets", :app_integration do
         it "is the injected assets" do
           expect(context.assets).to be assets
         end
-
-        context "rebuilt context" do
-          subject(:new_context) { context.with }
-
-          it "retains the injected assets" do
-            expect(new_context.assets).to be assets
-          end
-        end
       end
     end
   end

--- a/spec/integration/view/context/inflector_spec.rb
+++ b/spec/integration/view/context/inflector_spec.rb
@@ -35,14 +35,6 @@ RSpec.describe "App view / Context / Inflector", :app_integration do
       it "is the injected inflector" do
         expect(context.inflector).to be inflector
       end
-
-      context "rebuilt context" do
-        subject(:new_context) { context.with }
-
-        it "retains the injected inflector" do
-          expect(new_context.inflector).to be inflector
-        end
-      end
     end
   end
 end

--- a/spec/integration/view/context/settings_spec.rb
+++ b/spec/integration/view/context/settings_spec.rb
@@ -41,14 +41,6 @@ RSpec.describe "App view / Context / Settings", :app_integration do
       it "is the injected settings" do
         expect(context.settings).to be settings
       end
-
-      context "rebuilt context" do
-        subject(:new_context) { context.with }
-
-        it "retains the injected settings" do
-          expect(new_context.settings).to be settings
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
In [earlier changes to hanami-view](https://github.com/hanami/view/pull/223) that will soon be released as 2.1.0, we removed the `Hanami::View::Context#with` method, instead expecting that a view context need only be initialized once, and then kept for the entire rendering.

However, at the time of that change, we did not make commensurate changes here in the app-level view context extension, instead just keeping a local `#with` method, and continuing to (needlessly) initialize a view contexet to pass to the action, only to _re-initialize it_ inside the action (via `#with`) with the request before rendering the view.

With this change, make the view app-level view context work in a way that matches the standard `Hanami::View::Context`: it should only be initialized once. To achieve this, inject a view context *class* into actions (instead of an instance) and then call `.new` on that context class when preparing the options for view rendering.

This simplifies the view context extension internals and allows us to remove a few tests, too. It will also make view contexts easier for users to modify, since they no longer have to think about the case of `#with` being called somewhere deep inside the framework, out of their sight. Instead, their context classes will be initialized just once, like any ordinary Ruby object. And the only expectation we have is that their `#initialize` accepts `**kwargs`.