### PR TITLE
Underscore slice names in public asset dirs

### DIFF
--- a/lib/hanami/providers/assets.rb
+++ b/lib/hanami/providers/assets.rb
@@ -29,8 +29,7 @@ module Hanami
 
       # @api private
       def start
-        assets_dir = slice.slice_name.to_s unless slice.app.eql?(slice)
-        root = slice.app.root.join("public", "assets", assets_dir.to_s)
+        root = slice.app.root.join("public", "assets", Hanami::Assets.public_assets_dir(slice).to_s)
 
         assets = Hanami::Assets.new(config: slice.config.assets, root: root)
 

--- a/spec/integration/assets/assets_spec.rb
+++ b/spec/integration/assets/assets_spec.rb
@@ -133,13 +133,13 @@ RSpec.describe "Assets", :app_integration do
 
       output = Main::Slice["views.posts.show"].call.to_s
 
-      expect(output).to match(%r{<link href="/assets/main/app-[A-Z0-9]{8}.css" type="text/css" rel="stylesheet">})
-      expect(output).to match(%r{<script src="/assets/main/app-[A-Z0-9]{8}.js" type="text/javascript"></script>})
+      expect(output).to match(%r{<link href="/assets/_main/app-[A-Z0-9]{8}.css" type="text/css" rel="stylesheet">})
+      expect(output).to match(%r{<script src="/assets/_main/app-[A-Z0-9]{8}.js" type="text/javascript"></script>})
 
       assets = Main::Slice["assets"]
 
-      expect(assets["app.css"].to_s).to match(%r{/assets/main/app-[A-Z0-9]{8}.css})
-      expect(assets["app.js"].to_s).to match(%r{/assets/main/app-[A-Z0-9]{8}.js})
+      expect(assets["app.css"].to_s).to match(%r{/assets/_main/app-[A-Z0-9]{8}.css})
+      expect(assets["app.js"].to_s).to match(%r{/assets/_main/app-[A-Z0-9]{8}.js})
     end
   end
 

--- a/spec/support/app_integration.rb
+++ b/spec/support/app_integration.rb
@@ -37,7 +37,7 @@ module RSpec
 
         write "public/assets/assets.json", JSON.generate(manifest_hash)
 
-        # An assets dir isrequired to load the assets provider
+        # An assets dir is required to load the assets provider
         write "app/assets/.keep", ""
       end
 


### PR DESCRIPTION
This will avoid naming collisions with ordinary user-controlled files or directories.

Uses the new `Hanami::Assets.public_assets_dir` method introduced in https://github.com/hanami/assets/pull/140.