### PR TITLE
Add Ruby 3.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
           - "3.3"
           - "3.2"
           - "3.1"

--- a/Gemfile
+++ b/Gemfile
@@ -10,15 +10,15 @@ unless ENV["CI"]
 end
 
 gem "hanami-utils", github: "hanami/utils", branch: "main"
-gem "hanami-db", github: "hanami/db", branch: "main"
-gem "hanami-router", github: "hanami/router", branch: "main"
-gem "hanami-controller", github: "hanami/controller", branch: "main"
-gem "hanami-cli", github: "hanami/cli", branch: "main"
-gem "hanami-view", github: "hanami/view", branch: "main"
-gem "hanami-assets", github: "hanami/assets", branch: "main"
-gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
+gem "hanami-db", github: "hanami/db", branch: "add-ruby-3-4-support"
+gem "hanami-router", github: "hanami/router", branch: "add-ruby-3-4-support"
+gem "hanami-controller", github: "hanami/controller", branch: "add-ruby-3-4-support"
+gem "hanami-cli", github: "hanami/cli", branch: "add-ruby-3-4-support"
+gem "hanami-view", github: "hanami/view", branch: "add-ruby-3-4-support"
+gem "hanami-assets", github: "hanami/assets", branch: "add-ruby-3-4-support"
+gem "hanami-webconsole", github: "hanami/webconsole", branch: "add-ruby-3-4-support"
 
-gem "hanami-devtools", github: "hanami/devtools", branch: "main"
+gem "hanami-devtools", github: "hanami/devtools", branch: "add-ruby-3-4-support"
 
 # This is needed for settings specs to pass
 gem "dry-types"

--- a/Gemfile
+++ b/Gemfile
@@ -10,15 +10,15 @@ unless ENV["CI"]
 end
 
 gem "hanami-utils", github: "hanami/utils", branch: "main"
-gem "hanami-db", github: "hanami/db", branch: "add-ruby-3-4-support"
-gem "hanami-router", github: "hanami/router", branch: "add-ruby-3-4-support"
-gem "hanami-controller", github: "hanami/controller", branch: "add-ruby-3-4-support"
-gem "hanami-cli", github: "hanami/cli", branch: "add-ruby-3-4-support"
-gem "hanami-view", github: "hanami/view", branch: "add-ruby-3-4-support"
-gem "hanami-assets", github: "hanami/assets", branch: "add-ruby-3-4-support"
-gem "hanami-webconsole", github: "hanami/webconsole", branch: "add-ruby-3-4-support"
+gem "hanami-db", github: "hanami/db", branch: "main"
+gem "hanami-router", github: "hanami/router", branch: "main"
+gem "hanami-controller", github: "hanami/controller", branch: "main"
+gem "hanami-cli", github: "hanami/cli", branch: "main"
+gem "hanami-view", github: "hanami/view", branch: "main"
+gem "hanami-assets", github: "hanami/assets", branch: "main"
+gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
-gem "hanami-devtools", github: "hanami/devtools", branch: "add-ruby-3-4-support"
+gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
 # This is needed for settings specs to pass
 gem "dry-types"

--- a/spec/integration/logging/exception_logging_spec.rb
+++ b/spec/integration/logging/exception_logging_spec.rb
@@ -73,7 +73,12 @@ RSpec.describe "Logging / Exception logging", :app_integration do
       expect(logs.lines.length).to be > 10
       expect(logs).to match %r{GET 500 \d+(µs|ms) 127.0.0.1 /}
       expect(logs).to include("unhandled (TestApp::Actions::Test::UnhandledError)")
-      expect(logs).to include("app/actions/test.rb:7:in `handle'")
+
+      if RUBY_VERSION < "3.4"
+        expect(logs).to include("app/actions/test.rb:7:in `handle'")
+      else
+        expect(logs).to include("app/actions/test.rb:7:in 'TestApp::Actions::Test#handle'")
+      end
     end
 
     it "re-raises the exception" do

--- a/spec/unit/hanami/web/rack_logger_spec.rb
+++ b/spec/unit/hanami/web/rack_logger_spec.rb
@@ -53,10 +53,17 @@ RSpec.describe Hanami::Web::RackLogger do
       stream.rewind
       actual = stream.read
 
-      expect(actual).to eql(<<~LOG)
-        [#{app_name}] [INFO] [#{time}] #{verb} #{status} #{elapsed}µs #{ip} #{path} #{content_length}
-          {"user"=>{"password"=>"[FILTERED]"}}
-      LOG
+      if RUBY_VERSION < "3.4"
+        expect(actual).to eql(<<~LOG)
+          [#{app_name}] [INFO] [#{time}] #{verb} #{status} #{elapsed}µs #{ip} #{path} #{content_length}
+            {"user"=>{"password"=>"[FILTERED]"}}
+        LOG
+      else
+        expect(actual).to eql(<<~LOG)
+          [#{app_name}] [INFO] [#{time}] #{verb} #{status} #{elapsed}µs #{ip} #{path} #{content_length}
+            {"user" => {"password" => "[FILTERED]"}}
+        LOG
+      end
     end
 
     context "ip" do


### PR DESCRIPTION
Draft because I've switched the branch sources in the Gemfile to `add-ruby-3-4-support` on all the Hanami dependencies.

Once all those are merged into main, the branches can be reset back to `main` (by removing or reverting `331c429` on this branch), then CI should pass and this can be merged. 

Related PR's:
* https://github.com/hanami/utils/pull/413
* https://github.com/hanami/controller/pull/459
* https://github.com/hanami/view/pull/258
* https://github.com/hanami/router/pull/276
* https://github.com/hanami/db/pull/15
* https://github.com/hanami/validations/pull/231
* https://github.com/hanami/cli/pull/282
* https://github.com/hanami/assets/pull/145
* https://github.com/hanami/webconsole/pull/11
* https://github.com/hanami/reloader/pull/31
* https://github.com/hanami/devtools/pull/89