### PR TITLE
Disconnect DB on provider stop

### DIFF
--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -59,6 +59,10 @@ module Hanami
         register "rom", rom
       end
 
+      def stop
+        target["db.rom"].disconnect
+      end
+
       private
 
       def relations_path


### PR DESCRIPTION
This is important to include because we run Hanami.shutdown in the before_fork hook in our default Puma config.