### PR TITLE
Only auto-inject db.rom when hanami-db is bundled

### DIFF
--- a/lib/hanami/extensions/operation.rb
+++ b/lib/hanami/extensions/operation.rb
@@ -26,6 +26,8 @@ module Hanami
         # @api private
         # @since 2.2.0
         def configure_for_slice(slice)
+          return unless Hanami.bundled?("hanami-db")
+
           include slice.namespace::Deps["db.rom"]
         end
 


### PR DESCRIPTION
If hanami-db is not bundled, our standard DB setup will not be present, which leads to errors initializing operations due to a missing “db.rom” container component.

Fixes #1488.