### PR TITLE
Remove current_path from default view context

### DIFF
--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -138,10 +138,6 @@ module Hanami
               end
             end
 
-            def current_path
-              request.fullpath
-            end
-
             def csrf_token
               request.session[Hanami::Action::CSRFProtection::CSRF_TOKEN]
             end


### PR DESCRIPTION
This is too presumptive about what a user may want in their context. A user can choose to access this from the request directly, instead.

In general, I'd like to keep our default view context as slim as possible, so it's easy for a user to understand the full extent of its capabilities. Having this method there for the sake of convenience felt unnecessary.