### PR TITLE
Register "db.gateway" instead of "db.connection"

### DIFF
--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -44,7 +44,7 @@ module Hanami
         apply_parent_config @rom_config
 
         register "config", @rom_config
-        register "connection", gateway
+        register "gateway", gateway
       end
 
       # @api private
@@ -127,7 +127,7 @@ module Hanami
         @rom_config = target.parent["db.config"]
 
         register "config", (@rom_config = target.parent["db.config"])
-        register "connection", target.parent["db.connection"]
+        register "gateway", target.parent["db.gateway"]
       end
 
       def start_and_import_parent_db

--- a/spec/integration/db/db_slices_spec.rb
+++ b/spec/integration/db/db_slices_spec.rb
@@ -125,17 +125,17 @@ RSpec.describe "DB / Slices", :app_integration do
       Main::Slice.prepare :db
 
       expect(Main::Slice["db.config"]).to be_an_instance_of ROM::Configuration
-      expect(Main::Slice["db.connection"]).to be_an_instance_of ROM::SQL::Gateway
+      expect(Main::Slice["db.gateway"]).to be_an_instance_of ROM::SQL::Gateway
 
       expect(Admin::Slice.registered?("db.config")).to be false
 
       Admin::Slice.prepare :db
 
       expect(Admin::Slice["db.config"]).to be_an_instance_of ROM::Configuration
-      expect(Admin::Slice["db.connection"]).to be_an_instance_of ROM::SQL::Gateway
+      expect(Admin::Slice["db.gateway"]).to be_an_instance_of ROM::SQL::Gateway
 
       # Manually run a migration and add a test record
-      gateway = Admin::Slice["db.connection"]
+      gateway = Admin::Slice["db.gateway"]
       migration = gateway.migration do
         change do
           create_table :posts do
@@ -259,9 +259,9 @@ RSpec.describe "DB / Slices", :app_integration do
 
       # Manually run a migration and add a test record in each slice's database
       gateways = [
-        Admin::Slice["db.connection"],
-        Admin::Super::Slice["db.connection"],
-        Main::Slice["db.connection"]
+        Admin::Slice["db.gateway"],
+        Admin::Super::Slice["db.gateway"],
+        Main::Slice["db.gateway"]
       ]
       gateways.each do |gateway|
         migration = gateway.migration do

--- a/spec/integration/db/db_spec.rb
+++ b/spec/integration/db/db_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe "DB", :app_integration do
       Hanami.app.prepare :db
 
       expect(Hanami.app["db.config"]).to be_an_instance_of ROM::Configuration
-      expect(Hanami.app["db.connection"]).to be_an_instance_of ROM::SQL::Gateway
+      expect(Hanami.app["db.gateway"]).to be_an_instance_of ROM::SQL::Gateway
 
       # Manually run a migration and add a test record
-      gateway = Hanami.app["db.connection"]
+      gateway = Hanami.app["db.gateway"]
       migration = gateway.migration do
         change do
           # drop_table? :posts
@@ -89,10 +89,10 @@ RSpec.describe "DB", :app_integration do
       Hanami.app.prepare :db
 
       expect(Hanami.app["db.config"]).to be_an_instance_of ROM::Configuration
-      expect(Hanami.app["db.connection"]).to be_an_instance_of ROM::SQL::Gateway
+      expect(Hanami.app["db.gateway"]).to be_an_instance_of ROM::SQL::Gateway
 
       # Manually run a migration and add a test record
-      gateway = Hanami.app["db.connection"]
+      gateway = Hanami.app["db.gateway"]
       migration = gateway.migration do
         change do
           # drop_table? :posts
@@ -166,7 +166,7 @@ RSpec.describe "DB", :app_integration do
       require "hanami/prepare"
 
       Hanami.app.prepare :db
-      gateway = Hanami.app["db.connection"]
+      gateway = Hanami.app["db.gateway"]
       migration = gateway.migration do
         change do
           # drop_table? :posts

--- a/spec/integration/db/slices_importing_from_parent.rb
+++ b/spec/integration/db/slices_importing_from_parent.rb
@@ -70,7 +70,7 @@ RSpec.describe "DB / Slices / Importing from app", :app_integration do
       Hanami.app.prepare :db
 
       # Manually run a migration and add a test record
-      gateway = Hanami.app["db.connection"]
+      gateway = Hanami.app["db.gateway"]
       migration = gateway.migration do
         change do
           # drop_table? :posts


### PR DESCRIPTION
Stay truer to ROM by using its own terminology for this container key.