### PR TITLE
Return nil when capturing in content_for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 The web, with simplicity.
 
-## Changed
+## Unreleased
+
+### Changed
+
+- [Tim Riley] Return `nil` when setting content via `#content_for` on the app's view context. This
+  allows it to be used with tempalte output tags (such as ERB's `<%=`) that capture a block for the
+  given content. (#1369)
+
+## v2.1.0.rc2 - 2023-11-08
 
 - [Tim Riley] Enable `config.render_detailed_errors` in development mode only by default. (#1365)
 - [Tim Riley] Remove current_path from context (#1362)

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -194,7 +194,7 @@ module Hanami
             #     content_for(:page_title, "Hello world")
             #
             #   @example In a template
-            #     <% content_for :page_title do %>
+            #     <%= content_for :page_title do %>
             #       <h1>Hello world</h1>
             #     <% end %>
             #
@@ -211,8 +211,10 @@ module Hanami
             def content_for(key, value = nil)
               if block_given?
                 @content_for[key] = yield
+                nil
               elsif value
                 @content_for[key] = value
+                nil
               else
                 @content_for[key]
               end


### PR DESCRIPTION
This allows it to be used in template expression tags (like ERB's `<%=` and Slim's `=`), which are the only tags in which our standard HTML template engines consistently provide the implicit capture template content via yielded blocks.

The result is that when using content_for with a block, it should be used via an expression tag, e.g.

```erb
<%= content_for :foo %>
  <span>Hello</span>
<% end %>
```

Fixes https://github.com/hanami/view/issues/250