### PR TITLE
Support cross slice assets

### DIFF
--- a/lib/hanami/helpers/assets_helper.rb
+++ b/lib/hanami/helpers/assets_helper.rb
@@ -85,7 +85,7 @@ module Hanami
       # name of the algorithm, then a hyphen, then the hash value of the file.
       # If more than one algorithm is used, they"ll be separated by a space.
       #
-      # @param source_paths [Array<String>] one or more assets by name or absolute URL
+      # @param source_paths [Array<String, #url>] one or more assets by name or absolute URL
       #
       # @return [Hanami::View::HTML::SafeString] the markup
       #
@@ -189,7 +189,7 @@ module Hanami
       # name of the algorithm, then a hyphen, then the hashed value of the file.
       # If more than one algorithm is used, they"ll be separated by a space.
       #
-      # @param source_paths [Array<String>] one or more assets by name or absolute URL
+      # @param source_paths [Array<String, #url>] one or more assets by name or absolute URL
       #
       # @return [Hanami::View::HTML::SafeString] the markup
       #
@@ -282,7 +282,7 @@ module Hanami
       # If the "CDN mode" is on, the `src` is an absolute URL of the
       # application CDN.
       #
-      # @param source [String] asset name or absolute URL
+      # @param source [String, #url] asset name, absolute URL, or asset object
       # @param options [Hash] HTML 5 attributes
       #
       # @return [Hanami::View::HTML::SafeString] the markup
@@ -353,7 +353,7 @@ module Hanami
       # If the "CDN mode" is on, the `href` is an absolute URL of the
       # application CDN.
       #
-      # @param source [String] asset name
+      # @param source [String, #url] asset name or asset object
       # @param options [Hash] HTML 5 attributes
       #
       # @return [Hanami::View::HTML::SafeString] the markup
@@ -424,7 +424,7 @@ module Hanami
       # If the "CDN mode" is on, the `src` is an absolute URL of the
       # application CDN.
       #
-      # @param source [String] asset name or absolute URL
+      # @param source [String, #url] asset name, absolute URL or asset object
       # @param options [Hash] HTML 5 attributes
       #
       # @return [Hanami::View::HTML::SafeString] the markup
@@ -526,7 +526,7 @@ module Hanami
       # If the "CDN mode" is on, the `src` is an absolute URL of the
       # application CDN.
       #
-      # @param source [String] asset name or absolute URL
+      # @param source [String, #url] asset name, absolute URL or asset object
       # @param options [Hash] HTML 5 attributes
       #
       # @return [Hanami::View::HTML::SafeString] the markup
@@ -626,7 +626,7 @@ module Hanami
       #
       # If CDN mode is on, it returns the absolute URL of the asset.
       #
-      # @param source_path [String] the asset name
+      # @param source_path [String, #url] the asset name or asset object
       #
       # @return [String] the asset path
       #

--- a/lib/hanami/helpers/assets_helper.rb
+++ b/lib/hanami/helpers/assets_helper.rb
@@ -666,6 +666,7 @@ module Hanami
       #
       #   # "https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.js"
       def asset_url(source_path)
+        return source_path.url if source_path.respond_to?(:url)
         return source_path if _absolute_url?(source_path)
 
         _context.assets[source_path].url
@@ -684,7 +685,7 @@ module Hanami
       # @since 2.1.0
       # @api private
       def _typed_path(source, ext)
-        source = "#{source}#{ext}" if _append_extension?(source, ext)
+        source = "#{source}#{ext}" if source.is_a?(String) && _append_extension?(source, ext)
         asset_url(source)
       end
 

--- a/spec/integration/assets/cross_slice_assets_helpers_spec.rb
+++ b/spec/integration/assets/cross_slice_assets_helpers_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rack/test"
+require "stringio"
+
+RSpec.describe "Cross-slice assets via helpers", :app_integration do
+  include Rack::Test::Methods
+  let(:app) { Hanami.app }
+  let(:root) { make_tmp_directory }
+
+  before do
+    with_directory(root) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = StringIO.new
+          end
+        end
+      RUBY
+
+      write "config/slices/admin.rb", <<~RUBY
+        module Admin
+          class Slice < Hanami::Slice
+            # TODO: we should update `import` to make importing from the app nicer
+            # TODO: this test failed when I tried doing `as: "app"` (string instead of symbol); fix this in dry-system
+            import keys: ["assets"], from: Hanami.app.container, as: :app
+          end
+        end
+      RUBY
+
+      write "config/assets.js", <<~JS
+        import * as assets from "hanami-assets";
+        await assets.run();
+      JS
+
+      write "package.json", <<~JSON
+        {
+          "type": "module"
+        }
+      JSON
+
+      write "app/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module TestApp
+          class View < Hanami::View
+            config.layout = nil
+          end
+        end
+      RUBY
+
+      write "app/assets/js/app.ts", <<~TS
+        import "../css/app.css";
+
+        console.log("Hello from index.ts");
+      TS
+
+      write "app/assets/css/app.css", <<~CSS
+        .btn {
+          background: #f00;
+        }
+      CSS
+
+      write "slices/admin/assets/js/app.ts", <<~TS
+        import "../css/app.css";
+
+        console.log("Hello from admin's index.ts");
+      TS
+
+      write "slices/admin/assets/css/app.css", <<~CSS
+        .btn {
+          background: #f00;
+        }
+      CSS
+
+      write "slices/admin/view.rb", <<~RUBY
+        # auto_register: false
+
+        module Admin
+          class View < TestApp::View
+          end
+        end
+      RUBY
+
+      write "slices/admin/views/posts/show.rb", <<~RUBY
+        module Admin
+          module Views
+            module Posts
+              class Show < Admin::View
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/views/context.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module Admin
+          module Views
+            class Context < Hanami::View::Context
+              include Deps[app_assets: "app.assets"]
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/templates/posts/show.html.erb", <<~ERB
+        <%= stylesheet_tag(app_assets["app.css"]) %>
+        <%= javascript_tag(app_assets["app.js"]) %>
+      ERB
+
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  specify "assets are available in helpers and in `assets` component" do
+    compile_assets!
+
+    output = Admin::Slice["views.posts.show"].call.to_s
+
+    expect(output).to match(%r{<link href="/assets/app-[A-Z0-9]{8}.css" type="text/css" rel="stylesheet">})
+    expect(output).to match(%r{<script src="/assets/app-[A-Z0-9]{8}.js" type="text/javascript"></script>})
+  end
+end

--- a/spec/unit/hanami/helpers/assets_helper/asset_url_spec.rb
+++ b/spec/unit/hanami/helpers/assets_helper/asset_url_spec.rb
@@ -106,4 +106,15 @@ RSpec.describe Hanami::Helpers::AssetsHelper, "#asset_url", :app_integration do
       end
     end
   end
+
+  context "given an asset object" do
+    it "returns the URL for the asset" do
+      asset = Hanami::Assets::Asset.new(
+        path: "/foo/bar.js",
+        base_url: Hanami.app.config.assets.base_url
+      )
+
+      expect(asset_url(asset)).to eq "/foo/bar.js"
+    end
+  end
 end


### PR DESCRIPTION
Update asset helpers to accept `Hanami::Assets::Asset` instances and use the URL from those, instead of trying to look up the asset from the `assets` in the view context.

See `spec/integration/assets/cross_slice_assets_helpers_spec.rb` (added in this PR) for a full demonstration, but in short, using assets from across slices involves:

(1) Importing the `assets` object from one slice to another:

```ruby
module Admin
  class Slice < Hanami::Slice
    import keys: ["assets"], from: Hanami.app.container, as: :app
  end
end
```

(2) Making the imported assets component available in the view context:

```ruby
module Admin
  module Views
    class Context < Hanami::View::Context
      include Deps[app_assets: "app.assets"]
    end
  end
end
```

(3) Using the asset objects directly with the assets helpers:

```erb
<%= javascript_tag(app_assets["app.js"]) %>
```

The recommended way to use assets is in full isolation, which is why I don't think we need to further streamline the steps above. But doing this shows how it is possible and should allow people to achieve cross-slice asset usage if their situation requires it.