### PR TITLE
Avoid calling bundler exec in assets:precompile

### DIFF
--- a/lib/hanami/rake_tasks.rb
+++ b/lib/hanami/rake_tasks.rb
@@ -44,17 +44,9 @@ Hanami::CLI::RakeTasks.register_tasks do
   if Hanami.bundled?("hanami-assets")
     namespace :assets do
       task :precompile do
-        run_hanami_command("assets compile")
+        Hanami::CLI::Commands::App::Assets::Compile.new.call
       end
     end
-  end
-
-  private
-
-  @_hanami_cli_bundler = Hanami::CLI::Bundler.new
-
-  def run_hanami_command(command)
-    @_hanami_cli_bundler.hanami_exec(command)
   end
 end
 


### PR DESCRIPTION
Instead of invoking `bundle exec hanami assets compile` as a shell command, instead call the `Hanami::CLI::Commands::App::Assets::Compile` CLI conmand object directly.

This still achieves the same goal, and it works around an issue we were seeing on Heroku where `bundle exec` could not find the `hanami` command when this rake task is called during the app's build phase.

Later on, once we've had time to properly debug the issue, we may want to return to the previous approach of shelling out to `bundle exec hanami`, this change gives us working Heroku deploys and asset compilation for 2.1.0 and buys us the time to do that further investigation without the pressure of us blocking new users wanting to deploy their apps.

Fixes https://github.com/hanami/hanami/issues/1367