### PR TITLE
Access providers via `#[]` method

### DIFF
--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -152,7 +152,7 @@ module Hanami
         register_provider(:inflector, source: Hanami::Providers::Inflector)
 
         # Allow logger to be replaced by users with a manual provider, for advanced cases
-        unless container.providers.find_and_load_provider(:logger)
+        unless container.providers[:logger]
           require_relative "providers/logger"
           register_provider(:logger, source: Hanami::Providers::Logger)
         end

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -131,7 +131,7 @@ module Hanami
         return @parent_db_provider if instance_variable_defined?(:@parent_db_provider)
 
         @parent_db_provider = target.parent &&
-          target.parent.container.providers.find_and_load_provider(:db)
+          target.parent.container.providers[:db]
       end
 
       def import_from_parent?

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -941,11 +941,11 @@ module Hanami
           require_relative "providers/db"
 
           # Only register providers if the user hasn't provided their own
-          if !container.providers.find_and_load_provider(:db)
+          if !container.providers[:db]
             register_provider(:db, namespace: true, source: Providers::DB)
           end
 
-          if !container.providers.find_and_load_provider(:relations)
+          if !container.providers[:relations]
             register_provider(:relations, namespace: true, source: Providers::Relations)
           end
         end
@@ -1099,7 +1099,7 @@ module Hanami
       def import_db_from_parent?
         parent &&
           config.db.import_from_parent &&
-          parent.container.providers.find_and_load_provider(:db)
+          parent.container.providers[:db]
       end
 
       # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
Now that dry-system is updated to find and load providers when accessing them via `#[]` (see https://github.com/dry-rb/dry-system/pull/273), we can use this shorter, nicer method.