### PR TITLE
Apply gateway config from parent slice (and simplify config)

### DIFF
--- a/lib/hanami/providers/db/adapters.rb
+++ b/lib/hanami/providers/db/adapters.rb
@@ -30,9 +30,7 @@ module Hanami
         # @api private
         # @since 2.2.0
         def initialize
-          @adapters = Hash.new do |hsh, key|
-            hsh[key] = self.class.new_adapter(key)
-          end
+          @adapters = {}
         end
 
         # @api private
@@ -43,6 +41,24 @@ module Hanami
           source.adapters.each do |key, val|
             @adapters[key] = val.dup
           end
+        end
+
+        # @api private
+        # @since 2.2.0
+        def adapter(key)
+          adapters[key] ||= new(key)
+        end
+
+        # @api private
+        # @since 2.2.0
+        def find(key)
+          adapters.fetch(key) { new(key) }
+        end
+
+        # @api private
+        # @since 2.2.0
+        def new(key)
+          self.class.new_adapter(key)
         end
       end
     end

--- a/lib/hanami/providers/db/config.rb
+++ b/lib/hanami/providers/db/config.rb
@@ -20,15 +20,7 @@ module Hanami
 
         # @api public
         # @since 2.2.0
-        def adapter_name
-          self[:adapter]
-        end
-
-        # @api public
-        # @since 2.2.0
-        def adapter(name = Undefined)
-          return adapter_name if name.eql?(Undefined)
-
+        def adapter(name)
           adapter = (adapters[name] ||= Adapter.new)
           yield adapter if block_given?
           adapter

--- a/lib/hanami/providers/db/config.rb
+++ b/lib/hanami/providers/db/config.rb
@@ -21,7 +21,7 @@ module Hanami
         # @api public
         # @since 2.2.0
         def adapter(name)
-          adapter = (adapters[name] ||= Adapter.new)
+          adapter = adapters.adapter(name)
           yield adapter if block_given?
           adapter
         end

--- a/lib/hanami/providers/db/config.rb
+++ b/lib/hanami/providers/db/config.rb
@@ -34,24 +34,14 @@ module Hanami
           adapter
         end
 
-        # @api public
-        # @since 2.2.0
-        def any_adapter
-          adapter = (adapters[nil] ||= Adapter.new)
-          yield adapter if block_given?
-          adapter
-        end
-
         # @api private
         def each_plugin
           return to_enum(__method__) unless block_given?
 
-          universal_plugins = adapters[nil].plugins
-
           gateways.values.group_by(&:adapter_name).each do |adapter_name, adapter_gateways|
-            per_adapter_plugins = adapter_gateways.map { _1.adapter.plugins }.flatten(1)
+            per_adapter_plugins = adapter_gateways.map { _1.adapter.plugins }.flatten(1).uniq
 
-            (universal_plugins + per_adapter_plugins).uniq.each do |plugin_spec, config_block|
+            per_adapter_plugins.each do |plugin_spec, config_block|
               yield adapter_name, plugin_spec, config_block
             end
           end

--- a/lib/hanami/providers/db/gateway.rb
+++ b/lib/hanami/providers/db/gateway.rb
@@ -48,7 +48,7 @@ module Hanami
         # @api public
         # @since 2.2.0
         def options
-          {**connection_options, **adapter.gateway_options}
+          {**connection_options, **config.adapter.gateway_options}
         end
 
         # @api private

--- a/lib/hanami/providers/db/gateway.rb
+++ b/lib/hanami/providers/db/gateway.rb
@@ -53,7 +53,7 @@ module Hanami
 
         # @api private
         def configure_adapter(default_adapters)
-          default_adapter = default_adapters[config.adapter_name]
+          default_adapter = default_adapters.find(config.adapter_name)
           config.adapter ||= default_adapter.dup
 
           config.adapter.configure_from_adapter(default_adapter)

--- a/lib/hanami/providers/db/gateway.rb
+++ b/lib/hanami/providers/db/gateway.rb
@@ -57,7 +57,7 @@ module Hanami
           config.adapter ||= default_adapter.dup
 
           config.adapter.configure_from_adapter(default_adapter)
-          config.adapter.configure_from_adapter(default_adapters[nil])
+
           config.adapter.configure_for_database(config.database_url)
 
           self

--- a/lib/hanami/providers/db/sql_adapter.rb
+++ b/lib/hanami/providers/db/sql_adapter.rb
@@ -13,7 +13,7 @@ module Hanami
         # @api public
         # @since 2.2.0
         def extension(*extensions)
-          self.extensions.concat(extensions)
+          self.extensions.concat(extensions).uniq!
         end
 
         # @api public

--- a/spec/integration/db/db_slices_spec.rb
+++ b/spec/integration/db/db_slices_spec.rb
@@ -33,6 +33,67 @@ RSpec.describe "DB / Slices", :app_integration do
     end
   end
 
+  specify "slices using a parent gateway with connection options share a gateway/connection" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "config/providers/db.rb", <<~RUBY
+        Hanami.app.configure_provider :db do
+          config.gateway :default do |gw|
+            gw.connection_options timeout: 10_000
+          end
+
+          config.gateway :extra do |gw|
+            gw.connection_options timeout: 20_000
+          end
+        end
+      RUBY
+
+      write "slices/main/config/providers/db.rb", <<~RUBY
+        Main::Slice.configure_provider :db do
+          config.gateway :bonus do |gw|
+            gw.connection_options timeout: 5_000
+          end
+        end
+      RUBY
+
+      write "db/.keep", ""
+      write "slices/admin/relations/.keep", ""
+      write "slices/main/relations/.keep", ""
+
+      ENV["DATABASE_URL"] = "sqlite://" + Pathname(@dir).realpath.join("app.sqlite").to_s
+      ENV["DATABASE_URL__EXTRA"] = "sqlite://" + Pathname(@dir).realpath.join("extra.sqlite").to_s
+      ENV["DATABASE_URL__BONUS"] = "sqlite://" + Pathname(@dir).realpath.join("bonus.sqlite").to_s
+
+      # "extra" gateway in admin slice, same URL as app
+      ENV["ADMIN__DATABASE_URL__EXTRA"] = ENV["DATABASE_URL__EXTRA"]
+      # "extra" gatway in main slice, different URL
+      ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://" + Pathname(@dir).realpath.join("extra-main.sqlite").to_s
+      # "bonus" gateway in admin slice, same URL as app
+      ENV["ADMIN__DATABASE_URL__BONUS"] = ENV["DATABASE_URL__BONUS"]
+      # "bonus" gateway in main slice, same URL as app; different connection options in provider
+      ENV["MAIN__DATABASE_URL__BONUS"] = ENV["DATABASE_URL__BONUS"]
+
+      require "hanami/prepare"
+
+      expect(Admin::Slice["db.gateway"]).to be Hanami.app["db.gateway"]
+
+      expect(Admin::Slice["db.gateways.extra"]).to be Hanami.app["db.gateways.extra"]
+      expect(Main::Slice["db.gateways.extra"]).not_to be Hanami.app["db.gateways.extra"]
+
+      expect(Admin::Slice["db.gateways.bonus"]).to be Hanami.app["db.gateways.bonus"]
+      expect(Main::Slice["db.gateways.bonus"]).not_to be Hanami.app["db.gateways.bonus"]
+    end
+  end
+
   specify "slices using the same database_url but different extensions have distinct gateways/connections" do
     with_tmp_directory(@dir = Dir.mktmpdir) do
       write "config/app.rb", <<~RUBY

--- a/spec/integration/db/db_slices_spec.rb
+++ b/spec/integration/db/db_slices_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "DB / Slices", :app_integration do
 
         module TestApp
           class App < Hanami::App
+            config.logger.stream = File::NULL
           end
         end
       RUBY
@@ -39,6 +40,7 @@ RSpec.describe "DB / Slices", :app_integration do
 
         module TestApp
           class App < Hanami::App
+            config.logger.stream = File::NULL
           end
         end
       RUBY
@@ -80,6 +82,7 @@ RSpec.describe "DB / Slices", :app_integration do
 
         module TestApp
           class App < Hanami::App
+            config.logger.stream = File::NULL
           end
         end
       RUBY
@@ -213,6 +216,7 @@ RSpec.describe "DB / Slices", :app_integration do
 
         module TestApp
           class App < Hanami::App
+            config.logger.stream = File::NULL
           end
         end
       RUBY
@@ -253,6 +257,7 @@ RSpec.describe "DB / Slices", :app_integration do
 
         module TestApp
           class App < Hanami::App
+            config.logger.stream = File::NULL
           end
         end
       RUBY

--- a/spec/integration/db/gateways_spec.rb
+++ b/spec/integration/db/gateways_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "DB / Gateways", :app_integration do
     end
   end
 
-  it "combines ROM plugins from the default adapter and all gateways" do
+  it "combines ROM plugins from both default adapter and gateway-configured adapters" do
     with_tmp_directory(@dir = Dir.mktmpdir) do
       write "config/app.rb", <<~RUBY
         require "hanami"

--- a/spec/unit/hanami/providers/db/config_spec.rb
+++ b/spec/unit/hanami/providers/db/config_spec.rb
@@ -32,19 +32,6 @@ RSpec.describe "Hanami::Providers::DB.config", :app_integration do
     end
   end
 
-  describe "#any_adapter" do
-    it "adds an adapter keyed without a name" do
-      expect { config.any_adapter }
-        .to change { config.adapters.to_h }
-        .to hash_including(nil)
-    end
-
-    it "yields the adapter for configuration" do
-      expect { |b| config.any_adapter(&b) }
-        .to yield_with_args(an_instance_of(Hanami::Providers::DB::Adapter))
-    end
-  end
-
   describe "adapters" do
     subject(:adapter) { config.adapter(:yaml) }
 


### PR DESCRIPTION
Follow up from @alassek's work in #1450 and ensure that a gateway configured with `connection_options` in an app's DB provider can have those same `connection_options` used in child slices configured to use the same gateway.

To achieve this, when a slice's `:db` provider prepares itself, copy the config from matching gateways in the parent slice. This will apply `connection_options` configured from the parent.

This is an important change, because it ensures that the parent and its child slices can share database connections for the gateway (this is because `connection_options` is now included in the cache key for the gateways that we cache and reuse across slices).

Some additional particulars about the behavior:

- Config from parent gateways is only copied if the gateway has an identical (a) name, and (b) database URL.
- Aside from `database_url`, gateways only have three other settings. Of these, `adapter_name` and `connection_options` are copied directly.
- The `adapter` setting has some special handling: if there is a custom default adapter configured for the provider (i.e. `config.adapter(:sql) do ... end`), then the `.adapter` from the parent gateway will _not_ be copied. This is because we want the provider's custom default adapter to be applied to the gateway in order to honour the user's intention for that config.
- To support the above, change `config.adapters[...]` to return `nil` if an adapter has not been explicitly configured for the provider, rather than have it create a new adapter and automatically assign it to the given key. To offer the existing behaviour of "return or create+assign me an adapter, please", we add `config.adapters.adapter(...)`, which we use internally where required. (n.b. this is entirely private API, the public interface of `config.adapter(...)` is unchanged.
- If a user has set `config.db.configure_from_parent = false` in the slice, then we uphold the existing behaviour for this flag, and do not copy any gateway config from the parent.

---

While here, simplify the gateway config a little: removing the `config.any_adapter` from DB providers.

Keeping this meant another complicating factor in how we apply config from parent gateways, and it made me realise that it just complicates how we think about gateway/adapter config _in general._

A user can still achieve what they want without having this method. If they need a ROM plugin to be used in multiple adapter, they can just configure it explicitly in each adapter. Given that the number of adapters in use will tend to be low, this does not feel onerous at all. We can always choose to reintroduce something like this based on actual user feedback, which I think is the right way to go in this case.

Resolves #1457 