### PR TITLE
Update dry-logger compatibility check

### DIFF
--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -79,7 +79,7 @@ module Hanami
           end
 
           def accepts_entry_payload?(logger)
-            logger.method(:info).parameters.last.then { |type, _| type == :keyrest }
+            logger.method(:info).parameters.any? { |(type, _)| type == :keyrest }
           end
         end
 


### PR DESCRIPTION
Allow it to return true for dry-logger versions that also accept a block as the last parameter for the `#log`, `#info`, etc. methods (which as been introduced as of dry-logger 1.0.4).

Without this change, Rack logging would fail when upgrading to dry-logger 1.0.4.