### PR TITLE
Share parent DB via `config.db.import_from_parent`

### DIFF
--- a/lib/hanami/config/db.rb
+++ b/lib/hanami/config/db.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "dry/configurable"
+
+module Hanami
+  class Config
+    # Hanami DB config
+    #
+    # @since 2.2.0
+    # @api public
+    class DB
+      include Dry::Configurable
+
+      setting :import_from_parent, default: false
+
+      private
+
+      def method_missing(name, *args, &block)
+        if config.respond_to?(name)
+          config.public_send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, _include_all = false)
+        config.respond_to?(name) || super
+      end
+    end
+  end
+end

--- a/spec/integration/db/slices_importing_from_parent.rb
+++ b/spec/integration/db/slices_importing_from_parent.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / Slices / Importing from app", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  specify "app DB components do not import into slices by default" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/.keep", ""
+
+      require "hanami/prepare"
+
+      expect { Admin::Slice.start :db }.to raise_error Dry::System::ProviderNotFoundError
+    end
+  end
+
+  specify "importing app DB components into slices via config.db.import_from_parent = true" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.db.import_from_parent = true
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/.keep", ""
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      # Manually run a migration and add a test record
+      gateway = Hanami.app["db.connection"]
+      migration = gateway.migration do
+        change do
+          # drop_table? :posts
+          create_table :posts do
+            primary_key :id
+            column :title, :text, null: false
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+      Admin::Slice.start :db
+
+      expect(Admin::Slice["db.rom"]).to be(Hanami.app["db.rom"])
+      expect(Admin::Slice["relations.posts"]).to be(Hanami.app["relations.posts"])
+
+      expect(Admin::Slice["relations.posts"].to_a).to eq [{id: 1, title: "Together breakfast"}]
+    end
+  end
+
+  specify "disabling import of the DB components within a specific slice" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.db.import_from_parent = true
+          end
+        end
+      RUBY
+
+      write "config/slices/admin.rb", <<~RUBY
+        module Admin
+          class Slice < Hanami::Slice
+            config.db.import_from_parent = false
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      expect { Admin::Slice.start :db }.to raise_error Dry::System::ProviderNotFoundError
+    end
+  end
+end

--- a/spec/unit/hanami/config/db_spec.rb
+++ b/spec/unit/hanami/config/db_spec.rb
@@ -2,23 +2,17 @@
 
 require "hanami/config"
 
-RSpec.describe Hanami::Config, "#router" do
+RSpec.describe Hanami::Config, "#db" do
   let(:config) { described_class.new(app_name: app_name, env: :development) }
-  let(:app_name) { "MyApp::app" }
+  let(:app_name) { "MyApp::App" }
 
-  subject(:router) { config.router }
+  subject(:db) { config.db }
 
   context "hanami-router is bundled" do
     it "is a full router configuration" do
-      is_expected.to be_an_instance_of(Hanami::Config::Router)
+      is_expected.to be_an_instance_of(Hanami::Config::DB)
 
-      is_expected.to respond_to(:resolver)
-    end
-
-    it "loads the middleware stack" do
-      subject
-
-      expect(config.middleware_stack).not_to be_nil
+      is_expected.to respond_to(:import_from_parent)
     end
 
     it "can be finalized" do
@@ -26,15 +20,15 @@ RSpec.describe Hanami::Config, "#router" do
     end
   end
 
-  context "hanami-router is not bundled" do
+  context "hanami-db is not bundled" do
     before do
       allow(Hanami).to receive(:bundled?).and_call_original
-      allow(Hanami).to receive(:bundled?).with("hanami-router").and_return(false)
+      allow(Hanami).to receive(:bundled?).with("hanami-db").and_return(false)
     end
 
     it "does not expose any settings" do
       is_expected.to be_an_instance_of(Hanami::Config::NullConfig)
-      is_expected.not_to respond_to(:resolver)
+      is_expected.not_to respond_to(:import_from_parent)
     end
 
     it "can be finalized" do


### PR DESCRIPTION
This new setting defaults to false. When set to true, instead of initializing an independent ROM setup per slice, the app’s ROM setup will be imported directly into each slice, allowing the app’s relations (and other ROM components) to be shared across all slices.

Resolves #1394.