### PR TITLE
Apply Hanami::DB::Testing.database_url

### DIFF
--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -92,8 +92,10 @@ module Hanami
 
         # For "main" slice, expect MAIN__DATABASE_URL
         slice_url_var = "#{target.slice_name.name.gsub("/", "__").upcase}__DATABASE_URL"
+        chosen_url = config.database_url || ENV[slice_url_var] || ENV["DATABASE_URL"]
+        chosen_url &&= Hanami::DB::Testing.database_url(chosen_url) if Hanami.env?(:test)
 
-        @database_url = config.database_url || ENV[slice_url_var] || ENV["DATABASE_URL"]
+        @database_url = chosen_url
       end
 
       def apply_parent_provider_config


### PR DESCRIPTION
This integrates test database renaming when HANAMI_ENV=test

Closes hanami/hanami#1395

As per [our discussion](https://github.com/orgs/hanami/projects/6/views/1?pane=issue&itemId=64371170), I am relying on the unit testing in hanami-db. Integration testing this won't be possible until there is a testing database running in CI.