### PR TITLE
default to development.log instead of stdout

### DIFF
--- a/lib/hanami/config/logger.rb
+++ b/lib/hanami/config/logger.rb
@@ -124,7 +124,7 @@ module Hanami
         case env
         when :development, :test
           config.level = :debug
-          config.stream = File.join("log", "#{env}.log") if env == :test
+          config.stream = File.join("log", "#{env}.log")
           config.logger_constructor = method(:development_logger)
         else
           config.level = :info

--- a/spec/unit/hanami/config/logger_spec.rb
+++ b/spec/unit/hanami/config/logger_spec.rb
@@ -40,17 +40,17 @@ RSpec.describe Hanami::Config::Logger do
   end
 
   describe "#stream" do
-    it "defaults to $stdout" do
-      expect(subject.stream).to eq($stdout)
+    it "defaults to file" do
+      expected = File.join("log", "#{subject.env}.log")
+
+      expect(subject.stream).to eq(expected)
     end
 
-    context "when :test environment" do
-      let(:env) { :test }
+    context "when :production environment" do
+      let(:env) { :production }
 
-      it "returns a file" do
-        expected = File.join("log", "test.log")
-
-        expect(subject.stream).to eq(expected)
+      it "writes to $stdout" do
+        expect(subject.stream).to eq($stdout)
       end
     end
   end


### PR DESCRIPTION
closes [#1442](https://github.com/hanami/hanami/issues/1442)