### PR TITLE
Only load rom extension if hanami-db is bundled

### DIFF
--- a/lib/hanami/extensions/operation.rb
+++ b/lib/hanami/extensions/operation.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "dry/operation"
-require "dry/operation/extensions/rom"
 
 module Hanami
   module Extensions
@@ -38,6 +37,7 @@ module Hanami
           return unless subclass.superclass == self
           return unless Hanami.bundled?("hanami-db")
 
+          require "dry/operation/extensions/rom"
           subclass.include Dry::Operation::Extensions::ROM
         end
       end


### PR DESCRIPTION
Move the require for dry-operation’s “dry/operation/extensions/rom” extension to after our checks for the presence of the “hanami-db” gem.

Without this, a hanami app generated with `--skip-db` will fail to boot, because the dry-operation extension raises an error at require-time if the rom-sql gem isn’t available.

Fixes https://github.com/hanami/cli/issues/267