### PR TITLE
Don't disable prompt for select

### DIFF
--- a/lib/hanami/helpers/form_helper/form_builder.rb
+++ b/lib/hanami/helpers/form_helper/form_builder.rb
@@ -938,7 +938,7 @@ module Hanami
         #
         #   =>
         #   <select name="book[store]" id="book-store" class="form-control">
-        #     <option disabled="disabled">Select a store</option>
+        #     <option>Select a store</option>
         #     <option value="it">Italy</option>
         #     <option value="au">Australia</option>
         #   </select>
@@ -995,7 +995,7 @@ module Hanami
           input_value = _value(name)
 
           option_tags = []
-          option_tags << tag.option(prompt, disabled: true) if prompt
+          option_tags << tag.option(prompt) if prompt
 
           already_selected = nil
           values.each do |content, value|

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -2659,7 +2659,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
           f.select "book.store", option_values, options: {prompt: "Select a store"}
         end
 
-        expect(html).to include %(<select name="book[store]" id="book-store"><option disabled="disabled">Select a store</option><option value="it">Italy</option><option value="us">United States</option></select>)
+        expect(html).to include %(<select name="book[store]" id="book-store"><option>Select a store</option><option value="it">Italy</option><option value="us">United States</option></select>)
       end
 
       it "allows blank string" do
@@ -2667,7 +2667,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
           f.select "book.store", option_values, options: {prompt: ""}
         end
 
-        expect(html).to include %(<select name="book[store]" id="book-store"><option disabled="disabled"></option><option value="it">Italy</option><option value="us">United States</option></select>)
+        expect(html).to include %(<select name="book[store]" id="book-store"><option></option><option value="it">Italy</option><option value="us">United States</option></select>)
       end
 
       context "with values" do
@@ -2679,7 +2679,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
             f.select "book.store", option_values, options: {prompt: "Select a store"}
           end
 
-          expect(html).to include %(<select name="book[store]" id="book-store"><option disabled="disabled">Select a store</option><option value="it" selected="selected">Italy</option><option value="us">United States</option></select>)
+          expect(html).to include %(<select name="book[store]" id="book-store"><option>Select a store</option><option value="it" selected="selected">Italy</option><option value="us">United States</option></select>)
         end
       end
 
@@ -2693,7 +2693,7 @@ RSpec.describe Hanami::Helpers::FormHelper do
               f.select "book.store", option_values, options: {prompt: "Select a store"}
             end
 
-            expect(html).to include %(<select name="book[store]" id="book-store"><option disabled="disabled">Select a store</option><option value="it" selected="selected">Italy</option><option value="us">United States</option></select>)
+            expect(html).to include %(<select name="book[store]" id="book-store"><option>Select a store</option><option value="it" selected="selected">Italy</option><option value="us">United States</option></select>)
           end
         end
 


### PR DESCRIPTION
Disabling the prompt makes it not show as the selected option when it's displayed in the DOM. Instead, the first (non-prompt) option is shown as selected. 

One _could_ mark the prompt as both selected and disabled but then if people pick one of the options, there's no way to go back and make it empty, which is a bad UX anti-pattern.
