### PR TITLE
rack 3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,14 +11,14 @@ end
 
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 gem "hanami-db", github: "hanami/db", branch: "main"
-gem "hanami-router", github: "hanami/router", branch: "main"
-gem "hanami-controller", github: "hanami/controller", branch: "main"
+gem "hanami-router", github: "kyleplump/router", branch: "rack3"
+gem "hanami-controller", github: "kyleplump/controller", branch: "rack3"
 gem "hanami-cli", github: "hanami/cli", branch: "main"
 gem "hanami-view", github: "hanami/view", branch: "main"
 gem "hanami-assets", github: "hanami/assets", branch: "main"
 gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
 
-gem "hanami-devtools", github: "hanami/devtools", branch: "main"
+gem "hanami-devtools", github: "kyleplump/devtools", branch: "rack3"
 
 # This is needed for settings specs to pass
 gem "dry-types"

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -42,8 +42,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hanami-utils",     "~> 2.2"
   spec.add_dependency "json",             ">= 2.7.2"
   spec.add_dependency "zeitwerk",         "~> 2.6"
+  spec.add_dependency "rack-session"      "~> 2.0"
 
   spec.add_development_dependency "rspec",     "~> 3.8"
-  spec.add_development_dependency "rack-test", "~> 1.1"
+  spec.add_development_dependency "rack-test", "~> 2.0"
   spec.add_development_dependency "rake",      "~> 13.0"
 end


### PR DESCRIPTION
updates to Rack 3.  one part of many gem updates

[list of changes](https://github.com/hanami/router/pull/277)

## highlights
adds `rack-session` as an [explicit dependency](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#racksession-was-moved-to-a-separate-gem)