### PR TITLE
Correct handling of symbols by label form helper

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -295,7 +295,7 @@ module Hanami
           attributes[:for] = _input_id(attributes[:for] || content)
 
           if content && !for_attribute_given
-            content = inflector.humanize(content.split(INPUT_NAME_SEPARATOR).last)
+            content = inflector.humanize(content.to_s.split(INPUT_NAME_SEPARATOR).last)
           end
 
           tag.label(content, **attributes, &block)

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -404,6 +404,14 @@ RSpec.describe Hanami::Helpers::FormHelper do
       expect(html).to include %(<label for="book-free-shipping">Free shipping</label>)
     end
 
+    it "accepts a symbol" do
+      html = form_for("/books") do |f|
+        f.label :free_shipping
+      end
+
+      expect(html).to include %(<label for="free-shipping">Free shipping</label>)
+    end
+
     it "accepts a string as custom content" do
       html = form_for("/books") do |f|
         f.label "Free Shipping!", for: "book.free_shipping"


### PR DESCRIPTION
## Summary

When provided a symbol argument, the `label` form helper produces an error.

## Expected behavior

I'm not sure what the correct actual behavior is, so this may not be an issue at all. In all of the examples I saw in the [unpublished docs](https://github.com/hanami/guides/blob/guides-2.1/content/v2.1/helpers/form_helper.md) for `form_for` and its related helpers, all of the name/content method arguments are shown as strings. However, I noticed that some of the tests (notably the `fields_for_collection` tests) use symbol arguments.

If symbols are acceptable arguments, then `label` does not currently parse them correctly.

When the following erb template is used:

```ruby
<%= form_for("/books") do |f| %>
  <%= f.label :free_shipping %>
<% end %>
```

It should produce:

```html
<label for="free-shipping">Free shipping</label>
```

## Actual behavior

Instead, an error is produced:

```ruby
undefined method `split' for :free_shipping:Symbol
```

## Discussion

If symbols should be accepted as the `content` argument to the `label` form helper, this pull request includes a fix.

Resolves #1422 