### PR TITLE
Require dry-configurable >= 1.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
-gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 
 # This is needed for settings specs to pass

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.add_dependency "bundler",          ">= 1.16", "< 3"
-  spec.add_dependency "dry-configurable", "~> 1.0", "< 2"
+  spec.add_dependency "dry-configurable", "~> 1.0", ">= 1.2.0", "< 2"
   spec.add_dependency "dry-core",         "~> 1.0", "< 2"
   spec.add_dependency "dry-inflector",    "~> 1.0", ">= 1.1.0", "< 2"
   spec.add_dependency "dry-monitor",      "~> 1.0", ">= 1.0.1", "< 2"


### PR DESCRIPTION
This includes the support for including Dry::Configurable multiple times in a class hierarchy, which we use for providing the custom config class for the :db provider.