### PR TITLE
Add DB provider adapter config & sensible defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,9 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
-gem "dry-system", github: "dry-rb/dry-system", branch: "main"
+gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "allow-multiple-includes"
 gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
+gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 
 # This is needed for settings specs to pass
 gem "dry-types"

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
-gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "allow-multiple-includes"
+gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
 gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -18,6 +18,7 @@ module Hanami
   def self.loader
     @loader ||= Zeitwerk::Loader.for_gem.tap do |loader|
       loader.inflector.inflect "db" => "DB"
+      loader.inflector.inflect "sql_adapter" => "SQLAdapter"
       loader.ignore(
         "#{loader.dirs.first}/hanami/{constants,boot,errors,extensions/router/errors,prepare,rake_tasks,setup}.rb"
       )

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -132,7 +132,6 @@ module Hanami
 
         parent_db_provider.source.config.adapters.each do |adapter_name, parent_adapter|
           adapter = config.adapters[adapter_name]
-          # binding.irb if target == Main::Slice
 
           adapter.class.settings.keys.each do |key|
             next if adapter.config.configured?(key)

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -47,12 +47,11 @@ module Hanami
         @rom_config = ROM::Configuration.new(gateway)
 
         config.each_plugin do |plugin_spec, config_block|
-          @rom_config.plugin(
-            config.adapter,
-            plugin_spec
-          )
-
-          # TODO: figure out what to do with the blocks!!!
+          if config_block
+            @rom_config.plugin(config.adapter, plugin_spec, &config_block)
+          else
+            @rom_config.plugin(config.adapter, plugin_spec)
+          end
         end
 
         register "config", @rom_config

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/configurable"
 require "dry/core"
 
 module Hanami
@@ -8,6 +9,8 @@ module Hanami
     # @since 2.2.0
     class DB < Dry::System::Provider::Source
       extend Dry::Core::Cache
+
+      include Dry::Configurable(config_class: Providers::DB::Config)
 
       setting :database_url
 

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -16,6 +16,8 @@ module Hanami
 
       setting :adapter, default: :sql
 
+      setting :adapters, default: {}
+
       # TODO: Determine ideal default extensions
       # TODO: Switch extensions based on configured adapter
       setting :extensions, default: [:error_sql]

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -59,7 +59,7 @@ module Hanami
         # @api public
         # @since 2.2.0
         def clear
-          plugins.clear
+          config.plugins = nil
           self
         end
       end

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -14,6 +14,10 @@ module Hanami
         # @since 2.2.0
         setting :plugins, default: []
 
+        # @api private
+        def configure_for_database(database_url)
+        end
+
         # @api public
         # @since 2.2.0
         def plugin(**plugin_spec, &config_block)
@@ -27,18 +31,16 @@ module Hanami
         end
 
         # @api private
-        # @since 2.2.0
         def gateway_cache_keys
           gateway_options
         end
 
         # @api private
-        # @since 2.2.0
         def gateway_options
           {}
         end
 
-        # @api private
+        # @api public
         # @since 2.2.0
         def clear
           config.plugins.clear

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -1,0 +1,28 @@
+require "dry/configurable"
+
+module Hanami
+  module Providers
+    class DB < Dry::System::Provider::Source
+      # @api public
+      # @since 2.2.0
+      class Adapter
+        include Dry::Configurable
+
+        setting :plugins, default: {}
+
+        # TODO: move to SQL adapter-specific class
+        setting :extensions, default: []
+
+        def plugin(**options, &block)
+          config.plugins[options] = block
+        end
+
+        def clear
+          config.plugins.clear
+          config.extensions.clear
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -8,15 +8,53 @@ module Hanami
       class Adapter
         include Dry::Configurable
 
-        setting :plugins, default: {}
+        # @api public
+        # @since 2.2.0
+        setting :plugins, default: []
 
         # TODO: move to SQL adapter-specific class
+        # @api public
+        # @since 2.2.0
         setting :extensions, default: []
 
-        def plugin(**options, &block)
-          config.plugins[options] = block
+        # @api public
+        # @since 2.2.0
+        def plugin(**plugin_spec, &config_block)
+          config.plugins << [plugin_spec, config_block]
         end
 
+        # @api public
+        # @since 2.2.0
+        def plugins
+          config.plugins
+        end
+
+        # @api public
+        # @since 2.2.0
+        def extension(*extensions)
+          config.extensions += extensions
+        end
+
+        # @api public
+        # @since 2.2.0
+        def extensions
+          config.extensions
+        end
+
+        # @api private
+        # @since 2.2.0
+        def gateway_cache_keys
+          gateway_options
+        end
+
+        # @api private
+        # @since 2.2.0
+        def gateway_options
+          {extensions: config.extensions}
+        end
+
+        # @api private
+        # @since 2.2.0
         def clear
           config.plugins.clear
           config.extensions.clear

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -15,6 +15,22 @@ module Hanami
         setting :plugins, default: []
 
         # @api private
+        def initialize(...)
+          @skip_defaults = Hash.new(false)
+        end
+
+        # @api public
+        # @since 2.2.0
+        def skip_defaults(setting_name = nil)
+          @skip_defaults[setting_name] = true
+        end
+
+        # @api private
+        private def skip_defaults?(setting_name = nil)
+          @skip_defaults[setting_name]
+        end
+
+        # @api private
         def configure_for_database(database_url)
         end
 

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -12,7 +12,7 @@ module Hanami
 
         # @api public
         # @since 2.2.0
-        setting :plugins, default: []
+        setting :plugins, mutable: true
 
         # @api private
         def initialize(...)
@@ -37,13 +37,13 @@ module Hanami
         # @api public
         # @since 2.2.0
         def plugin(**plugin_spec, &config_block)
-          config.plugins << [plugin_spec, config_block]
+          plugins << [plugin_spec, config_block]
         end
 
         # @api public
         # @since 2.2.0
         def plugins
-          config.plugins
+          config.plugins ||= []
         end
 
         # @api private
@@ -59,7 +59,7 @@ module Hanami
         # @api public
         # @since 2.2.0
         def clear
-          config.plugins.clear
+          plugins.clear
           self
         end
       end

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dry/configurable"
 
 module Hanami

--- a/lib/hanami/providers/db/adapters.rb
+++ b/lib/hanami/providers/db/adapters.rb
@@ -6,6 +6,13 @@ module Hanami
       # @api public
       # @since 2.2.0
       class Adapters
+        # @api private
+        # @since 2.2.0
+        ADAPTER_CLASSES = Hash.new(Adapter).update(
+          sql: SQLAdapter
+        ).freeze
+        private_constant :ADAPTER_CLASSES
+
         extend Forwardable
 
         def_delegators :adapters, :[], :[]=, :each, :to_h
@@ -18,12 +25,7 @@ module Hanami
         # @since 2.2.0
         def initialize
           @adapters = Hash.new do |hsh, key|
-            hsh[key] =
-              if key == :sql
-                SQLAdapter.new
-              else
-                Adapter.new
-              end
+            hsh[key] = ADAPTER_CLASSES[key].new
           end
         end
 

--- a/lib/hanami/providers/db/adapters.rb
+++ b/lib/hanami/providers/db/adapters.rb
@@ -33,7 +33,8 @@ module Hanami
         # @since 2.2.0
         def initialize_copy(source)
           @adapters = source.adapters.dup
-          @adapters.each do |key, val|
+
+          source.adapters.each do |key, val|
             @adapters[key] = val.dup
           end
         end

--- a/lib/hanami/providers/db/adapters.rb
+++ b/lib/hanami/providers/db/adapters.rb
@@ -1,0 +1,34 @@
+module Hanami
+  module Providers
+    class DB < Dry::System::Provider::Source
+      # @api public
+      # @since 2.2.0
+      class Adapters
+        extend Forwardable
+
+        def_delegators :adapters, :[], :[]=, :each, :to_h
+
+        # @api private
+        # @since 2.2.0
+        attr_reader :adapters
+
+        # @api private
+        # @since 2.2.0
+        def initialize
+          @adapters = Hash.new do |hsh, key|
+            hsh[key] = Adapter.new
+          end
+        end
+
+        # @api private
+        # @since 2.2.0
+        def initialize_copy(source)
+          @adapters = source.adapters.dup
+          @adapters.each do |key, val|
+            @adapters[key] = val.dup
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/providers/db/adapters.rb
+++ b/lib/hanami/providers/db/adapters.rb
@@ -18,7 +18,12 @@ module Hanami
         # @since 2.2.0
         def initialize
           @adapters = Hash.new do |hsh, key|
-            hsh[key] = Adapter.new
+            hsh[key] =
+              if key == :sql
+                SQLAdapter.new
+              else
+                Adapter.new
+              end
           end
         end
 

--- a/lib/hanami/providers/db/adapters.rb
+++ b/lib/hanami/providers/db/adapters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Providers
     class DB < Dry::System::Provider::Source

--- a/lib/hanami/providers/db/config.rb
+++ b/lib/hanami/providers/db/config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Providers
+    class DB < Dry::System::Provider::Source
+      # @api public
+      # @since 2.2.0
+      class Config < Dry::Configurable::Config
+      end
+    end
+  end
+end

--- a/lib/hanami/providers/db/config.rb
+++ b/lib/hanami/providers/db/config.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
+require "dry/core"
+
 module Hanami
   module Providers
     class DB < Dry::System::Provider::Source
       # @api public
       # @since 2.2.0
       class Config < Dry::Configurable::Config
+        include Dry::Core::Constants
+
+        def adapter(adapter_name = Undefined)
+          return self[:adapter] if adapter_name.eql?(Undefined)
+
+          yield adapters[adapter_name] ||= Adapter.new
+        end
+
+        def any_adapter
+          yield adapters[nil] ||= Adapter.new
+        end
       end
     end
   end

--- a/lib/hanami/providers/db/config.rb
+++ b/lib/hanami/providers/db/config.rb
@@ -10,14 +10,55 @@ module Hanami
       class Config < Dry::Configurable::Config
         include Dry::Core::Constants
 
-        def adapter(adapter_name = Undefined)
-          return self[:adapter] if adapter_name.eql?(Undefined)
-
-          yield adapters[adapter_name] ||= Adapter.new
+        # @api public
+        # @since 2.2.0
+        def adapter_name
+          self[:adapter]
         end
 
+        # @api public
+        # @since 2.2.0
+        def adapter(name = Undefined)
+          return adapter_name if name.eql?(Undefined)
+
+          adapter = (adapters[name] ||= Adapter.new)
+          yield adapter if block_given?
+          adapter
+        end
+
+        # @api public
+        # @since 2.2.0
         def any_adapter
-          yield adapters[nil] ||= Adapter.new
+          adapter = (adapters[nil] ||= Adapter.new)
+          yield adapter  if block_given?
+          adapter
+        end
+
+        # @api private
+        # @since 2.2.0
+        def gateway_cache_keys
+          adapters[adapter_name].gateway_cache_keys
+        end
+
+        # @api private
+        # @since 2.2.0
+        def gateway_options
+          adapters[adapter_name].gateway_options
+        end
+
+        # @api public
+        # @since 2.2.0
+        def each_plugin
+          universal_plugins = adapters[nil].plugins
+          adapter_plugins = adapters[adapter_name].plugins
+
+          plugins = universal_plugins + adapter_plugins
+
+          return to_enum(__method__) unless block_given?
+
+          plugins.each do |plugin_spec, config_block|
+            yield plugin_spec, config_block
+          end
         end
       end
     end

--- a/lib/hanami/providers/db/sql_adapter.rb
+++ b/lib/hanami/providers/db/sql_adapter.rb
@@ -1,48 +1,38 @@
 # frozen_string_literal: true
 
-require "dry/configurable"
-
 module Hanami
   module Providers
     class DB < Dry::System::Provider::Source
       # @api public
       # @since 2.2.0
-      class Adapter
-        include Dry::Configurable
+      class SQLAdapter < Adapter
+        # @api public
+        # @since 2.2.0
+        setting :extensions, default: []
 
         # @api public
         # @since 2.2.0
-        setting :plugins, default: []
-
-        # @api public
-        # @since 2.2.0
-        def plugin(**plugin_spec, &config_block)
-          config.plugins << [plugin_spec, config_block]
+        def extension(*extensions)
+          config.extensions += extensions
         end
 
         # @api public
         # @since 2.2.0
-        def plugins
-          config.plugins
-        end
-
-        # @api private
-        # @since 2.2.0
-        def gateway_cache_keys
-          gateway_options
+        def extensions
+          config.extensions
         end
 
         # @api private
         # @since 2.2.0
         def gateway_options
-          {}
+          {extensions: config.extensions}
         end
 
         # @api private
         # @since 2.2.0
         def clear
-          config.plugins.clear
-          self
+          config.extensions.clear
+          super
         end
       end
     end

--- a/lib/hanami/providers/db/sql_adapter.rb
+++ b/lib/hanami/providers/db/sql_adapter.rb
@@ -71,7 +71,7 @@ module Hanami
         # @api public
         # @since 2.2.0
         def clear
-          extensions.clear
+          config.extensions = nil
           super
         end
       end

--- a/lib/hanami/providers/db/sql_adapter.rb
+++ b/lib/hanami/providers/db/sql_adapter.rb
@@ -10,6 +10,35 @@ module Hanami
         # @since 2.2.0
         setting :extensions, default: []
 
+        # @api private
+        def initialize(...)
+          super
+          @cleared = false
+        end
+
+        # @api private
+        def configure_for_database(database_url)
+          return if cleared?
+
+          # Extensions for all SQL databases
+          extension(
+            :caller_logging,
+            :error_sql,
+            :sql_comments
+          )
+
+          # Extensions for specific databases
+          if database_url.start_with?("postgresql://")
+            extension(
+              :pg_array,
+              :pg_json,
+              :pg_range
+            )
+          elsif database_url.start_with?("sqlite://")
+            extension(:sqlite_json_ops)
+          end
+        end
+
         # @api public
         # @since 2.2.0
         def extension(*extensions)
@@ -23,16 +52,20 @@ module Hanami
         end
 
         # @api private
-        # @since 2.2.0
         def gateway_options
           {extensions: config.extensions}
         end
 
-        # @api private
+        # @api public
         # @since 2.2.0
         def clear
+          @cleared = true
           config.extensions.clear
           super
+        end
+
+        def cleared?
+          @cleared
         end
       end
     end

--- a/lib/hanami/providers/db/sql_adapter.rb
+++ b/lib/hanami/providers/db/sql_adapter.rb
@@ -8,18 +8,18 @@ module Hanami
       class SQLAdapter < Adapter
         # @api public
         # @since 2.2.0
-        setting :extensions, default: []
+        setting :extensions, mutable: true
 
         # @api public
         # @since 2.2.0
         def extension(*extensions)
-          config.extensions += extensions
+          self.extensions.concat(extensions)
         end
 
         # @api public
         # @since 2.2.0
         def extensions
-          config.extensions
+          config.extensions ||= []
         end
 
         # @api private
@@ -71,7 +71,7 @@ module Hanami
         # @api public
         # @since 2.2.0
         def clear
-          config.extensions.clear
+          extensions.clear
           super
         end
       end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -935,18 +935,20 @@ module Hanami
           register_provider(:assets, source: Providers::Assets)
         end
 
-        if Hanami.bundled?("hanami-db") && register_db_provider?
+        if Hanami.bundled?("hanami-db")
           # Explicit require here to ensure the provider source registers itself, to allow the user
           # to configure it within their own concrete provider file.
           require_relative "providers/db"
 
-          # Only register providers if the user hasn't provided their own
-          if !container.providers[:db]
-            register_provider(:db, namespace: true, source: Providers::DB)
-          end
+          if register_db_provider?
+            # Only register providers if the user hasn't provided their own
+            if !container.providers[:db]
+              register_provider(:db, namespace: true, source: Providers::DB)
+            end
 
-          if !container.providers[:relations]
-            register_provider(:relations, namespace: true, source: Providers::Relations)
+            if !container.providers[:relations]
+              register_provider(:relations, namespace: true, source: Providers::Relations)
+            end
           end
         end
       end

--- a/spec/integration/db/db_slices_spec.rb
+++ b/spec/integration/db/db_slices_spec.rb
@@ -216,8 +216,6 @@ RSpec.describe "DB / Slices", :app_integration do
       write "config/providers/db.rb", <<~RUBY
         Hanami.app.configure_provider :db do
           config.adapter :sql do |a|
-            # a.skip_defaults
-            # a.plugin relation: :auto_restrictions
             a.extension :exclude_or_null
           end
         end

--- a/spec/integration/db/db_slices_spec.rb
+++ b/spec/integration/db/db_slices_spec.rb
@@ -187,14 +187,9 @@ RSpec.describe "DB / Slices", :app_integration do
         :sql_comments,
       ]
       # Except when it has been explicitly configured in a child slice provider
-      # FIXME: this isn't working
-      # expect(Main::Slice["db.gateway"].options[:extensions]).to eq []
+      expect(Main::Slice["db.gateway"].options[:extensions]).to eq []
 
-      # TODO: Find a way to configure plugins via provider config, so we can share them without
-      # preparing a parent's :db provider (which can lead to establishing unwanted db connections).
-      #
       # Plugins configured in the app's db provider are copied to child slice providers
-
       expect(Admin::Slice["db.config"].setup.plugins.length).to eq 2
       expect(Admin::Slice["db.config"].setup.plugins).to include an_object_satisfying { |plugin|
         plugin.type == :relation && plugin.name == :auto_restrictions

--- a/spec/integration/db/db_slices_spec.rb
+++ b/spec/integration/db/db_slices_spec.rb
@@ -45,13 +45,18 @@ RSpec.describe "DB / Slices", :app_integration do
 
       write "slices/admin/config/providers/db.rb", <<~RUBY
         Admin::Slice.configure_provider :db do
-          config.extensions = []
+          config.adapter :sql do |a|
+            a.extensions.clear
+          end
         end
       RUBY
 
       write "slices/main/config/providers/db.rb", <<~RUBY
         Main::Slice.configure_provider :db do
-          config.extensions = [:error_sql]
+          config.adapter :sql do |a|
+            a.extensions.clear
+            a.extension :error_sql
+          end
         end
       RUBY
 
@@ -82,7 +87,9 @@ RSpec.describe "DB / Slices", :app_integration do
 
       write "config/providers/db.rb", <<~RUBY
         Hanami.app.configure_provider :db do
-          config.extensions += [:exclude_or_null]
+          config.adapter :sql do |a|
+            a.extension :exclude_or_null
+          end
 
           after(:prepare) do
             @rom_config.plugin(:sql, relations: :auto_restrictions)
@@ -112,7 +119,9 @@ RSpec.describe "DB / Slices", :app_integration do
 
       write "slices/main/config/providers/db.rb", <<~RUBY
         Main::Slice.configure_provider :db do
-          config.extensions = []
+          config.adapter :sql do |a|
+            a.extensions.clear
+          end
         end
       RUBY
 
@@ -216,7 +225,9 @@ RSpec.describe "DB / Slices", :app_integration do
 
       write "slices/admin/config/providers/db.rb", <<~RUBY
         Admin::Slice.configure_provider :db do
-          config.extensions = []
+          config.adapter :sql do |a|
+            a.extensions.clear
+          end
         end
       RUBY
 

--- a/spec/integration/db/provider_config_spec.rb
+++ b/spec/integration/db/provider_config_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / Provider / Config", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  it "is a Hanami::Providers::DB::Config" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/db/.keep", ""
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      provider = Hanami.app.container.providers[:db]
+      expect(provider.source.config).to be_an_instance_of Hanami::Providers::DB::Config
+    end
+  end
+end

--- a/spec/integration/db/provider_config_spec.rb
+++ b/spec/integration/db/provider_config_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe "DB / Provider / Config", :app_integration do
     ENV.replace(@env)
   end
 
+  # TODO
+  specify "default config" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/db/.keep", ""
+    end
+  end
+
   it "evaluates plugin config blocks in the context of the provider" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/app.rb", <<~RUBY
@@ -24,7 +40,7 @@ RSpec.describe "DB / Provider / Config", :app_integration do
       write "config/providers/db.rb", <<~RUBY
         Hanami.app.configure_provider :db do
           config.adapter :sql do |a|
-            a.plugins.clear
+            a.skip_defaults :plugins
 
             a.plugin relations: :instrumentation do |plugin|
               plugin.notifications = target["custom_notifications"]

--- a/spec/unit/hanami/providers/db/config/default_config_spec.rb
+++ b/spec/unit/hanami/providers/db/config/default_config_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe "Hanami::Providers::DB / Config / Default config", :app_integrati
     describe "plugins" do
       specify do
         expect(config.adapter(:sql).plugins).to match [
-          [{relations: :instrumentation}, instance_of(Proc)]
+          [{relations: :instrumentation}, instance_of(Proc)],
+          [{relations: :auto_restrictions}, nil],
         ]
       end
 
@@ -97,6 +98,7 @@ RSpec.describe "Hanami::Providers::DB / Config / Default config", :app_integrati
         :error_sql,
         :sql_comments,
         :pg_array,
+        :pg_enum,
         :pg_json,
         :pg_range
       ]

--- a/spec/unit/hanami/providers/db/config/default_config_spec.rb
+++ b/spec/unit/hanami/providers/db/config/default_config_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "dry/system"
+require "hanami/providers/db"
+
+RSpec.describe "Hanami::Providers::DB / Config / Default config", :app_integration do
+  subject(:config) { provider.source.config }
+
+  let(:provider) {
+    Hanami.app.configure_provider(:db)
+    Hanami.app.container.providers[:db]
+  }
+
+  before do
+    module TestApp
+      class App < Hanami::App
+      end
+    end
+  end
+
+  specify "database_url = nil" do
+    expect(config.database_url).to be nil
+  end
+
+  specify "adapter = :sql" do
+    expect(config.adapter).to eq :sql
+  end
+
+  specify %(relations_path = "relations") do
+    expect(config)
+  end
+
+  describe "sql adapter" do
+    before do
+      config.adapter(:sql).configure_for_database("mysql://localhost/test_app_development")
+    end
+
+    specify "extensions" do
+      expect(config.adapter(:sql).extensions).to eq [
+        :caller_logging,
+        :error_sql,
+        :sql_comments
+      ]
+    end
+  end
+
+  describe "sql adapter for postgres" do
+    before do
+      config.adapter(:sql).configure_for_database("postgresql://localhost/test_app_development")
+    end
+
+    specify "extensions" do
+      expect(config.adapters[:sql].extensions).to eq [
+        :caller_logging,
+        :error_sql,
+        :sql_comments,
+        :pg_array,
+        :pg_json,
+        :pg_range
+      ]
+    end
+  end
+
+  describe "sql adapter for sqlite" do
+    before do
+      config.adapter(:sql).configure_for_database("sqlite:///path/to/db.sqlite3")
+    end
+
+    specify "extensions" do
+      expect(config.adapters[:sql].extensions).to eq [
+        :caller_logging,
+        :error_sql,
+        :sql_comments,
+        :sqlite_json_ops
+      ]
+    end
+  end
+end

--- a/spec/unit/hanami/providers/db/config/default_config_spec.rb
+++ b/spec/unit/hanami/providers/db/config/default_config_spec.rb
@@ -32,15 +32,57 @@ RSpec.describe "Hanami::Providers::DB / Config / Default config", :app_integrati
 
   describe "sql adapter" do
     before do
+      skip_defaults if respond_to?(:skip_defaults)
       config.adapter(:sql).configure_for_database("mysql://localhost/test_app_development")
     end
 
-    specify "extensions" do
-      expect(config.adapter(:sql).extensions).to eq [
-        :caller_logging,
-        :error_sql,
-        :sql_comments
-      ]
+    describe "plugins" do
+      specify do
+        expect(config.adapter(:sql).plugins).to match [
+          [{relations: :instrumentation}, instance_of(Proc)]
+        ]
+      end
+
+      describe "skipping defaults" do
+        def skip_defaults
+          config.adapter(:sql).skip_defaults :plugins
+        end
+
+        it "configures no plugins" do
+          expect(config.adapter(:sql).plugins).to eq []
+        end
+      end
+    end
+
+    describe "extensions" do
+      specify do
+        expect(config.adapter(:sql).extensions).to eq [
+          :caller_logging,
+          :error_sql,
+          :sql_comments
+        ]
+      end
+
+      describe "skipping defaults" do
+        def skip_defaults
+          config.adapter(:sql).skip_defaults :extensions
+        end
+
+        it "configures no extensions" do
+          expect(config.adapter(:sql).extensions).to eq []
+        end
+      end
+    end
+
+    describe "skipping all defaults" do
+      def skip_defaults
+        config.adapter(:sql).skip_defaults
+      end
+
+      it "configures no plugins or extensions" do
+        expect(config.adapter(:sql).plugins).to eq []
+        expect(config.adapter(:sql).extensions).to eq []
+      end
     end
   end
 
@@ -57,21 +99,6 @@ RSpec.describe "Hanami::Providers::DB / Config / Default config", :app_integrati
         :pg_array,
         :pg_json,
         :pg_range
-      ]
-    end
-  end
-
-  describe "sql adapter for sqlite" do
-    before do
-      config.adapter(:sql).configure_for_database("sqlite:///path/to/db.sqlite3")
-    end
-
-    specify "extensions" do
-      expect(config.adapters[:sql].extensions).to eq [
-        :caller_logging,
-        :error_sql,
-        :sql_comments,
-        :sqlite_json_ops
       ]
     end
   end

--- a/spec/unit/hanami/providers/db/config_spec.rb
+++ b/spec/unit/hanami/providers/db/config_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
     end
 
     describe "#clear" do
-      it "clears previously configured plugins and extensions" do
+      it "clears previously configured plugins" do
         adapter.plugin relations: :foo
 
         expect { adapter.clear }.to change { adapter.plugins }.to([])
@@ -145,6 +145,17 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
           adapter.clear
           adapter.extension :foo, :bar
           expect(adapter.gateway_options).to eq(extensions: [:foo, :bar])
+        end
+      end
+
+      describe "#clear" do
+        it "clears previously configured plugins and extensions" do
+          adapter.plugin relations: :foo
+          adapter.extension :foo
+
+          expect { adapter.clear }
+            .to change { adapter.plugins }.to([])
+            .and change { adapter.extensions }.to([])
         end
       end
 

--- a/spec/unit/hanami/providers/db/config_spec.rb
+++ b/spec/unit/hanami/providers/db/config_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require "dry/system"
+require "hanami/providers/db"
+
+RSpec.describe "Hanami::Providers::DB.config", :app_integration do
+  subject(:config) { provider.source.config }
+
+  let(:provider) {
+    Hanami.app.configure_provider(:db)
+    Hanami.app.container.providers[:db]
+  }
+
+  before do
+    module TestApp
+      class App < Hanami::App
+      end
+    end
+  end
+
+  describe "default config" do
+    specify "database_url = nil" do
+      expect(config.database_url).to be nil
+    end
+
+    specify "adapter = :sql" do
+      expect(config.adapter).to eq :sql
+    end
+
+    describe "sql adapter" do
+      specify "extensions" do
+        expect(config.adapters[:sql].extensions).to eq [:error_sql]
+      end
+    end
+
+    specify %(relations_path = "relations") do
+      expect(config)
+    end
+  end
+
+  describe "#adapter_name" do
+    it "aliases #adapter" do
+      expect { config.adapter = :yaml }
+        .to change { config.adapter_name }
+        .to :yaml
+    end
+  end
+
+  describe "#adapter" do
+    it "adds an adapter" do
+      expect { config.adapter(:yaml) }
+        .to change { config.adapters.to_h }
+        .to hash_including(:yaml)
+    end
+
+    it "yields the adapter for configuration" do
+      expect { |b| config.adapter(:yaml, &b) }
+        .to yield_with_args(an_instance_of(Hanami::Providers::DB::Adapter))
+    end
+  end
+
+  describe "#any_adapter" do
+    it "adds an adapter keyed without a name" do
+      expect { config.any_adapter }
+        .to change { config.adapters.to_h }
+        .to hash_including(nil)
+    end
+
+    it "yields the adapter for configuration" do
+      expect { |b| config.any_adapter(&b) }
+        .to yield_with_args(an_instance_of(Hanami::Providers::DB::Adapter))
+    end
+  end
+
+  describe "adapters" do
+    subject(:adapter) { config.adapter(:yaml) }
+
+    describe "#plugin" do
+      it "adds a plugin without a block" do
+        expect { adapter.plugin relations: :foo }
+          .to change { adapter.plugins }
+          .to [[{relations: :foo}, nil]]
+      end
+
+      it "adds a plugin with a block" do
+        block = -> plugin_config { }
+
+        expect {
+          adapter.plugin(relations: :foo, &block)
+        }
+          .to change { adapter.plugins }
+          .to [[{relations: :foo}, block]]
+      end
+    end
+
+    describe "#plugins" do
+      it "can be cleared" do
+        adapter.plugin relations: :foo
+
+        expect { adapter.plugins.clear }
+          .to change { adapter.plugins }
+          .to []
+      end
+    end
+
+    describe "#extension" do
+      it "adds an extension" do
+        expect { adapter.extension :foo }
+          .to change { adapter.extensions }
+          .to [:foo]
+      end
+
+      it "adds multiple extensions" do
+        expect { adapter.extension :foo, :bar }
+          .to change { adapter.extensions }
+          .to [:foo, :bar]
+      end
+    end
+
+    describe "#extensions" do
+      it "can be cleareed" do
+        adapter.extension :foo
+
+        expect { adapter.extensions.clear }
+          .to change { adapter.extensions }
+          .to []
+      end
+    end
+
+    describe "#gateway_cache_keys" do
+      it "includes the configured extensions" do
+        adapter.extension :foo, :bar
+        expect(adapter.gateway_cache_keys).to eq(extensions: [:foo, :bar])
+      end
+    end
+
+    describe "#gateway_options" do
+      it "includes the configured extensions" do
+        adapter.extension :foo, :bar
+        expect(adapter.gateway_options).to eq(extensions: [:foo, :bar])
+      end
+    end
+
+    describe "#clear" do
+      it "clears previously configured plugins and extensions" do
+        adapter.plugin relations: :foo
+        adapter.extension :foo
+
+        expect { adapter.clear }
+          .to change { adapter.plugins }.to([])
+          .and change {adapter.extensions }.to([])
+      end
+    end
+  end
+
+  describe "#gateway_cache_keys" do
+    it "returns the cache keys from the currently configured adapter" do
+      config.adapter(:yaml) { |a| a.extension :foo }
+      config.adapter = :yaml
+
+      expect(config.gateway_cache_keys).to eq(config.adapter(:yaml).gateway_cache_keys)
+    end
+  end
+
+  describe "#gateway_options" do
+    it "returns the options from the currently configured adapter" do
+      config.adapter(:yaml) { |a| a.extension :foo }
+      config.adapter = :yaml
+
+      expect(config.gateway_options).to eq(config.adapter(:yaml).gateway_options)
+    end
+  end
+
+  describe "#each_plugin" do
+    before do
+      config.any_adapter { |a| a.plugin relations: :any_foo }
+      config.adapter(:yaml) { |a| a.plugin relations: :yaml_foo }
+      config.adapter = :yaml
+    end
+
+    it "yields the plugins specified for any adapter as well as the currently configured adapter" do
+      expect { |b| config.each_plugin(&b) }
+        .to yield_successive_args(
+          [{relations: :any_foo}, nil],
+          [{relations: :yaml_foo}, nil]
+        )
+    end
+
+    it "returns the plugins as an enumerator if no block is given" do
+      expect(config.each_plugin.to_a).to eq [
+        [{relations: :any_foo}, nil],
+        [{relations: :yaml_foo}, nil]
+      ]
+    end
+  end
+end

--- a/spec/unit/hanami/providers/db/config_spec.rb
+++ b/spec/unit/hanami/providers/db/config_spec.rb
@@ -103,71 +103,93 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
       end
     end
 
-    describe "#extension" do
-      it "adds an extension" do
-        expect { adapter.extension :foo }
-          .to change { adapter.extensions }
-          .to [:foo]
-      end
-
-      it "adds multiple extensions" do
-        expect { adapter.extension :foo, :bar }
-          .to change { adapter.extensions }
-          .to [:foo, :bar]
-      end
-    end
-
-    describe "#extensions" do
-      it "can be cleareed" do
-        adapter.extension :foo
-
-        expect { adapter.extensions.clear }
-          .to change { adapter.extensions }
-          .to []
-      end
-    end
-
     describe "#gateway_cache_keys" do
       it "includes the configured extensions" do
-        adapter.extension :foo, :bar
-        expect(adapter.gateway_cache_keys).to eq(extensions: [:foo, :bar])
+        expect(adapter.gateway_cache_keys).to eq({})
       end
     end
 
     describe "#gateway_options" do
-      it "includes the configured extensions" do
-        adapter.extension :foo, :bar
-        expect(adapter.gateway_options).to eq(extensions: [:foo, :bar])
+      specify do
+        expect(adapter.gateway_options).to eq({})
       end
     end
 
     describe "#clear" do
       it "clears previously configured plugins and extensions" do
         adapter.plugin relations: :foo
-        adapter.extension :foo
+        # adapter.extension :foo
 
         expect { adapter.clear }
           .to change { adapter.plugins }.to([])
-          .and change {adapter.extensions }.to([])
+          # .and change {adapter.extensions }.to([])
       end
+    end
+
+    describe ":sql adapter" do
+      subject(:adapter) { config.adapter(:sql) }
+
+      describe "#extension" do
+        it "adds an extension" do
+          adapter.clear
+          expect { adapter.extension :foo }
+            .to change { adapter.extensions }
+            .to [:foo]
+        end
+
+        it "adds multiple extensions" do
+          adapter.clear
+          expect { adapter.extension :foo, :bar }
+            .to change { adapter.extensions }
+            .to [:foo, :bar]
+        end
+      end
+
+      describe "#extensions" do
+        it "can be cleareed" do
+          adapter.extension :foo
+
+          expect { adapter.extensions.clear }
+            .to change { adapter.extensions }
+            .to []
+        end
+      end
+
+      describe "#gateway_cache_keys" do
+        it "includes the configured extensions" do
+          adapter.clear
+          adapter.extension :foo, :bar
+          expect(adapter.gateway_cache_keys).to eq(extensions: [:foo, :bar])
+        end
+      end
+
+      describe "#gateway_options" do
+        it "includes the configured extensions" do
+          adapter.clear
+          adapter.extension :foo, :bar
+          expect(adapter.gateway_options).to eq(extensions: [:foo, :bar])
+        end
+      end
+
+      # TODO clear
     end
   end
 
   describe "#gateway_cache_keys" do
     it "returns the cache keys from the currently configured adapter" do
-      config.adapter(:yaml) { |a| a.extension :foo }
-      config.adapter = :yaml
+      config.adapter(:sql) { |a| a.clear; a.extension :foo }
+      config.adapter = :sql
 
-      expect(config.gateway_cache_keys).to eq(config.adapter(:yaml).gateway_cache_keys)
+      expect(config.gateway_cache_keys).to eq(config.adapter(:sql).gateway_cache_keys)
     end
   end
 
   describe "#gateway_options" do
     it "returns the options from the currently configured adapter" do
-      config.adapter(:yaml) { |a| a.extension :foo }
-      config.adapter = :yaml
+      config.adapter(:sql) { |a| a.clear; a.extension :foo }
+      config.adapter = :sql
 
-      expect(config.gateway_options).to eq(config.adapter(:yaml).gateway_options)
+      expect(config.gateway_options).to eq(config.adapter(:sql).gateway_options)
     end
   end
 

--- a/spec/unit/hanami/providers/db/config_spec.rb
+++ b/spec/unit/hanami/providers/db/config_spec.rb
@@ -18,26 +18,6 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
     end
   end
 
-  describe "default config" do
-    specify "database_url = nil" do
-      expect(config.database_url).to be nil
-    end
-
-    specify "adapter = :sql" do
-      expect(config.adapter).to eq :sql
-    end
-
-    describe "sql adapter" do
-      specify "extensions" do
-        expect(config.adapters[:sql].extensions).to eq [:error_sql]
-      end
-    end
-
-    specify %(relations_path = "relations") do
-      expect(config)
-    end
-  end
-
   describe "#adapter_name" do
     it "aliases #adapter" do
       expect { config.adapter = :yaml }
@@ -118,11 +98,8 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
     describe "#clear" do
       it "clears previously configured plugins and extensions" do
         adapter.plugin relations: :foo
-        # adapter.extension :foo
 
-        expect { adapter.clear }
-          .to change { adapter.plugins }.to([])
-          # .and change {adapter.extensions }.to([])
+        expect { adapter.clear }.to change { adapter.plugins }.to([])
       end
     end
 


### PR DESCRIPTION
_Note to reviewers: I'm 99% confident this is a good approach and should work well for us. I'm interested in your perspectives on the config API here. Have I missed anything?_

Add adapter config and sensible adapter defaults to the DB provider.

Now you can configure your adapters like so:

```ruby
# config/providers/db.rb

Hanami.app.configure_provider :db do
  config.adapter :sql do |a|
    # Add a Sequel extension (available in :sql adapter only)
    a.extension :some_extension

    # Add a ROM plugin
    a.plugin relations: :some_plugin
  end
end
```

The following defaults are provided for the :sql adapter:

```ruby
plugin relations: :instrumentation do |plugin|
  plugin.notifications = target["notifications"]
end

plugin relations: :auto_restrictions

extension(
  :caller_logging,
  :error_sql,
  :sql_comments
)
```

And in addition for Postgres databases:

```ruby
extension(
  :pg_array,
  :pg_enum,
  :pg_json,
  :pg_range
)
```

These defaults are set as part of the db provider's `prepare` lifecycle step. This is necessary (instead of doing it earlier, i.e. at the stage of establishing the setting defaults) to allow the user to configure and set their `database_url`, which is required to determine the set of defaults to provide.

When configuring the db provider, the defaults may be skipped by the user:

```ruby
Hanami.app.configure_provider :db do
  config.adapter :sql do |a|
    # Skip all defaults
    a.skip_defaults

    # Or plugins only
	a.skip_defaults :plugins

    # Or extensions only
	a.skip_defaults :extensions
  end
end
```

If you want to configure the db provider to use a non-sql adapter, then you can configure it independently:

```ruby
Hanami.app.configure_provider :db do
  config.adapter = :yaml

  config.adapter :yaml do |a|
    # configure plugins here
    # (extensions not available since these are sql-only)
  end
end
```

You can also configure ROM plugins for _any_ adapter via `any_adapter`:

```ruby
Hanami.app.configure_provider :db do
  config.any_adapter do |a|
    # configure plugins here
  end
end
```

This may be useful in an advanced setup where your app uses different ROM adapters, but you want certain plugins to be used consistently across all of them.

For db providers in slices, when using the default `app.config.db.configure_from_parent` arrangement (`true`), adapter config is applied from the parent slice just like any other config.

However, if the configures their own `:sql` adapter in a slice provider (either plugins or extensions), then the respective plugins or extensions from the parent will _not_ be applied. We might be able to provide more sophisticated handling here, but this felt like a reasonable first approach. In a Hanami app with multiple slices but a single shared database, I think it would be unlikely that different ROM plugins or Sequel extensions would be needed on a slice-by-slice basis anyway.

This change depends on https://github.com/dry-rb/dry-configurable/pull/164 to allow for the custom config class we use for the db provider. I'm going to make sure that PR merges first before this one, but I wanted to open this one up for review first.

Resolves #1389, resolves #1409