### PR TITLE
Register ROM commands and mappers

### DIFF
--- a/lib/hanami/constants.rb
+++ b/lib/hanami/constants.rb
@@ -52,4 +52,8 @@ module Hanami
   # @api private
   RB_EXT = ".rb"
   private_constant :RB_EXT
+
+  # @api private
+  RB_EXT_REGEXP = %r{.rb$}
+  private_constant :RB_EXT_REGEXP
 end

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -105,7 +105,20 @@ module Hanami
           @rom_config.register_command(command_class)
         end
 
-        # TODO: register mappers
+        # Find and register mappers
+        mappers_path = target.source_path.join("db", "mappers")
+        mappers_path.glob("**/*.rb").each do |mapper_file|
+          mapper_name = mapper_file
+            .relative_path_from(mappers_path)
+            .sub(Regexp.new("#{Regexp.escape(mapper_file.extname)}$"), "") # TODO: more efficient way?
+            .to_s
+
+          mapper_class = target.inflector.camelize(
+            "#{target.slice_name.name}/db/mappers/#{mapper_name}"
+          ).then { target.inflector.constantize(_1) }
+
+          @rom_config.register_mapper(mapper_class)
+        end
 
         rom = ROM.container(@rom_config)
 

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -2,6 +2,7 @@
 
 require "dry/configurable"
 require "dry/core"
+require_relative "../constants"
 
 module Hanami
   module Providers
@@ -95,7 +96,7 @@ module Hanami
         commands_path.glob("**/*.rb").each do |command_file|
           command_name = command_file
             .relative_path_from(commands_path)
-            .sub(Regexp.new("#{Regexp.escape(command_file.extname)}$"), "") # TODO: more efficient way?
+            .sub(RB_EXT_REGEXP, "")
             .to_s
 
           command_class = target.inflector.camelize(
@@ -110,7 +111,7 @@ module Hanami
         mappers_path.glob("**/*.rb").each do |mapper_file|
           mapper_name = mapper_file
             .relative_path_from(mappers_path)
-            .sub(Regexp.new("#{Regexp.escape(mapper_file.extname)}$"), "") # TODO: more efficient way?
+            .sub(RB_EXT_REGEXP, "")
             .to_s
 
           mapper_class = target.inflector.camelize(

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -90,7 +90,22 @@ module Hanami
           @rom_config.register_relation(relation_class)
         end
 
-        # TODO: register mappers & commands
+        # Find and register commands
+        commands_path = target.source_path.join("db", "commands")
+        commands_path.glob("**/*.rb").each do |command_file|
+          command_name = command_file
+            .relative_path_from(commands_path)
+            .sub(Regexp.new("#{Regexp.escape(command_file.extname)}$"), "") # TODO: more efficient way?
+            .to_s
+
+          command_class = target.inflector.camelize(
+            "#{target.slice_name.name}/db/commands/#{command_name}"
+          ).then { target.inflector.constantize(_1) }
+
+          @rom_config.register_command(command_class)
+        end
+
+        # TODO: register mappers
 
         rom = ROM.container(@rom_config)
 

--- a/spec/integration/db/commands_spec.rb
+++ b/spec/integration/db/commands_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / Commands", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  it "registers custom commands" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      write "app/db/commands/nested/create_post_with_default_title.rb", <<~RUBY
+        module TestApp
+          module DB
+            module Commands
+              module Nested
+                class CreatePostWithDefaultTitle < ROM::SQL::Commands::Create
+                  relation :posts
+                  register_as :create_with_default_title
+                  result :one
+
+                  before :set_title
+
+                  def set_title(tuple, *)
+                    tuple[:title] ||= "Default title from command"
+                    tuple
+                  end
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      # Manually run a migration and add a test record
+      gateway = TestApp::App["db.gateway"]
+      migration = gateway.migration do
+        change do
+          create_table :posts do
+            primary_key :id
+            column :title, :text, null: false
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+
+      post = TestApp::App["relations.posts"].command(:create_with_default_title).call({})
+      expect(post[:title]).to eq "Default title from command"
+    end
+  end
+end

--- a/spec/integration/db/mappers_spec.rb
+++ b/spec/integration/db/mappers_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / Mappers", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  it "registers custom mappers" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      write "app/db/mappers/nested/default_title_mapper.rb", <<~RUBY
+        require "rom/transformer"
+
+        module TestApp
+          module DB
+            module Mappers
+              module Nested
+                class DefaultTitleMapper < ROM::Transformer
+                  relation :posts
+                  register_as :default_title_mapper
+
+                  map do
+                    set_default_title
+                  end
+
+                  def set_default_title(row)
+                    row[:title] ||= "Default title from mapper"
+                    row
+                  end
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      # Manually run a migration and add a test record
+      gateway = TestApp::App["db.gateway"]
+      migration = gateway.migration do
+        change do
+          create_table :posts do
+            primary_key :id
+            column :title, :text
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES (NULL)")
+
+      post = TestApp::App["relations.posts"].map_with(:default_title_mapper).to_a[0]
+      expect(post[:title]).to eq "Default title from mapper"
+    end
+  end
+end

--- a/spec/integration/db/relations_spec.rb
+++ b/spec/integration/db/relations_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / Relations", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  it "registers nested relations" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "app/relations/nested/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            module Nested
+              class Posts < Hanami::DB::Relation
+                schema :posts, infer: true
+              end
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      # Manually run a migration and add a test record
+      gateway = TestApp::App["db.gateway"]
+      migration = gateway.migration do
+        change do
+          create_table :posts do
+            primary_key :id
+            column :title, :text
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES ('Hi from nested relation')")
+
+      post = TestApp::App["relations.posts"].to_a[0]
+      expect(post[:title]).to eq "Hi from nested relation"
+    end
+  end
+end


### PR DESCRIPTION
Register ROM commands from `db/commands/` and mappers from `db/mappers/`. Support registration of components from deeply nested files within these directories.

Update ROM relation registration to also support nested files.

Extract ROM component registration code into a private method and use it to register all ROM components: relations, commands, mappers.

Remove `relations_path` setting from `:db` provider: it will be simpler to support a single location only for relations in our first release of the Hanami 2 DB layer.

Resolves #1391, resolves #1441, resolves #1449