### PR TITLE
Support multiple DB gateways

### DIFF
--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -182,6 +182,12 @@ module Hanami
         # Create a single default gateway if none is configured or detected from database URLs
         config.gateways[:default] = Gateway.new if config.gateways.empty?
 
+        # Leave gateways in a stable order: :default first, followed by others in sort order
+        if config.gateways.length > 1
+          gateways = config.gateways
+          config.gateways = {default: gateways[:default], **gateways.sort.to_h}.compact
+        end
+
         config.gateways.each do |key, gw_config|
           gw_config.database_url ||= database_urls_from_env.fetch(key) {
             raise Hanami::ComponentLoadError, "A database_url for gateway #{key} is required to start :db."

--- a/lib/hanami/providers/db/adapter.rb
+++ b/lib/hanami/providers/db/adapter.rb
@@ -31,6 +31,13 @@ module Hanami
         end
 
         # @api private
+        def configure_from_adapter(other_adapter)
+          return if skip_defaults?
+
+          plugins.concat(other_adapter.plugins).uniq! unless skip_defaults?(:plugins)
+        end
+
+        # @api private
         def configure_for_database(database_url)
         end
 

--- a/lib/hanami/providers/db/adapters.rb
+++ b/lib/hanami/providers/db/adapters.rb
@@ -19,13 +19,19 @@ module Hanami
 
         # @api private
         # @since 2.2.0
+        def self.new_adapter(name)
+          ADAPTER_CLASSES[name].new
+        end
+
+        # @api private
+        # @since 2.2.0
         attr_reader :adapters
 
         # @api private
         # @since 2.2.0
         def initialize
           @adapters = Hash.new do |hsh, key|
-            hsh[key] = ADAPTER_CLASSES[key].new
+            hsh[key] = self.class.new_adapter(key)
           end
         end
 

--- a/lib/hanami/providers/db/gateway.rb
+++ b/lib/hanami/providers/db/gateway.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "dry/configurable"
+require "dry/core"
+
+module Hanami
+  module Providers
+    class DB < Hanami::Provider::Source
+      # @api public
+      # @since 2.2.0
+      class Gateway
+        include Dry::Core::Constants
+        include Dry::Configurable
+
+        setting :database_url
+        setting :adapter_name, default: :sql
+        setting :adapter, mutable: true
+
+        # @api public
+        # @since 2.2.0
+        def adapter(name = Undefined)
+          return config.adapter if name.eql?(Undefined)
+
+          if block_given?
+            # If a block is given, explicitly configure the gateway's adapter
+            config.adapter_name = name
+            adapter = (config.adapter ||= Adapters.new_adapter(name))
+            yield adapter
+            adapter
+          else
+            # If an adapter name is given without a block, use the default adapter configured with
+            # the same name
+            config.adapter_name = adapter_name
+          end
+        end
+
+        # @api private
+        def configure_adapter(default_adapters)
+          default_adapter = default_adapters[config.adapter_name]
+          config.adapter ||= default_adapter.dup
+
+          config.adapter.configure_from_adapter(default_adapter)
+          config.adapter.configure_from_adapter(default_adapters[nil])
+          config.adapter.configure_for_database(config.database_url)
+
+          self
+        end
+
+        # @api private
+        def cache_keys
+          [config.database_url, config.adapter.gateway_cache_keys]
+        end
+
+        private
+
+        def method_missing(name, *args, &block)
+          if config.respond_to?(name)
+            config.public_send(name, *args, &block)
+          else
+            super
+          end
+        end
+
+        def respond_to_missing?(name, _include_all = false)
+          config.respond_to?(name) || super
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/db/db_slices_spec.rb
+++ b/spec/integration/db/db_slices_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "DB / Slices", :app_integration do
       gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
 
       # Gateways on app are not passed down to child slices
-      expect(Hanami.app["db.rom"].gateways.keys).to eq [:extra, :default]
+      expect(Hanami.app["db.rom"].gateways.keys).to eq [:default, :extra]
       expect(Main::Slice["db.rom"].gateways.keys).to eq [:default]
       expect(Admin::Slice["db.rom"].gateways.keys).to eq [:default]
 

--- a/spec/integration/db/db_spec.rb
+++ b/spec/integration/db/db_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "DB", :app_integration do
 
       expect(Hanami.app["db.config"]).to be_an_instance_of ROM::Configuration
       expect(Hanami.app["db.gateway"]).to be_an_instance_of ROM::SQL::Gateway
+      expect(Hanami.app["db.gateways.default"]).to be Hanami.app["db.gateway"]
 
       # Manually run a migration and add a test record
       gateway = Hanami.app["db.gateway"]
@@ -90,6 +91,7 @@ RSpec.describe "DB", :app_integration do
 
       expect(Hanami.app["db.config"]).to be_an_instance_of ROM::Configuration
       expect(Hanami.app["db.gateway"]).to be_an_instance_of ROM::SQL::Gateway
+      expect(Hanami.app["db.gateways.default"]).to be Hanami.app["db.gateway"]
 
       # Manually run a migration and add a test record
       gateway = Hanami.app["db.gateway"]
@@ -117,8 +119,6 @@ RSpec.describe "DB", :app_integration do
 
         module TestApp
           class App < Hanami::App
-            config.inflections do |inflections|
-            end
           end
         end
       RUBY
@@ -154,11 +154,10 @@ RSpec.describe "DB", :app_integration do
 
       write "config/providers/db.rb", <<~RUBY
         Hanami.app.configure_provider :db do
-          configure do |config|
-            # In this test, we're not setting an ENV["DATABASE_URL"], and instead configuring
-            # it via the provider source config, to prove that this works
-
-            config.database_url = "sqlite::memory"
+          # In this test, we're not setting an ENV["DATABASE_URL"], and instead configuring
+          # it via the provider source config, to prove that this works
+          config.gateway :default do |gw|
+            gw.database_url = "sqlite::memory"
           end
         end
       RUBY

--- a/spec/integration/db/gateways_spec.rb
+++ b/spec/integration/db/gateways_spec.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / Gateways", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  it "configures gateways by detecting ENV vars" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "db/.keep", ""
+      write "app/relations/.keep", ""
+      write "slices/admin/relations/.keep", ""
+
+      ENV["DATABASE_URL"] = "sqlite://db/default.sqlite3"
+      ENV["DATABASE_URL__EXTRA"] = "sqlite://db/extra.sqlite3"
+      ENV["ADMIN__DATABASE_URL__DEFAULT"] = "sqlite://db/admin.sqlite3"
+      ENV["ADMIN__DATABASE_URL__SPECIAL"] = "sqlite://db/admin_special.sqlite3"
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["db.rom"].gateways[:default]).to be
+      expect(Hanami.app["db.rom"].gateways[:extra]).to be
+      expect(Hanami.app["db.gateway"]).to be Hanami.app["db.rom"].gateways[:default]
+      expect(Hanami.app["db.gateways.default"]).to be Hanami.app["db.rom"].gateways[:default]
+      expect(Hanami.app["db.gateways.extra"]).to be Hanami.app["db.rom"].gateways[:extra]
+
+      expect(Admin::Slice["db.rom"].gateways[:default]).to be
+      expect(Admin::Slice["db.rom"].gateways[:special]).to be
+      expect(Admin::Slice["db.gateway"]).to be Admin::Slice["db.rom"].gateways[:default]
+      expect(Admin::Slice["db.gateways.default"]).to be Admin::Slice["db.rom"].gateways[:default]
+      expect(Admin::Slice["db.gateways.special"]).to be Admin::Slice["db.rom"].gateways[:special]
+    end
+  end
+
+  it "configures gateways from explicit config in the provider" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "db/.keep", ""
+
+      write "config/providers/db.rb", <<~RUBY
+        Hanami.app.configure_provider :db do
+          config.gateway :default do |gw|
+            gw.database_url = "sqlite://db/default.sqlite3"
+          end
+
+          config.gateway :extra do |gw|
+            gw.database_url = "sqlite://db/extra.sqlite3"
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["db.rom"].gateways[:default]).to be
+      expect(Hanami.app["db.rom"].gateways[:extra]).to be
+      expect(Hanami.app["db.gateway"]).to be Hanami.app["db.rom"].gateways[:default]
+      expect(Hanami.app["db.gateways.default"]).to be Hanami.app["db.rom"].gateways[:default]
+      expect(Hanami.app["db.gateways.extra"]).to be Hanami.app["db.rom"].gateways[:extra]
+    end
+  end
+
+
+
+  it "exposes all database URLs as #database_urls on the provider source (for CLI commands)" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/providers/db.rb", <<~RUBY
+        Hanami.app.configure_provider :db do
+          config.gateway :special do |gw|
+            gw.database_url = "sqlite://db/special.sqlite3"
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite://db/default.sqlite3"
+      ENV["DATABASE_URL__EXTRA"] = "sqlite://db/extra.sqlite3"
+
+      require "hanami/prepare"
+
+      database_urls = Hanami.app.container.providers[:db].source.finalize_config.database_urls
+
+      expect(database_urls).to eq(
+        default: "sqlite://db/default.sqlite3",
+        extra: "sqlite://db/extra.sqlite3",
+        special: "sqlite://db/special.sqlite3"
+      )
+    end
+  end
+
+  it "applies extensions from the default adapter to explicitly configured gateway adapters" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/providers/db.rb", <<~RUBY
+        Hanami.app.configure_provider :db do
+          config.adapter :sql do |a|
+            a.extension :is_distinct_from
+          end
+
+          config.gateway :default do |gw|
+            gw.adapter :sql do |a|
+              a.extension :exclude_or_null
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+      ENV["DATABASE_URL__SPECIAL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["db.gateways.default"].options[:extensions])
+        .to eq [:exclude_or_null, :is_distinct_from, :caller_logging, :error_sql, :sql_comments]
+
+      expect(Hanami.app["db.gateways.special"].options[:extensions])
+        .to eq [:is_distinct_from, :caller_logging, :error_sql, :sql_comments]
+    end
+  end
+
+  it "combines ROM plugins from the default adapter and all gateways" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/providers/db.rb", <<~RUBY
+        Hanami.app.configure_provider :db do
+          config.adapter :sql do |a|
+            a.plugin command: :associates
+          end
+
+          config.gateway :default do |gw|
+            gw.database_url = "sqlite::memory"
+            gw.adapter :sql do |a|
+              a.plugin relation: :nullify
+            end
+          end
+
+          config.gateway :special do |gw|
+            gw.adapter :sql do |a|
+              a.plugin relation: :pagination
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+      ENV["DATABASE_URL__SPECIAL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["db.config"].setup.plugins.length).to eq 5
+      expect(Hanami.app["db.config"].setup.plugins).to include(
+        satisfying { |plugin| plugin.type == :command && plugin.name == :associates },
+        satisfying { |plugin| plugin.type == :relation && plugin.name == :nullify },
+        satisfying { |plugin| plugin.type == :relation && plugin.name == :pagination },
+        satisfying { |plugin| plugin.type == :relation && plugin.name == :auto_restrictions },
+        satisfying { |plugin| plugin.type == :relation && plugin.name == :instrumentation }
+      )
+    end
+  end
+
+  it "configures gateway adapters for their specific database types" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/providers/db.rb", <<~RUBY
+        Hanami.app.configure_provider :db do
+          config.gateway :default do |gw|
+            gw.database_url = "sqlite::memory"
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+      ENV["DATABASE_URL__SPECIAL"] = "postgres://localhost/database"
+
+      require "hanami/prepare"
+
+      # Get the provider source and finalize config, because the tests here aren't set up to handle
+      # connections to a running postgres database
+      provider_source = Hanami.app.container.providers[:db].source
+      provider_source.finalize_config
+
+      expect(provider_source.config.gateways[:default].config.adapter.extensions)
+        .to eq [:caller_logging, :error_sql, :sql_comments]
+
+      expect(provider_source.config.gateways[:special].config.adapter.extensions)
+        .to eq [
+          :caller_logging, :error_sql, :sql_comments,
+          :pg_array, :pg_enum, :pg_json, :pg_range
+        ]
+    end
+  end
+
+  it "makes the gateways available to relations" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      write "app/relations/users.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Users < Hanami::DB::Relation
+              gateway :extra
+              schema :users, infer: true
+            end
+          end
+        end
+      RUBY
+
+      write "db/.keep", ""
+      ENV["DATABASE_URL"] = "sqlite://db/default.sqlite3"
+      ENV["DATABASE_URL__EXTRA"] = "sqlite://db/extra.sqlite3"
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      # Manually run a migration and add a test record
+      default_gateway = Hanami.app["db.gateways.default"]
+      migration = default_gateway.migration do
+        change do
+          create_table :posts do
+            primary_key :id
+            column :title, :text, null: false
+          end
+        end
+      end
+      migration.apply(default_gateway, :up)
+      default_gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+      extra_gateway = Hanami.app["db.gateways.extra"]
+      migration = extra_gateway.migration do
+        change do
+          create_table :users do
+            primary_key :id
+            column :name, :text, null: false
+          end
+        end
+      end
+      migration.apply(extra_gateway, :up)
+      extra_gateway.connection.execute("INSERT INTO users (name) VALUES ('Jane Doe')")
+
+      Hanami.app.boot
+
+      expect(Hanami.app["relations.posts"].to_a).to eq [{id: 1, title: "Together breakfast"}]
+      expect(Hanami.app["relations.users"].to_a).to eq [{id: 1, name: "Jane Doe"}]
+    end
+  end
+end

--- a/spec/unit/hanami/providers/db/config/default_config_spec.rb
+++ b/spec/unit/hanami/providers/db/config/default_config_spec.rb
@@ -19,14 +19,6 @@ RSpec.describe "Hanami::Providers::DB / Config / Default config", :app_integrati
     end
   end
 
-  specify "database_url = nil" do
-    expect(config.database_url).to be nil
-  end
-
-  specify "adapter = :sql" do
-    expect(config.adapter).to eq :sql
-  end
-
   specify %(relations_path = "relations") do
     expect(config)
   end

--- a/spec/unit/hanami/providers/db/config_spec.rb
+++ b/spec/unit/hanami/providers/db/config_spec.rb
@@ -19,14 +19,6 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
     end
   end
 
-  describe "#adapter_name" do
-    it "aliases #adapter" do
-      expect { config.adapter = :yaml }
-        .to change { config.adapter_name }
-        .to :yaml
-    end
-  end
-
   describe "#adapter" do
     it "adds an adapter" do
       expect { config.adapter(:yaml) }
@@ -159,49 +151,6 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
             .and change { adapter.extensions }.to([])
         end
       end
-
-      # TODO clear
-    end
-  end
-
-  describe "#gateway_cache_keys" do
-    it "returns the cache keys from the currently configured adapter" do
-      config.adapter(:sql) { |a| a.clear; a.extension :foo }
-      config.adapter = :sql
-
-      expect(config.gateway_cache_keys).to eq(config.adapter(:sql).gateway_cache_keys)
-    end
-  end
-
-  describe "#gateway_options" do
-    it "returns the options from the currently configured adapter" do
-      config.adapter(:sql) { |a| a.clear; a.extension :foo }
-      config.adapter = :sql
-
-      expect(config.gateway_options).to eq(config.adapter(:sql).gateway_options)
-    end
-  end
-
-  describe "#each_plugin" do
-    before do
-      config.any_adapter { |a| a.plugin relations: :any_foo }
-      config.adapter(:yaml) { |a| a.plugin relations: :yaml_foo }
-      config.adapter = :yaml
-    end
-
-    it "yields the plugins specified for any adapter as well as the currently configured adapter" do
-      expect { |b| config.each_plugin(&b) }
-        .to yield_successive_args(
-          [{relations: :any_foo}, nil],
-          [{relations: :yaml_foo}, nil]
-        )
-    end
-
-    it "returns the plugins as an enumerator if no block is given" do
-      expect(config.each_plugin.to_a).to eq [
-        [{relations: :any_foo}, nil],
-        [{relations: :yaml_foo}, nil]
-      ]
     end
   end
 end


### PR DESCRIPTION
Introduce support for multiple [gateways](https://rom-rb.org/learn/introduction/core-concepts/#gateways) to the ROM setup created by Hanami's `:db` provider.

Gateways in ROM represent a connection to a distinct database, and can be used within relations by declaring their `gateway`:

```ruby
module MyApp
  module Relations
    class Posts < MyApp::DB::Relation
      # If this is not given, it presumes a `:default` gateway
      gateway :my_gateway
    end
  end
end
```

With this change, individual slices can connect to multiple gateways internally, with every distinct slice being able to manage its own distinct set of gateways.

This is a _progressively disclosed_ feature. By default, slices will set up a single `:default` gateway, with no additional user config required.

## How do I configure gateways?

### Zero config

First, ENV vars alone, no config required:

```
DATABASE_URL="sqlite://db/app.sqlite3"
DATABASE_URL__EXTRA="sqlite://db/app_extra.sqlite3"
ADMIN__DATABASE_URL="sqlite://db/admin.sqlite3"
ADMIN__DATABASE_URL__EXTRA="sqlite://db/admin_extra.sqlite3"
```

Given an app and an `Admin` slice, the env vars above will create:

1. a `:default` gateway in the app (`db/app.sqlite3`)
2. an `:extra` gateway in the app (`db/app_extra.sqlite3`)
3. a `:default` gateway in the `Admin` slice (`db/admin.sqlite3`)
4. an `:extra` gateway in the `Admin` slice (`db/admin_extra.sqlite3`)

In this scenario, no custom provider config is required.

You can probably infer the env var pattern, but to be clear, it is:

```
DATABASE_URL__GATEWAY_NAME             # For the app
SLICE_NAME__DATABASE_URL__GATEWAY_NAME # For slices
```

Any ENV vars matching this pattern will be picked up and new gateways will be configured to match.

There is one special case. If, after detecting ENV vars with the explicit `__GATEWAY_NAME` suffix and configuring the respective gateways, there is still no `:default` gateway, then both the suffix-less `SLICE_NAME__DATABASE_URL` and `DATABASE_URL` ENV vars will also be checked (n.b. `DATABASE_URL` will be checked even for slices). If either of these are found, then they will be used to configure a `:default` gateway with that database URL. This approach preserves the simplicity of a single `DATABASE_URL` ENV var representing a single database that is used across multiple slices.

### Explicit config

You can configure gateways via `config.gateway` in the `:db` provider:

```ruby
Hanami.app.configure_provider :db do
  config.gateway :extra do |gw|
    # If this is not given, it will still be filled from `ENV["DATABASE_URL__EXTRA"]`
    gw.database_url = "..."

    # Specify an adapter to use by name (more on this later)
    gw.adapter :yaml

    # Or configure an adapter explicitly
    gw.adapter :yaml do |a|
      # You can call `a.plugin` here
      # Or also `a.extension` if this is an `:sql` adapter
    end
  end

  # Multiple gateways can be configured
  config.gateway :another do |gw|
    # ...
  end
end
```

### Mix and match

You don't have to pick one gateway configuration approach over another, you can mix and match.

When the `:db` provider detects database URLs from ENV vars, for each found ENV far, it will:

1. If you have already explicitly configured a matching gateway, it will set its `config.database_url` to match (but only if `config.database_url` itself is `nil`; if you configure it directly, it will not be overwritten)
2. Create a new gateway and configure its `config.database_url`, as described in the "Zero config" section above

### Sharing adapter config

You can configure "default adapters" directly in the `:db` provider, and these will be applied to any gateways configured with a matching adapter name:

```ruby
Hanami.app.configure_provider :db do
  config.adapter :sql do |a|
    a.extension :is_distinct_from
  end
end
```

In the zero config gateway scenario, this adapter config will be used for all gateways, since they default to using `:sql` for their adapter name.

When explicitly configuring gateways, you can still share adapter config by specifying the adapter name alone:

```ruby
Hanami.app.configure_provider :db do
  config.adapter :sql do |a|
    a.extension :is_distinct_from
  end

  config.gateway :extra do |gw|
    # No block given means we set the adapter name only,
    # which means the default adapter config (above) will apply
    gw.adapter :sql
  end

  config.gateway :special do |gw|
    gw.adapter :sql
  end
end
```

By default, all gateways default to :sql` adapter names, so the config above isn't strictly necessary. When using non-`:sql` adapters, however, this approach is required.

When an `any_adapter` default adapter is configured for the provider, its config will _also_ be applied to every gateway, in addition to any named default adapter:

```ruby
Hanami.app.configure_provider :db do
  config.any_adapter do |a|
    a.plugin relation: :pagination
  end

  config.adapter :sql do |a|
    a.extension :is_distinct_from
  end

  # Config from _both_ of the default adapters above will be applied to this gateway
  config.gateway :extra do |gw|
    gw.adapter :sql
  end
end
```

### Adapter plugins are merged when given to ROM

While ROM can be configured with multiple distinct gateways, it can only be configured with a single set of plugins per adapter type.

Given this, when we configure ROM's plugins, we merge all the plugins from all the gateways' adapters into a single set per adapter type, and then provide all of these to ROM.

## Implementation notes

Let's step through the actual changes:

- Remove the `database_url` and `adapter` settings from the DB provider.
- Introduce a `gateways` setting, which is just a regular hash, keys intended to be gateway names, and values being instances of a new `Hanami::Providers::DB::Gateway` class.
- `Hanami::Providers::DB::Gateway` is configurable, with settings for `database_url` (defaulting to `nil`), `adapter_name` (defaulting to `:sql`) and `adapter` (defaulting to `nil`).
- Introduce `Hanami::Providers::DB::Config#gateway` (available as `config.gateway` in the DB provider) as a convenience for users to configure their own gateways. This yields a `Hanami::Providers::DB::Gateway` to the given block.
- Update the `prepare` step of the DB provider to:
  - Detect different gateway database URLs from the ENV (as described above). It applies these URLs to user-configured gateways, or creates new gateways as required. (By this point, every gateway is available via `config.gateways` on the provider source).
  - Configure each gateway's adapter. If the `config.adapter` is `nil` on the gateway, it creates a new gateway first (based on the `config.gateway_name`). It then applies config to the adapter from any _default adapters_ configured on the provider source itself. See `Hanami::Providers::DB::Gateway#configure_adapter` for details.
    - (Move the previous `Hanami::Providers::DB#configure_for_database` into this `Gateway#configure_adapter` method, so that every adapter still receives appropriate per-database defaults based on its database type.)
  - Register each gateway in the container via a new namespace: "db.gateways.[gateway_name]". A gateway named `:default` will continue to be registered as `"db.gateway"`.
  - Pass each configured gateway to ROM.
  - Configure ROM with the plugins for each configured adapter (across all gateways).
- Change `Hanami::Providers::DB#database_url` to `#database_urls` (plural) and return a hash of gateway_name => URL pairs. These will be used by the CLI commands (they'll be made gateway-aware in a PR very soon).
- Move `Hanami::Providers::DB::Config#gateway_cache_keys` to `Gateway#cache_keys`, and `Hanami::Providers::DB::Config#gateway_options` to `Adapter#gateway_options`, which are IMO both much clearer locations, demonstrating that the refactoring to support gateways is an overall positive change!

Resolves #1439