### PR TITLE
Replace ROM::Inflector in DB Provider

### DIFF
--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -24,6 +24,7 @@ module Hanami
         prepare_and_import_parent_db and return if import_from_parent?
 
         apply_parent_provider_config
+        override_rom_inflector
 
         require "hanami-db"
 
@@ -151,6 +152,20 @@ module Hanami
         target.parent.start :db
 
         register "rom", target.parent["db.rom"]
+      end
+
+      # ROM 5.3 doesn't have a configurable inflector.
+      #
+      # This is a problem in Hanami because using different
+      # inflection rules for ROM will lead to constant loading
+      # errors.
+      def override_rom_inflector
+        return if ROM::Inflector == Hanami.app["inflector"]
+
+        ROM.instance_eval {
+          remove_const :Inflector
+          const_set :Inflector, Hanami.app["inflector"]
+        }
       end
     end
 

--- a/spec/integration/db/db_inflector_spec.rb
+++ b/spec/integration/db/db_inflector_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "dry/system"
+
+RSpec.describe "ROM::Inflector", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  around :each do |example|
+    inflector = ROM::Inflector
+    ROM.instance_eval {
+      remove_const :Inflector
+      const_set :Inflector, Dry::Inflector.new
+    }
+    example.run
+  ensure
+    ROM.instance_eval {
+      remove_const :Inflector
+      const_set :Inflector, inflector
+    }
+  end
+
+  it "replaces ROM::Inflector with the Hanami inflector" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      expect { Hanami.app.prepare :db }.to change { ROM::Inflector == Hanami.app["inflector"] }.from(false).to(true)
+    end
+  end
+end


### PR DESCRIPTION
Inconsistent inflections between ROM and Hanami will lead to constant loading errors. Since ROM 5.3 does not include a configuration setting for inflection, we have to swap out the constant manually.

Closes #1400

I chose the `remove_const` approach for this. The other common solution is to set `$VERBOSE` to false momentarily, but this felt like a more surgical approach.