### PR TITLE
Fix name attribute generation in fields_for_collection when base name provided

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -226,10 +226,8 @@ module Hanami
         # @api public
         # @since 2.1.0
         def fields_for_collection(name, &block)
-          collection_base_name = [base_name, name.to_s].compact.join(INPUT_NAME_SEPARATOR)
-
           _value(name).each_with_index do |value, index|
-            fields_for("#{collection_base_name}.#{index}", index, value, &block)
+            fields_for("#{name}.#{index}", index, value, &block)
           end
         end
 

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -399,18 +399,18 @@ RSpec.describe Hanami::Helpers::FormHelper do
 
       it "renders" do
         html = render(<<~ERB)
-        <%= form_for("book", "/books") do |f| %>
-          <% f.fields_for_collection "categories" do |fa| %>
-            <%= fa.text_field :name %>
+          <%= form_for("book", "/books") do |f| %>
+            <% f.fields_for_collection "categories" do |fa| %>
+              <%= fa.text_field :name %>
+            <% end %>
           <% end %>
-        <% end %>
         ERB
 
         expected = <<~HTML
-        <form action="/books" accept-charset="utf-8" method="POST">
-          <input type="text" name="book[categories][][name]" id="book-categories-0-name" value="foo">
-          <input type="text" name="book[categories][][name]" id="book-categories-1-name" value="bar">
-        </form>
+          <form action="/books" accept-charset="utf-8" method="POST">
+            <input type="text" name="book[categories][][name]" id="book-categories-0-name" value="foo">
+            <input type="text" name="book[categories][][name]" id="book-categories-1-name" value="bar">
+          </form>
         HTML
 
         expect(html).to eq_html(expected)

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -393,6 +393,29 @@ RSpec.describe Hanami::Helpers::FormHelper do
 
       expect(html).to eq_html(expected)
     end
+
+    context "with base name" do
+      let(:params) { {book: {categories: [{name: "foo"}, {name: "bar"}]}} }
+
+      it "renders" do
+        html = render(<<~ERB)
+        <%= form_for("book", "/books") do |f| %>
+          <% f.fields_for_collection "categories" do |fa| %>
+            <%= fa.text_field :name %>
+          <% end %>
+        <% end %>
+        ERB
+
+        expected = <<~HTML
+        <form action="/books" accept-charset="utf-8" method="POST">
+          <input type="text" name="book[categories][][name]" id="book-categories-0-name" value="foo">
+          <input type="text" name="book[categories][][name]" id="book-categories-1-name" value="bar">
+        </form>
+        HTML
+
+        expect(html).to eq_html(expected)
+      end
+    end
   end
 
   describe "#label" do


### PR DESCRIPTION
## Summary

When using the `fields_for_collection` form helper method with a base name provided to the parent `form_for`, the name attributes of all form elements within the collection are incorrectly formed (as are the id attributes). This leads to two issues:

1. Incorrect name attributes lead to unexpected parameter names when the submitted data is parsed by Rack.
2. The form builder is unable to provide a correct value attribute, because the `_value` method is also provided an incorrect key path to the proper value. This will always return a value of nil (unless the incorrect key path happens to exist :monocle_face:).

## Expected behavior

With the following parameters in the request object (or a similar exposure provided in the view):

```ruby
{book: {categories: [{name: "foo"}, {name: "bar"}] }}
```

and the following erb code in the template:

```ruby
<%= form_for("book", "/books") do |f| %>
  <% f.fields_for_collection "categories" do |fa| %>
    <%= fa.text_field :name %>
  <% end %>
<% end %>
```

The helper should render:

```ruby
<form action="/books" accept-charset="utf-8" method="POST">
  <input type="text" name="book[categories][][name]" id="book-categories-0-name" value="foo">
  <input type="text" name="book[categories][][name]" id="book-categories-1-name" value="bar">
</form>
```

## Actual behavior

Instead it renders:

```ruby
<form action="/books" accept-charset="utf-8" method="POST">
  <input type="text" name="book[book][categories][][name]" id="book-book-categories-0-name" value="">
  <input type="text" name="book[book][categories][][name]" id="book-book-categories-1-name" value="">
</form>
```

## Discussion

As you can see, the base name is applied twice to all name and id attributes in the collection. This pull request includes a test to reproduce the error, and a change to make the test pass.

Resolves #1420