### PR TITLE
Bump dry-inflector and rom-sql dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,7 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
 gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
-gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
-gem "rom-sql", github: "rom-rb/rom-sql", branch: "release-3.6"
 
 # This is needed for settings specs to pass
 gem "dry-types"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler",          ">= 1.16", "< 3"
   spec.add_dependency "dry-configurable", "~> 1.0", "< 2"
   spec.add_dependency "dry-core",         "~> 1.0", "< 2"
-  spec.add_dependency "dry-inflector",    "~> 1.0", "< 2"
+  spec.add_dependency "dry-inflector",    "~> 1.0", ">= 1.1.0", "< 2"
   spec.add_dependency "dry-monitor",      "~> 1.0", ">= 1.0.1", "< 2"
   spec.add_dependency "dry-system",       "~> 1.0", "< 2"
   spec.add_dependency "dry-logger",       "~> 1.0", "< 2"


### PR DESCRIPTION
Depend on [dry-inflector v1.1.0](https://github.com/dry-rb/dry-inflector/releases/tag/v1.1.0) (which has "DB" as a default acronym), and rom-sql 3.6.4 (which has an instrumentation fix) via https://github.com/hanami/db/pull/11.