### PR TITLE
Depend on matching minor version of hanami-cli

### DIFF
--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-monitor",      "~> 1.0", ">= 1.0.1", "< 2"
   spec.add_dependency "dry-system",       "~> 1.1"
   spec.add_dependency "dry-logger",       "~> 1.0", "< 2"
-  spec.add_dependency "hanami-cli",       "~> 2.2"
+  spec.add_dependency "hanami-cli",       "~> 2.2.0"
   spec.add_dependency "hanami-utils",     "~> 2.2"
   spec.add_dependency "json",             ">= 2.7.2"
   spec.add_dependency "zeitwerk",         "~> 2.6"


### PR DESCRIPTION
This will ensure that a 2.2.x version of the “hanami” gem will not inadvertently pull down a 2.3.x (or newer) version of the “hanami-cli” gem, which could lead to unexpected experiences for our users.

Fixes #1470