### PR TITLE
`Dry::Operation` extensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 # This is needed for settings specs to pass
 gem "dry-types"
 
+# For testing operation integrations
+gem "dry-operation", github: "dry-rb/dry-operation", branch: "main"
+
 # For testing the DB layer
 gem "sqlite3"
 

--- a/lib/hanami/extensions.rb
+++ b/lib/hanami/extensions.rb
@@ -19,3 +19,7 @@ end
 if Hanami.bundled?("hanami-router")
   require_relative "extensions/router/errors"
 end
+
+if Hanami.bundled?("dry-operation")
+  require_relative "extensions/operation"
+end

--- a/lib/hanami/extensions/operation.rb
+++ b/lib/hanami/extensions/operation.rb
@@ -27,8 +27,7 @@ module Hanami
         # @api private
         # @since 2.2.0
         def configure_for_slice(slice)
-          namespace = slice.slice_name.namespace
-          include namespace::Deps["db.rom"]
+          include slice.namespace::Deps["db.rom"]
         end
 
         # @api private

--- a/lib/hanami/extensions/operation.rb
+++ b/lib/hanami/extensions/operation.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "dry/operation"
+require "dry/operation/extensions/rom"
+
+module Hanami
+  module Extensions
+    # Integrated behavior for `Dry::Operation` classes within Hanami apps.
+    #
+    # @see https://github.com/dry-rb/dry-operation
+    #
+    # @api public
+    # @since 2.2.0
+    module Operation
+      # @api private
+      # @since 2.2.0
+      def self.included(operation_class)
+        super
+
+        operation_class.extend(Hanami::SliceConfigurable)
+        operation_class.extend(ClassMethods)
+      end
+
+      # @api private
+      # @since 2.2.0
+      module ClassMethods
+        # @api private
+        # @since 2.2.0
+        def configure_for_slice(slice)
+          namespace = slice.slice_name.namespace
+          include namespace::Deps["db.rom"]
+        end
+
+        # @api private
+        # @since 2.2.0
+        def inherited(subclass)
+          super
+
+          return unless subclass.superclass == self
+          return unless Hanami.bundled?("hanami-db")
+
+          subclass.include Dry::Operation::Extensions::ROM
+        end
+      end
+    end
+  end
+end
+
+Dry::Operation.include(Hanami::Extensions::Operation)

--- a/spec/integration/operations/extension_spec.rb
+++ b/spec/integration/operations/extension_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Operation / Extensions", :app_integration do
   specify "Transaction interface is made available automatically" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/app.rb", <<~RUBY
-          require "hanami"
+        require "hanami"
 
-          module TestApp
-            class App < Hanami::App
-            end
+        module TestApp
+          class App < Hanami::App
           end
+        end
       RUBY
 
       write "app/operation.rb", <<~RUBY

--- a/spec/integration/operations/extension_spec.rb
+++ b/spec/integration/operations/extension_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe "Operation / Extensions", :app_integration do
 
       expect(app).to respond_to(:transaction)
 
-      expect(app.rom.object_id).to eq TestApp::App["db.rom"].object_id
-      expect(app.rom.object_id).to_not eq Main::Slice["db.rom"].object_id
+      expect(app.rom).to be TestApp::App["db.rom"]
+      expect(app.rom).not_to be Main::Slice["db.rom"]
+      expect(main.rom).to be Main::Slice["db.rom"]
     end
   end
 end

--- a/spec/integration/operations/extension_spec.rb
+++ b/spec/integration/operations/extension_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "dry/operation"
+
+RSpec.describe "Operation / Extensions", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after { ENV.replace(@env) }
+
+  specify "Transaction interface is made available automatically" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+      RUBY
+
+      write "app/operation.rb", <<~RUBY
+        module TestApp
+          class Operation < Dry::Operation
+          end
+        end
+      RUBY
+
+      write "slices/main/operation.rb", <<~RUBY
+        module Main
+          class Operation < Dry::Operation
+          end
+        end
+      RUBY
+
+      write "db/.keep", ""
+      write "app/relations/.keep", ""
+
+      write "slices/main/db/.keep", ""
+      write "slices/main/relations/.keep", ""
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+      ENV["MAIN__DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      app = TestApp::Operation.new
+      main = Main::Operation.new
+
+      expect(app).to respond_to(:transaction)
+
+      expect(app.rom.object_id).to eq TestApp::App["db.rom"].object_id
+      expect(app.rom.object_id).to_not eq Main::Slice["db.rom"].object_id
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1437

Automatically extend Dry::Operation to include ROM extensions when hanami-db is present. Removes a line of boilerplate from generated Operation files.