### PR TITLE
Share connection for multiple slices using the same DB

### DIFF
--- a/spec/support/app_integration.rb
+++ b/spec/support/app_integration.rb
@@ -118,6 +118,9 @@ RSpec.configure do |config|
     Hanami.instance_variable_set(:@_bundled, {})
     Hanami.remove_instance_variable(:@_app) if Hanami.instance_variable_defined?(:@_app)
 
+    # Clear cached DB gateways across slices
+    Hanami::Providers::DB.cache.clear
+
     $LOAD_PATH.replace(@load_paths)
 
     # Remove example-specific LOADED_FEATURES added when running each example


### PR DESCRIPTION
Cache and reuse identically-configured gateways across slices. This ensures we don't create spurious DB connections.

<details>
<summary>Original work-in-progress comment</summary>

Some notes about this:

- It's great that ROM allowed us to do this out of the box!!
- I'm not actually sure about caching the connections in the `Hanami::Providers::DB` itself. Putting this on a static method on Hanami::DB might be better for clarity/accessibility.
- Sharing connections will mean it won't be possible to use a different set of Sequel `:extensions` per slice. This is because those extensions go straight onto the `Sequel::Database` object, which is the actual "connection" object that we're caching.

That last point is really the biggest one in terms of user-exposed features.

Here's what the connection object that we're caching actually looks like:

```ruby
Admin::Slice["db.rom"].gateways[:default].connection
# => #<Sequel::SQLite::Database: "sqlite:///path/to/database.db" {:extensions=>[:error_sql]}>
```

Ideas on approaches here?

One possibility could be to include the configured extensions in the key for the connection cache. That way a slice with different extensions would get a different connection (preserves behaviour at the cost of extra connections).

We could potentially also tackle this by emitting a warning when establishing a new connection due to different extensions only?

We could also make it so that the extensions can be configured on the app-level `config/providers/db.rb` and then shared to all slice providers, just like we already do for the ROM plugins, so at least the user has a single place to set all of those up.

Another to-do: need to make the cache thread safe. 

</details>