### PR TITLE
Fix auto setting of slice-repos root.

### DIFF
--- a/lib/hanami/extensions/db/repo.rb
+++ b/lib/hanami/extensions/db/repo.rb
@@ -83,7 +83,7 @@ module Hanami
                                  .then { slice.inflector.underscore(_1) }
     
           return if repo_class_name.match?(/^(repo|repository)$/)
-          return unless repo_class_name.match?(/(repo|repository)$/)
+          return unless repo_class_name.match?(/_(repo|repository)$/)
     
           repo_class_name.gsub(/_(repo|repository)$/, "")
                          .then { slice.inflector.pluralize(_1) }

--- a/lib/hanami/extensions/db/repo.rb
+++ b/lib/hanami/extensions/db/repo.rb
@@ -79,15 +79,15 @@ module Hanami
         end
 
         def root_for_repo_class(repo_class)
-          repo_class_name = repo_class.to_s.split("::").last
-          return if repo_class_name == "Repo"
-          return unless repo_class_name.end_with?("Repo")
-
-          slice.inflector.demodulize(repo_class)
-            .then { slice.inflector.underscore(_1) }
-            .then { _1.gsub(/_repo$/, "") }
-            .then { slice.inflector.pluralize(_1) }
-            .then { _1.to_sym }
+          repo_class_name = slice.inflector.demodulize(repo_class)
+                                 .then { slice.inflector.underscore(_1) }
+    
+          return if repo_class_name.match?(/^(repo|repository)$/)
+          return unless repo_class_name.match?(/(repo|repository)$/)
+    
+          repo_class_name.gsub(/_(repo|repository)$/, "")
+                         .then { slice.inflector.pluralize(_1) }
+                         .then(&:to_sym)
         end
 
         def struct_namespace

--- a/lib/hanami/extensions/db/repo.rb
+++ b/lib/hanami/extensions/db/repo.rb
@@ -79,7 +79,7 @@ module Hanami
         end
 
         def root_for_repo_class(repo_class)
-          repo_class_name = repo_class.to_s
+          repo_class_name = repo_class.to_s.split("::").last
           return if repo_class_name == "Repo"
           return unless repo_class_name.end_with?("Repo")
 

--- a/lib/hanami/extensions/db/repo.rb
+++ b/lib/hanami/extensions/db/repo.rb
@@ -79,7 +79,9 @@ module Hanami
         end
 
         def root_for_repo_class(repo_class)
-          return unless repo_class.to_s.end_with?("Repo")
+          repo_class_name = repo_class.to_s
+          return if repo_class_name == "Repo"
+          return unless repo_class_name.end_with?("Repo")
 
           slice.inflector.demodulize(repo_class)
             .then { slice.inflector.underscore(_1) }

--- a/lib/hanami/extensions/db/repo.rb
+++ b/lib/hanami/extensions/db/repo.rb
@@ -78,16 +78,18 @@ module Hanami
           slice["db.rom"]
         end
 
+        REPO_CLASS_NAME_REGEX = /^(?<name>.+)_(repo|repository)$/
+
         def root_for_repo_class(repo_class)
           repo_class_name = slice.inflector.demodulize(repo_class)
-                                 .then { slice.inflector.underscore(_1) }
-    
-          return if repo_class_name.match?(/^(repo|repository)$/)
-          return unless repo_class_name.match?(/_(repo|repository)$/)
-    
-          repo_class_name.gsub(/_(repo|repository)$/, "")
-                         .then { slice.inflector.pluralize(_1) }
-                         .then(&:to_sym)
+            .then { slice.inflector.underscore(_1) }
+
+          repo_class_match = repo_class_name.match(REPO_CLASS_NAME_REGEX)
+          return unless repo_class_match
+
+          repo_class_match[:name]
+            .then { slice.inflector.pluralize(_1) }
+            .then(&:to_sym)
         end
 
         def struct_namespace

--- a/spec/integration/db/repo_spec.rb
+++ b/spec/integration/db/repo_spec.rb
@@ -114,6 +114,13 @@ RSpec.describe "DB / Repo", :app_integration do
         end
       RUBY
 
+      write "app/repo.rb", <<~RUBY
+        module TestApp
+          class Repo < Hanami::DB::Repo
+          end
+        end
+      RUBY
+
       ENV["DATABASE_URL"] = "sqlite::memory"
 
       write "slices/admin/db/struct.rb", <<~RUBY
@@ -137,7 +144,7 @@ RSpec.describe "DB / Repo", :app_integration do
 
       write "slices/admin/repo.rb", <<~RUBY
         module Admin
-          class Repo < Hanami::DB::Repo
+          class Repo < TestApp::Repo
           end
         end
       RUBY
@@ -172,7 +179,7 @@ RSpec.describe "DB / Repo", :app_integration do
 
       write "slices/main/repo.rb", <<~RUBY
         module Main
-          class Repo < Hanami::DB::Repo
+          class Repo < TestApp::Repo
           end
         end
       RUBY
@@ -204,6 +211,7 @@ RSpec.describe "DB / Repo", :app_integration do
       migration.apply(gateway, :up)
       gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
 
+      expect(Admin::Slice["repos.post_repo"].root).to eql Admin::Slice["relations.posts"]
       expect(Admin::Slice["repos.post_repo"].posts).to eql Admin::Slice["relations.posts"]
       expect(Admin::Slice["repos.post_repo"].posts.by_pk(1).one!.class).to be < Admin::Structs::Post
 

--- a/spec/integration/db/repo_spec.rb
+++ b/spec/integration/db/repo_spec.rb
@@ -193,6 +193,15 @@ RSpec.describe "DB / Repo", :app_integration do
         end
       RUBY
 
+      write "slices/main/repositories/post_repository.rb", <<~RUBY
+        module Main
+          module Repositories
+            class PostRepository < Repo
+            end
+          end
+        end
+      RUBY
+
       require "hanami/prepare"
 
       Admin::Slice.prepare :db
@@ -216,6 +225,7 @@ RSpec.describe "DB / Repo", :app_integration do
       expect(Admin::Slice["repos.post_repo"].posts.by_pk(1).one!.class).to be < Admin::Structs::Post
 
       expect(Main::Slice["repos.post_repo"].posts).to eql Main::Slice["relations.posts"]
+      expect(Main::Slice["repositories.post_repository"].posts).to eql Main::Slice["relations.posts"]
       # Slice struct namespace used even when no concrete struct classes are defined
       expect(Main::Slice["repos.post_repo"].posts.by_pk(1).one!.class).to be < Main::Structs::Post
     end


### PR DESCRIPTION
Hey :wave:

this would fix #1477 and thus also hanami/db#14.

The issue is that specific slice repo inherits from its own base slice repo, which in turn inherits from the app's base repo.

```ruby
require "hanami/db/repo"

module MyApp
  module DB
    class Repo < Hanami::DB::Repo
    end
  end
end

module MySlice
  module DB
    class Repo < MyApp::DB::Repo
    end
  end
end

module MySlice
  module Repos
    class UserRepo < MySlice::DB::Repo
      commands :create
    end
  end
end
```

Therefore, `inherited` is executed for the Slices base repo class and root is set incorrectly, cause `MySlice::DB::Repo` ends with `Repo`. 

best regards