### PR TITLE
Do not auto-register from db, relations, structs

### DIFF
--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -110,7 +110,12 @@ module Hanami
     #
     #   @api public
     #   @since 2.0.0
-    setting :no_auto_register_paths, default: %w[entities]
+    setting :no_auto_register_paths, default: [
+      "db",
+      "entities",
+      "relations",
+      "structs"
+    ]
 
     # @!attribute [rw] base_url
     #   Sets the base URL for app's web server.

--- a/spec/integration/db/auto_registration_spec.rb
+++ b/spec/integration/db/auto_registration_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / auto-registration", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  it "does not auto-register files in entities/, structs/, or db/" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/db/changesets/update_posts.rb", ""
+      write "app/entities/post.rb", ""
+      write "app/structs/post.rb", ""
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/boot"
+
+      expect(Hanami.app.keys).not_to include(*[
+        "db.changesets.update_posts",
+        "entities.post",
+        "structs.post"
+      ])
+    end
+  end
+end

--- a/spec/integration/slices/slice_configuration_spec.rb
+++ b/spec/integration/slices/slice_configuration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Slices / Slice configuration", :app_integration do
           class App < Hanami::App
             config.logger.stream = StringIO.new
 
-            config.no_auto_register_paths << "structs"
+            config.no_auto_register_paths = ["structs"]
           end
         end
       RUBY
@@ -34,9 +34,9 @@ RSpec.describe "Slices / Slice configuration", :app_integration do
 
       require "hanami/prepare"
 
-      expect(TestApp::App.config.no_auto_register_paths).to eq %w[entities structs]
-      expect(Main::Slice.config.no_auto_register_paths).to eq %w[entities structs schemas]
-      expect(Search::Slice.config.no_auto_register_paths).to eq %w[entities structs]
+      expect(TestApp::App.config.no_auto_register_paths).to eq %w[structs]
+      expect(Main::Slice.config.no_auto_register_paths).to eq %w[structs schemas]
+      expect(Search::Slice.config.no_auto_register_paths).to eq %w[structs]
     end
   end
 end


### PR DESCRIPTION
db/ and relations/ are special directories for ROM, and either contain files that should not be registered (like db/changesets/, db/commands/, db/mappers.), and relations/ is already managed by the db provider.

strcuts/ (like entities/, which was already handled in this way) contains classes that should be instantiated directly with specific data, instead of being accessed pre-built off the container.

Resolves #1411.