### PR TITLE
Pass through kwargs to middleware

### DIFF
--- a/lib/hanami/slice/routing/middleware/stack.rb
+++ b/lib/hanami/slice/routing/middleware/stack.rb
@@ -91,16 +91,16 @@ module Hanami
           #
           # @api public
           # @since 2.0.0
-          def use(spec, *args, path_prefix: ::Hanami::Router::DEFAULT_PREFIX, before: nil, after: nil, &blk)
+          def use(spec, *args, path_prefix: ::Hanami::Router::DEFAULT_PREFIX, before: nil, after: nil, **kwargs, &blk)
             middleware = resolve_middleware_class(spec)
-            item = [middleware, args, blk]
+            item = [middleware, args, kwargs, blk]
 
             if before
               @stack[path_prefix].insert((idx = index_of(before, path_prefix)).zero? ? 0 : idx - 1, item)
             elsif after
               @stack[path_prefix].insert(index_of(after, path_prefix) + 1, item)
             else
-              @stack[path_prefix].push([middleware, args, blk])
+              @stack[path_prefix].push(item)
             end
 
             self


### PR DESCRIPTION
Most middleware expect the old-school approach of hash options, but some are now using keyword arguments instead (such as Rack::Timeout). So let's presume that any keyword arguments that aren't known by Hanami should be passed through.

There is the edge-case of both the middleware and Hanami expecting arguments with the same name - this does not address that. 😓

The CI for this won't be green until https://github.com/hanami/router/pull/267 is merged in (but I've tested it locally with that branch, and is happy).