### PR TITLE
Defer Dry::System::Container freeze

### DIFF
--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -307,7 +307,7 @@ module Hanami
 
         prepare
 
-        container.finalize!
+        container.finalize!(freeze: false).freeze
         slices.each(&:boot)
 
         @booted = true


### PR DESCRIPTION
This small change defers the freeze of the container until after hooks have been run. This allows you to make alterations to the container in a `after_finalize` hook such as decorating keys by enumeration.

[Use-case: APM monitoring](https://discourse.hanamirb.org/t/newrelic-apm-on-hanami-2/872)