### PR TITLE
Render detailed errors in development mode only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The web, with simplicity.
 
+## Changed
+
+- [Tim Riley] Enable config.render_detailed_errors in development mode only by default.
+
 ## v2.1.0.rc1 - 2023-11-01
 
 ### Added

--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -272,7 +272,7 @@ module Hanami
       # Apply default values that are only knowable at initialize-time (vs require-time)
       self.root = Dir.pwd
       self.render_errors = (env == :production)
-      self.render_detailed_errors = (env != :production)
+      self.render_detailed_errors = (env == :development)
       load_from_env
 
       @logger = Config::Logger.new(env: env, app_name: app_name)

--- a/spec/unit/hanami/config/render_detailed_errors_spec.rb
+++ b/spec/unit/hanami/config/render_detailed_errors_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hanami::Config, "#render_detailed_errors" do
 
   context "test mode" do
     let(:env) { :test }
-    it { is_expected.to be true }
+    it { is_expected.to be false }
   end
 
   context "production mode" do


### PR DESCRIPTION
If these get rendered in test mode, then the text in the error messages themselves may actually confuse assertions in the tests, especially for feature tests that assert on page content.

For example, given an expectation like this:

```ruby
expect(page).to have_content("Hello world")
```

If the page has some error and the BetterErrors screen shows, then it will include the exact copy of this line above as part of its backtrace, which will lead to the test passing due to the test line itself having the text it was looking for.

This is undesirable, and we can avoid any potentially confusing errors like this by simply disabling the detailed errors middleware altogether in test mode.