### PR TITLE
Set up SQL logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "allow-multiple-includes"
 gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
+gem "rom-sql", github: "rom-rb/rom-sql", branch: "release-3.6"
 
 # This is needed for settings specs to pass
 gem "dry-types"

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -18,6 +18,7 @@ module Hanami
   def self.loader
     @loader ||= Zeitwerk::Loader.for_gem.tap do |loader|
       loader.inflector.inflect "db" => "DB"
+      loader.inflector.inflect "db_logging" => "DBLogging"
       loader.inflector.inflect "sql_adapter" => "SQLAdapter"
       loader.ignore(
         "#{loader.dirs.first}/hanami/{constants,boot,errors,extensions/router/errors,prepare,rake_tasks,setup}.rb"

--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -161,6 +161,10 @@ module Hanami
           require_relative "providers/rack"
           register_provider(:rack, source: Hanami::Providers::Rack, namespace: true)
         end
+
+        if Hanami.bundled?("hanami-db")
+          register_provider(:db_logging, source: Hanami::Providers::DBLogging)
+        end
       end
 
       def prepare_autoloader

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -71,6 +71,11 @@ module Hanami
       def start
         start_and_import_parent_db and return if import_from_parent?
 
+        # Set up SQL logging
+        require "dry/monitor/sql/logger"
+        target["notifications"].register_event :sql
+        Dry::Monitor::SQL::Logger.new(target["logger"]).subscribe(target["notifications"])
+
         # Find and register relations
         relations_path = target.source_path.join(config.relations_path)
         relations_path.glob("*.rb").each do |relation_file|

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -71,10 +71,9 @@ module Hanami
       def start
         start_and_import_parent_db and return if import_from_parent?
 
-        # Set up SQL logging
-        require "dry/monitor/sql/logger"
-        target["notifications"].register_event :sql
-        Dry::Monitor::SQL::Logger.new(target["logger"]).subscribe(target["notifications"])
+        # Set up DB logging for the whole app. We share the app's notifications bus across all
+        # slices, so we only need to configure the subsciprtion for DB logging just once.
+        target.app.start :db_logging
 
         # Find and register relations
         relations_path = target.source_path.join(config.relations_path)

--- a/lib/hanami/providers/db_logging.rb
+++ b/lib/hanami/providers/db_logging.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Providers
+    # @api private
+    # @since 2.2.0
+    class DBLogging < Dry::System::Provider::Source
+      # @api private
+      # @since 2.2.0
+      def prepare
+        require "dry/monitor/sql/logger"
+        target["notifications"].register_event :sql
+      end
+
+      # @api private
+      # @since 2.2.0
+      def start
+        Dry::Monitor::SQL::Logger.new(target["logger"]).subscribe(target["notifications"])
+      end
+    end
+  end
+end

--- a/spec/integration/db/db_slices_spec.rb
+++ b/spec/integration/db/db_slices_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe "DB / Slices", :app_integration do
       expect(Admin::Slice["db.rom"].gateways[:default].connection.opts[:uri])
         .to eq Main::Slice["db.rom"].gateways[:default].connection.opts[:uri]
     end
-
   end
 
   specify "using separate relations per slice, while sharing config from the app" do

--- a/spec/integration/db/logging_spec.rb
+++ b/spec/integration/db/logging_spec.rb
@@ -69,4 +69,170 @@ RSpec.describe "DB / Logging", :app_integration do
       expect(log_lines.first).to match /Loaded :sqlite in \d+ms SELECT `posts`.`title` FROM `posts` ORDER BY `posts`.`id`/
     end
   end
+
+  describe "slices sharing app db config" do
+    it "logs SQL queries" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "config/providers/db.rb", <<~RUBY
+          Hanami.app.configure_provider :db do
+          end
+        RUBY
+
+        ENV["DATABASE_URL"] = "sqlite::memory"
+
+        write "slices/admin/relations/posts.rb", <<~RUBY
+          module Admin
+            module Relations
+              class Posts < Hanami::DB::Relation
+                schema :posts, infer: true
+              end
+            end
+          end
+        RUBY
+
+        write "slices/main/relations/posts.rb", <<~RUBY
+          module Main
+            module Relations
+              class Posts < Hanami::DB::Relation
+                schema :posts, infer: true
+              end
+            end
+          end
+        RUBY
+
+        require "hanami/setup"
+
+        logger_stream = StringIO.new
+        Hanami.app.config.logger.stream = logger_stream
+
+        require "hanami/prepare"
+
+        Admin::Slice.prepare :db
+
+        # Manually run a migration
+        gateway = Admin::Slice["db.gateway"]
+        migration = gateway.migration do
+          change do
+            create_table :posts do
+              primary_key :id
+              column :title, :text, null: false
+            end
+          end
+        end
+        migration.apply(gateway, :up)
+        gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+        Hanami.app.boot
+
+        # Booting the app will have the ROM schemas infer themself via some `PRAGMA` queries to the
+        # database, which themselves will emit logs. Clear those logs, since we want to focus on
+        # individual query logging in this test.
+        logger_stream.truncate(0)
+
+        relation = Admin::Slice["relations.posts"]
+        relation.select(:title).to_a
+
+        log_lines = logger_stream.string.split("\n")
+        expect(log_lines.length).to eq 1
+        expect(log_lines.last).to match /Loaded :sqlite in \d+ms SELECT `posts`.`title` FROM `posts` ORDER BY `posts`.`id`/
+
+        relation = Main::Slice["relations.posts"]
+        relation.select(:id).to_a
+
+        log_lines = logger_stream.string.split("\n")
+        expect(log_lines.length).to eq 2
+        expect(log_lines.last).to match /Loaded :sqlite in \d+ms SELECT `posts`.`id` FROM `posts` ORDER BY `posts`.`id`/
+      end
+    end
+  end
+
+  describe "slices with independent db config" do
+    # This is the same test as above, except without the config/providers/db.rb file.
+    it "logs SQL queries" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        ENV["DATABASE_URL"] = "sqlite::memory"
+
+        write "slices/admin/relations/posts.rb", <<~RUBY
+          module Admin
+            module Relations
+              class Posts < Hanami::DB::Relation
+                schema :posts, infer: true
+              end
+            end
+          end
+        RUBY
+
+        write "slices/main/relations/posts.rb", <<~RUBY
+          module Main
+            module Relations
+              class Posts < Hanami::DB::Relation
+                schema :posts, infer: true
+              end
+            end
+          end
+        RUBY
+
+        require "hanami/setup"
+
+        logger_stream = StringIO.new
+        Hanami.app.config.logger.stream = logger_stream
+
+        require "hanami/prepare"
+
+        Admin::Slice.prepare :db
+
+        # Manually run a migration
+        gateway = Admin::Slice["db.gateway"]
+        migration = gateway.migration do
+          change do
+            create_table :posts do
+              primary_key :id
+              column :title, :text, null: false
+            end
+          end
+        end
+        migration.apply(gateway, :up)
+        gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+        Hanami.app.boot
+
+        # Booting the app will have the ROM schemas infer themself via some `PRAGMA` queries to the
+        # database, which themselves will emit logs. Clear those logs, since we want to focus on
+        # individual query logging in this test.
+        logger_stream.truncate(0)
+
+        relation = Admin::Slice["relations.posts"]
+        relation.select(:title).to_a
+
+        log_lines = logger_stream.string.split("\n")
+        expect(log_lines.length).to eq 1
+        expect(log_lines.last).to match /Loaded :sqlite in \d+ms SELECT `posts`.`title` FROM `posts` ORDER BY `posts`.`id`/
+
+        relation = Main::Slice["relations.posts"]
+        relation.select(:id).to_a
+
+        log_lines = logger_stream.string.split("\n")
+        expect(log_lines.length).to eq 2
+        expect(log_lines.last).to match /Loaded :sqlite in \d+ms SELECT `posts`.`id` FROM `posts` ORDER BY `posts`.`id`/
+      end
+    end
+  end
 end

--- a/spec/integration/db/logging_spec.rb
+++ b/spec/integration/db/logging_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / Logging", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  it "logs SQL queries" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/setup"
+
+      logger_stream = StringIO.new
+      Hanami.app.config.logger.stream = logger_stream
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      # Manually run a migration and add a test record
+      gateway = Hanami.app["db.gateway"]
+      migration = gateway.migration do
+        change do
+          create_table :posts do
+            primary_key :id
+            column :title, :text, null: false
+          end
+
+          create_table :authors do
+            primary_key :id
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+      relation = Hanami.app["relations.posts"]
+      expect(relation.select(:title).to_a).to eq [{:title=>"Together breakfast"}]
+
+      logger_stream.rewind
+      log_lines = logger_stream.read.split("\n")
+
+      expect(log_lines.length).to eq 1
+      expect(log_lines.first).to match /Loaded :sqlite in \d+ms SELECT `posts`.`title` FROM `posts` ORDER BY `posts`.`id`/
+    end
+  end
+end


### PR DESCRIPTION
Set up logging of SQL queries by default. To do this, we need to create a `:db_logging` provider at the app level that creates the dry-monitor SQL logger and subscribes it to `:sql` events on the `"notifications"` bus. From the `:db` provider in slices, start this `:db_logging` provider at the app level. Doing this setup in one place ensures we avoid repeated log lines from multiple redundant per-slice SQL logging subscriptions to the app's single notifications bus.

Depends on this fix to rom-sql: https://github.com/rom-rb/rom-sql/pull/428

Resolves #1427