### PR TITLE
Introduce Hanami::Provider::Source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
-gem "dry-system", github: "alassek/dry-system", branch: 'provider-class-override'
+gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
 
 # This is needed for settings specs to pass

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
-gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
 
 # This is needed for settings specs to pass
 gem "dry-types"

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
+gem "dry-system", github: "dry-rb/dry-system", branch: "provider-sources-2"
+gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
+
 # This is needed for settings specs to pass
 gem "dry-types"
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
-gem "dry-system", github: "dry-rb/dry-system", branch: "provider-sources-2"
+gem "dry-system", github: "alassek/dry-system", branch: 'provider-class-override'
 gem "dry-inflector", github: "dry-rb/dry-inflector", branch: "main"
 
 # This is needed for settings specs to pass

--- a/lib/hanami/provider/source.rb
+++ b/lib/hanami/provider/source.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Provider
+    class Source < Dry::System::Provider::Source
+      # This would also work, with less overall change (no need for additional `#initialize` args):
+      #
+      #   alias_method :slice, :target_container
+      #
+      # However, I'm showing the below to demonstrate an even more flexible approach.
+
+      attr_reader :slice
+
+      def initialize(slice:, **options, &block)
+        @slice = slice
+        super(**options, &block)
+      end
+    end
+  end
+end

--- a/lib/hanami/provider/source.rb
+++ b/lib/hanami/provider/source.rb
@@ -3,13 +3,10 @@
 module Hanami
   module Provider
     class Source < Dry::System::Provider::Source
-      # This would also work, with less overall change (no need for additional `#initialize` args):
-      #
-      #   alias_method :slice, :target_container
-      #
-      # However, I'm showing the below to demonstrate an even more flexible approach.
-
       attr_reader :slice
+
+      alias_method :target_container, :slice
+      alias_method :target, :slice
 
       def initialize(slice:, **options, &block)
         @slice = slice

--- a/lib/hanami/provider/source.rb
+++ b/lib/hanami/provider/source.rb
@@ -5,13 +5,12 @@ module Hanami
     class Source < Dry::System::Provider::Source
       attr_reader :slice
 
-      alias_method :target_container, :slice
-      alias_method :target, :slice
-
       def initialize(slice:, **options, &block)
         @slice = slice
         super(**options, &block)
       end
+
+      def target_container = slice
     end
   end
 end

--- a/lib/hanami/provider_registrar.rb
+++ b/lib/hanami/provider_registrar.rb
@@ -23,6 +23,8 @@ module Hanami
       slice
     end
 
+    def provider_source_class = Hanami::Provider::Source
+
     def provider_source_options
       {slice: slice}
     end

--- a/lib/hanami/provider_registrar.rb
+++ b/lib/hanami/provider_registrar.rb
@@ -22,5 +22,9 @@ module Hanami
     def target_container
       slice
     end
+
+    def provider_source_options
+      {slice: slice}
+    end
   end
 end

--- a/lib/hanami/provider_registrar.rb
+++ b/lib/hanami/provider_registrar.rb
@@ -19,10 +19,6 @@ module Hanami
       @slice = slice
     end
 
-    def target_container
-      slice
-    end
-
     def provider_source_class = Hanami::Provider::Source
 
     def provider_source_options

--- a/lib/hanami/providers/assets.rb
+++ b/lib/hanami/providers/assets.rb
@@ -9,7 +9,7 @@ module Hanami
     #
     # @api private
     # @since 2.0.0
-    class Assets < Dry::System::Provider::Source
+    class Assets < Hanami::Provider::Source
       # @api private
       def prepare
         require "hanami/assets"
@@ -17,9 +17,9 @@ module Hanami
 
       # @api private
       def start
-        root = target.app.root.join("public", "assets", Hanami::Assets.public_assets_dir(target).to_s)
+        root = slice.app.root.join("public", "assets", Hanami::Assets.public_assets_dir(target).to_s)
 
-        assets = Hanami::Assets.new(config: target.config.assets, root: root)
+        assets = Hanami::Assets.new(config: slice.config.assets, root: root)
 
         register(:assets, assets)
       end

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -8,7 +8,7 @@ module Hanami
   module Providers
     # @api private
     # @since 2.2.0
-    class DB < Dry::System::Provider::Source
+    class DB < Hanami::Provider::Source
       extend Dry::Core::Cache
 
       include Dry::Configurable(config_class: Providers::DB::Config)
@@ -72,8 +72,8 @@ module Hanami
         start_and_import_parent_db and return if import_from_parent?
 
         # Set up DB logging for the whole app. We share the app's notifications bus across all
-        # slices, so we only need to configure the subscription for DB logging just once.
-        target.app.start :db_logging
+        # slices, so we only need to configure the subsciprtion for DB logging just once.
+        slice.app.start :db_logging
 
         # Register ROM components
         register_rom_components :relation, "relations"
@@ -86,7 +86,7 @@ module Hanami
       end
 
       def stop
-        target["db.rom"].disconnect
+        slice["db.rom"].disconnect
       end
 
       # @api private
@@ -94,7 +94,7 @@ module Hanami
         return @database_url if instance_variable_defined?(:@database_url)
 
         # For "main" slice, expect MAIN__DATABASE_URL
-        slice_url_var = "#{target.slice_name.name.gsub("/", "__").upcase}__DATABASE_URL"
+        slice_url_var = "#{slice.slice_name.name.gsub("/", "__").upcase}__DATABASE_URL"
         chosen_url = config.database_url || ENV[slice_url_var] || ENV["DATABASE_URL"]
         chosen_url &&= Hanami::DB::Testing.database_url(chosen_url) if Hanami.env?(:test)
 
@@ -106,7 +106,7 @@ module Hanami
       def parent_db_provider
         return @parent_db_provider if instance_variable_defined?(:@parent_db_provider)
 
-        @parent_db_provider = target.parent && target.parent.container.providers[:db]
+        @parent_db_provider = slice.parent && slice.parent.container.providers[:db]
       end
 
       def apply_parent_config
@@ -134,7 +134,7 @@ module Hanami
       end
 
       def apply_parent_config?
-        target.config.db.configure_from_parent && parent_db_provider
+        slice.config.db.configure_from_parent && parent_db_provider
       end
 
       def configure_for_database
@@ -145,25 +145,25 @@ module Hanami
       end
 
       def import_from_parent?
-        target.config.db.import_from_parent && target.parent
+        slice.config.db.import_from_parent && slice.parent
       end
 
       def prepare_and_import_parent_db
         return unless parent_db_provider
 
-        target.parent.prepare :db
-        @rom_config = target.parent["db.config"]
+        slice.parent.prepare :db
+        @rom_config = slice.parent["db.config"]
 
-        register "config", (@rom_config = target.parent["db.config"])
-        register "gateway", target.parent["db.gateway"]
+        register "config", (@rom_config = slice.parent["db.config"])
+        register "gateway", slice.parent["db.gateway"]
       end
 
       def start_and_import_parent_db
         return unless parent_db_provider
 
-        target.parent.start :db
+        slice.parent.start :db
 
-        register "rom", target.parent["db.rom"]
+        register "rom", slice.parent["db.rom"]
       end
 
       # ROM 5.3 doesn't have a configurable inflector.

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -4,7 +4,7 @@ require "dry/configurable"
 
 module Hanami
   module Providers
-    class DB < Dry::System::Provider::Source
+    class DB < Hanami::Provider::Source
       # @api public
       # @since 2.2.0
       class Adapter

--- a/lib/hanami/providers/db/adapters.rb
+++ b/lib/hanami/providers/db/adapters.rb
@@ -2,7 +2,7 @@
 
 module Hanami
   module Providers
-    class DB < Dry::System::Provider::Source
+    class DB < Hanami::Provider::Source
       # @api public
       # @since 2.2.0
       class Adapters

--- a/lib/hanami/providers/db/config.rb
+++ b/lib/hanami/providers/db/config.rb
@@ -4,7 +4,7 @@ require "dry/core"
 
 module Hanami
   module Providers
-    class DB < Dry::System::Provider::Source
+    class DB < Hanami::Provider::Source
       # @api public
       # @since 2.2.0
       class Config < Dry::Configurable::Config

--- a/lib/hanami/providers/db/sql_adapter.rb
+++ b/lib/hanami/providers/db/sql_adapter.rb
@@ -2,7 +2,7 @@
 
 module Hanami
   module Providers
-    class DB < Dry::System::Provider::Source
+    class DB < Hanami::Provider::Source
       # @api public
       # @since 2.2.0
       class SQLAdapter < Adapter

--- a/lib/hanami/providers/db_logging.rb
+++ b/lib/hanami/providers/db_logging.rb
@@ -4,18 +4,18 @@ module Hanami
   module Providers
     # @api private
     # @since 2.2.0
-    class DBLogging < Dry::System::Provider::Source
+    class DBLogging < Hanami::Provider::Source
       # @api private
       # @since 2.2.0
       def prepare
         require "dry/monitor/sql/logger"
-        target["notifications"].register_event :sql
+        slice["notifications"].register_event :sql
       end
 
       # @api private
       # @since 2.2.0
       def start
-        Dry::Monitor::SQL::Logger.new(target["logger"]).subscribe(target["notifications"])
+        Dry::Monitor::SQL::Logger.new(slice["logger"]).subscribe(slice["notifications"])
       end
     end
   end

--- a/lib/hanami/providers/inflector.rb
+++ b/lib/hanami/providers/inflector.rb
@@ -7,7 +7,7 @@ module Hanami
     #
     # @api private
     # @since 2.0.0
-    class Inflector < Dry::System::Provider::Source
+    class Inflector < Hanami::Provider::Source
       # @api private
       def start
         register :inflector, Hanami.app.inflector

--- a/lib/hanami/providers/logger.rb
+++ b/lib/hanami/providers/logger.rb
@@ -9,7 +9,7 @@ module Hanami
     #
     # @api private
     # @since 2.0.0
-    class Logger < Dry::System::Provider::Source
+    class Logger < Hanami::Provider::Source
       # @api private
       def start
         register :logger, Hanami.app.config.logger_instance

--- a/lib/hanami/providers/rack.rb
+++ b/lib/hanami/providers/rack.rb
@@ -12,7 +12,7 @@ module Hanami
     #
     # @api private
     # @since 2.0.0
-    class Rack < Dry::System::Provider::Source
+    class Rack < Hanami::Provider::Source
       # @api private
       def prepare
         Dry::Monitor.load_extensions(:rack)
@@ -30,14 +30,14 @@ module Hanami
 
       # @api private
       def start
-        target.start :logger
+        slice.start :logger
 
         monitor_middleware = Dry::Monitor::Rack::Middleware.new(
           target["notifications"],
           clock: Dry::Monitor::Clock.new(unit: :microsecond)
         )
 
-        rack_logger = Hanami::Web::RackLogger.new(target[:logger], env: target.container.env)
+        rack_logger = Hanami::Web::RackLogger.new(target[:logger], env: slice.container.env)
         rack_logger.attach(monitor_middleware)
 
         register "monitor", monitor_middleware

--- a/lib/hanami/providers/relations.rb
+++ b/lib/hanami/providers/relations.rb
@@ -4,11 +4,11 @@ module Hanami
   module Providers
     # @api private
     # @since 2.2.0
-    class Relations < Dry::System::Provider::Source
+    class Relations < Hanami::Provider::Source
       def start
-        start_and_import_parent_relations and return if target.parent && target.config.db.import_from_parent
+        start_and_import_parent_relations and return if slice.parent && slice.config.db.import_from_parent
 
-        target.start :db
+        slice.start :db
 
         register_relations target["db.rom"]
       end
@@ -22,9 +22,9 @@ module Hanami
       end
 
       def start_and_import_parent_relations
-        target.parent.start :relations
+        slice.parent.start :relations
 
-        register_relations target.parent["db.rom"]
+        register_relations slice.parent["db.rom"]
       end
     end
   end

--- a/lib/hanami/providers/routes.rb
+++ b/lib/hanami/providers/routes.rb
@@ -9,7 +9,7 @@ module Hanami
     #
     # @api private
     # @since 2.0.0
-    class Routes < Dry::System::Provider::Source
+    class Routes < Hanami::Provider::Source
       # @api private
       def prepare
         require "hanami/slice/routes_helper"
@@ -21,7 +21,7 @@ module Hanami
         # router during the process of booting. This ensures the router's resolver can run strict
         # action key checks once when it runs on a fully booted slice.
         register :routes do
-          Hanami::Slice::RoutesHelper.new(target.router)
+          Hanami::Slice::RoutesHelper.new(slice.router)
         end
       end
     end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -876,6 +876,7 @@ module Hanami
         container.config.name = slice_name.to_sym
         container.config.root = root
         container.config.provider_registrar = ProviderRegistrar.for_slice(self)
+        container.config.provider_source_class = Hanami::Provider::Source
         container.config.provider_dirs = [File.join("config", "providers")]
         container.config.registrations_dir = File.join("config", "registrations")
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -876,7 +876,6 @@ module Hanami
         container.config.name = slice_name.to_sym
         container.config.root = root
         container.config.provider_registrar = ProviderRegistrar.for_slice(self)
-        container.config.provider_source_class = Hanami::Provider::Source
         container.config.provider_dirs = [File.join("config", "providers")]
         container.config.registrations_dir = File.join("config", "registrations")
 

--- a/spec/unit/hanami/providers/db/config/default_config_spec.rb
+++ b/spec/unit/hanami/providers/db/config/default_config_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Hanami::Providers::DB / Config / Default config", :app_integrati
   subject(:config) { provider.source.config }
 
   let(:provider) {
+    Hanami.app.prepare
     Hanami.app.configure_provider(:db)
     Hanami.app.container.providers[:db]
   }

--- a/spec/unit/hanami/providers/db/config_spec.rb
+++ b/spec/unit/hanami/providers/db/config_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
   subject(:config) { provider.source.config }
 
   let(:provider) {
+    Hanami.app.prepare
     Hanami.app.configure_provider(:db)
     Hanami.app.container.providers[:db]
   }


### PR DESCRIPTION
`Hanami::ProviderRegistrar` uses a custom superclass, `Hanami::Provider::Source`, for user-defined sources. This provides a `slice` method within the source.

Closes #1417 