### PR TITLE
Add the beginnings of a :db provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,13 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
+gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
 
 # This is needed for settings specs to pass
 gem "dry-types"
+
+# For testing the DB layer
+gem "sqlite3"
 
 group :test do
   gem "capybara"

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -17,6 +17,7 @@ module Hanami
   # @since 2.0.0
   def self.loader
     @loader ||= Zeitwerk::Loader.for_gem.tap do |loader|
+      loader.inflector.inflect "db" => "DB"
       loader.ignore(
         "#{loader.dirs.first}/hanami/{constants,boot,errors,extensions/router/errors,prepare,rake_tasks,setup}.rb"
       )

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Providers
+    # @api private
+    # @since 2.2.0
+    class DB < Dry::System::Provider::Source
+      setting :database_url
+
+      setting :adapter, default: :sql
+
+      # TODO: Determine ideal default extensions
+      # TODO: Switch extensions based on configured adapter
+      setting :extensions, default: [:error_sql]
+
+      setting :relations_path, default: "relations"
+
+      # @api private
+      def prepare
+        require "hanami-db"
+
+        # TODO: Add more logic around fetching database URL:
+        # - Loading the database URL from settings (if defined)
+        # - Check per-slice ENV vars before falling back to DATABASE_URL
+        database_url = config.database_url || ENV["DATABASE_URL"]
+
+        unless database_url
+          raise Hanami::ComponentLoadError, "A database_url is required to start :db."
+        end
+
+        @rom_config = ROM::Configuration.new(config.adapter, database_url, extensions: config.extensions)
+
+        register "config", @rom_config
+        register "connection", @rom_config.gateways[:default]
+      end
+
+      # @api private
+      def start
+        # Find and register relations
+        relations_path.glob("*.rb").each do |relation_file|
+          relation_name = relation_file
+            .relative_path_from(relations_path)
+            .basename(relation_file.extname)
+            .to_s
+
+          relation_class = target.namespace
+            .const_get(:Relations) # TODO don't hardcode
+            .const_get(target.inflector.camelize(relation_name))
+
+          @rom_config.register_relation(relation_class)
+        end
+
+        # TODO: register mappers & commands
+
+        rom = ROM.container(@rom_config)
+
+        register "rom", rom
+      end
+
+      private
+
+      def db_path
+        if target.app.eql?(target)
+          target.root.join("app", "db")
+        else
+          target.root.join("db")
+        end
+      end
+
+      def relations_path
+        if target.app.eql?(target)
+          target.root.join("app", config.relations_path)
+        else
+          target.root.join(config.relations_path)
+        end
+      end
+    end
+
+    Dry::System.register_provider_source(
+      :db,
+      source: DB,
+      group: :hanami,
+      provider_options: {namespace: true}
+    )
+  end
+end

--- a/lib/hanami/providers/relations.rb
+++ b/lib/hanami/providers/relations.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Providers
+    # @api private
+    # @since 2.2.0
+    class Relations < Dry::System::Provider::Source
+      def start
+        target.start(:db)
+
+        rom = target["db.rom"]
+        rom.relations.each do |name, _|
+          register(name) { rom.relations[name] }
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/db/db_spec.rb
+++ b/spec/integration/db/db_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  it "sets up ROM and reigsters relations" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      expect(Hanami.app["db.config"]).to be_an_instance_of ROM::Configuration
+      expect(Hanami.app["db.connection"]).to be_an_instance_of ROM::SQL::Gateway
+
+      # Manually run a migration and add a test record
+      gateway = Hanami.app["db.connection"]
+      migration = gateway.migration do
+        change do
+          # drop_table? :posts
+          create_table :posts do
+            primary_key :id
+            column :title, :text, null: false
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+      Hanami.app.boot
+
+      expect(Hanami.app["db.rom"].relations[:posts].to_a).to eq [{id: 1, title: "Together breakfast"}]
+      expect(Hanami.app["relations.posts"]).to be Hanami.app["db.rom"].relations[:posts]
+    end
+  end
+
+  it "provides access in a non-booted app" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      expect(Hanami.app["db.config"]).to be_an_instance_of ROM::Configuration
+      expect(Hanami.app["db.connection"]).to be_an_instance_of ROM::SQL::Gateway
+
+      # Manually run a migration and add a test record
+      gateway = Hanami.app["db.connection"]
+      migration = gateway.migration do
+        change do
+          # drop_table? :posts
+          create_table :posts do
+            primary_key :id
+            column :title, :text, null: false
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+      expect(Hanami.app["db.rom"].relations[:posts].to_a).to eq [{id: 1, title: "Together breakfast"}]
+      expect(Hanami.app["relations.posts"]).to be Hanami.app["db.rom"].relations[:posts]
+    end
+  end
+
+  it "raises an error when now database URL is provided" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.inflections do |inflections|
+            end
+          end
+        end
+      RUBY
+
+      write "app/relations/.keep", ""
+
+      require "hanami/prepare"
+
+      expect { Hanami.app.prepare :db }.to raise_error(Hanami::ComponentLoadError, /database_url/)
+    end
+  end
+
+  it "allows the user to configure the provider" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      write "config/providers/db.rb", <<~RUBY
+        Hanami.app.configure_provider :db do
+          configure do |config|
+            # In this test, we're not setting an ENV["DATABASE_URL"], and instead configuring
+            # it via the provider source config, to prove that this works
+
+            config.database_url = "sqlite::memory"
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+      gateway = Hanami.app["db.connection"]
+      migration = gateway.migration do
+        change do
+          # drop_table? :posts
+          create_table :posts do
+            primary_key :id
+            column :title, :text, null: false
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+      Hanami.app.boot
+
+      expect(Hanami.app["db.rom"].relations[:posts].to_a).to eq [{id: 1, title: "Together breakfast"}]
+      expect(Hanami.app["relations.posts"]).to be Hanami.app["db.rom"].relations[:posts]
+    end
+  end
+end


### PR DESCRIPTION
This provider sets up ROM and registers relations.

It may also be configured by the user in their own `config/providers/db.rb` using `Hanami.app.configure_provider(:db) { … }`.