### PR TITLE
Add connection_options to Hanami::Providers::DB::Gateway

### DIFF
--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -207,7 +207,7 @@ module Hanami
             ROM::Gateway.setup(
               gw_config.adapter_name,
               gw_config.database_url,
-              **gw_config.adapter.gateway_options
+              **gw_config.options
             )
           }
         }

--- a/lib/hanami/providers/db/gateway.rb
+++ b/lib/hanami/providers/db/gateway.rb
@@ -15,6 +15,7 @@ module Hanami
         setting :database_url
         setting :adapter_name, default: :sql
         setting :adapter, mutable: true
+        setting :connection_options, default: {}
 
         # @api public
         # @since 2.2.0
@@ -34,6 +35,22 @@ module Hanami
           end
         end
 
+        # @api public
+        # @since 2.2.0
+        def connection_options(**options)
+          if options.any?
+            config.connection_options.merge!(options)
+          end
+
+          config.connection_options
+        end
+
+        # @api public
+        # @since 2.2.0
+        def options
+          {**connection_options, **adapter.gateway_options}
+        end
+
         # @api private
         def configure_adapter(default_adapters)
           default_adapter = default_adapters[config.adapter_name]
@@ -48,7 +65,7 @@ module Hanami
 
         # @api private
         def cache_keys
-          [config.database_url, config.adapter.gateway_cache_keys]
+          [config.database_url, config.connection_options, config.adapter.gateway_cache_keys]
         end
 
         private

--- a/lib/hanami/providers/db/sql_adapter.rb
+++ b/lib/hanami/providers/db/sql_adapter.rb
@@ -85,7 +85,7 @@ module Hanami
 
         # @api private
         def gateway_options
-          {extensions: config.extensions}
+          {extensions: extensions}
         end
 
         # @api public

--- a/lib/hanami/providers/db/sql_adapter.rb
+++ b/lib/hanami/providers/db/sql_adapter.rb
@@ -73,7 +73,7 @@ module Hanami
           )
 
           # Extensions for specific databases
-          if database_url.to_s.start_with?(%r{postgres(ql)*://}) # FIXME: what is the canonical postgres URL?
+          if database_url.to_s.start_with?(%r{postgres(ql)*://})
             extension(
               :pg_array,
               :pg_enum,

--- a/spec/unit/hanami/providers/db/config/gateway_spec.rb
+++ b/spec/unit/hanami/providers/db/config/gateway_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "dry/system"
+require "hanami/providers/db"
+
+RSpec.describe "Hanami::Providers::DB / Config / Gateway config", :app_integration do
+  subject(:config) { provider.source.config }
+
+  let(:provider) {
+    Hanami.app.prepare
+    Hanami.app.configure_provider(:db)
+    Hanami.app.container.providers[:db]
+  }
+
+  before do
+    module TestApp
+      class App < Hanami::App
+      end
+    end
+  end
+
+  describe "sql adapter" do
+    before do
+      config.adapter(:sql).configure_for_database("sqlite::memory")
+    end
+
+    describe "connection_options" do
+      let(:default) { config.gateway(:default) }
+
+      it "merges kwargs into connection_options configuration" do
+        expect { default.connection_options(timeout: 10_000) }
+          .to change { default.connection_options }.from({}).to({timeout: 10_000})
+      end
+
+      it "sets options per-gateway" do
+        other = config.gateway(:other)
+        expect { default.connection_options(timeout: 10_000) }
+          .to_not change { other.connection_options }
+      end
+
+      it "is reflected in Gateway#cache_keys" do
+        default.adapter(:sql) {}
+        expect { default.connection_options(timeout: 10_000) }
+          .to change { default.cache_keys }
+      end
+    end
+
+    describe "options" do
+      it "combines connection_options with adapter.gateway_options" do
+        config.gateway :default do |gw|
+          gw.connection_options foo: "bar"
+
+          gw.adapter :sql do |a|
+            a.skip_defaults
+            a.extension :baz, :quux
+          end
+        end
+
+        expect(config.gateway(:default).options)
+          .to include(foo: "bar", extensions: [:baz, :quux])
+      end
+
+      it "ignores conflicting keys from connection_options" do
+        config.gateway :default do |gw|
+          gw.connection_options extensions: "foo"
+          gw.adapter(:sql) { _1.skip_defaults }
+        end
+
+        expect(config.gateway(:default).options).to eq({extensions: []})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1440

This adds a `connection_options` to gateway configuration that is passed through to `ROM::Gateway.setup`, so that various options specific to your datastore may be set without encoding them into the DATABASE_URL itself.

```ruby
Hanami.app.configure_provider :db do
  config.gateway :default do |gw|
    gw.connection_options timeout: 10_000, readonly: true
  end
end
```

You can see an overview of these settings in [the Sequel documentation](https://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html)