### PR TITLE
Add hanami-db as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,13 @@ unless ENV["CI"]
   gem "yard-junk"
 end
 
-gem "hanami-utils",      github: "hanami/utils",      branch: "main"
-gem "hanami-router",     github: "hanami/router",     branch: "main"
+gem "hanami-utils", github: "hanami/utils", branch: "main"
+gem "hanami-db", github: "hanami/db", branch: "main"
+gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
-gem "hanami-cli",        github: "hanami/cli",        branch: "main"
-gem "hanami-view",       github: "hanami/view",       branch: "main"
-gem "hanami-assets",     github: "hanami/assets",     branch: "main"
+gem "hanami-cli", github: "hanami/cli", branch: "main"
+gem "hanami-view", github: "hanami/view", branch: "main"
+gem "hanami-assets", github: "hanami/assets", branch: "main"
 gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"


### PR DESCRIPTION
This is a new gem for 2.2 and we’ll be updating code to reference it soon.