### PR TITLE
Depend on dry-system 1.1.0.beta1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
-gem "dry-system", github: "dry-rb/dry-system", branch: "main"
-
 # This is needed for settings specs to pass
 gem "dry-types"
 

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-core",         "~> 1.0", "< 2"
   spec.add_dependency "dry-inflector",    "~> 1.0", ">= 1.1.0", "< 2"
   spec.add_dependency "dry-monitor",      "~> 1.0", ">= 1.0.1", "< 2"
-  spec.add_dependency "dry-system",       "~> 1.0", "< 2"
+  spec.add_dependency "dry-system",       "= 1.1.0.beta1"
   spec.add_dependency "dry-logger",       "~> 1.0", "< 2"
   spec.add_dependency "hanami-cli",       "~> 2.1"
   spec.add_dependency "hanami-utils",     "~> 2.1"


### PR DESCRIPTION
This is the last of the dependencies still working off a git source, which unblocks our ability to do a 2.2 beta gem release soon.