### PR TITLE
Use gemspec to load json gem with no warnings

### DIFF
--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-logger",       "~> 1.0", "< 2"
   spec.add_dependency "hanami-cli",       "= 2.2.0.rc1"
   spec.add_dependency "hanami-utils",     "~> 2.2.rc"
+  spec.add_dependency "json",             ">= 2.7.2"
   spec.add_dependency "zeitwerk",         "~> 2.6"
 
   spec.add_development_dependency "rspec",     "~> 3.8"


### PR DESCRIPTION
As noted in https://github.com/hanami/hanami/issues/1454#issuecomment-2441462785, version 2.7.2 of the json gem fixes its usage of ostruct so that this warning is no longer emitted on Ruby 3.3.5 and later:

```
/path/to/installs/ruby/3.3.5/lib/ruby/3.3.0/json/generic_object.rb:2: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

Ruby 3.3.x's bundled version of json, however, is 2.7.1, which does not include this fix. To ensure we use the right version and stop this warning from showing to our users, require the appropriate version of json gem via hanami's own gemspec.

This adds another gemspec dependency, but its very highly likely that users will already have json bundled anyway.

Relates to #1454.