### PR TITLE
Add APP_ENV as a fallback of HANAMI ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The web, with simplicity.
 
+## [Unreleased]
+
+### Deprecated
+
+- [Sven Schwyn] Add `APP_ENV` as a fallback of `HANAMI_ENV` (#1487)
+
 ## v2.2.1 - 2024-11-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ The web, with simplicity.
 
 ## [Unreleased]
 
-### Deprecated
+### Added
 
-- [Sven Schwyn] Add `APP_ENV` as a fallback of `HANAMI_ENV` (#1487)
+- Check `ENV["APP_ENV"]` for the Hanami env if `ENV["HANAMI_ENV"]` is not set. The order of environment variable checks is now `HANAMI_ENV`->`APP_ENV`->`RACK_ENV` (@svoop in #1487).
 
 ## v2.2.1 - 2024-11-12
 

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -138,14 +138,20 @@ module Hanami
     end
   end
 
-  # Returns the Hanami app environment from the `HANAMI_ENV` environment
-  # variable or in this order one of the fallbacks `APP_ENV`, `RACK_ENV` and
-  # ultimately `:development`.
+  # Returns the Hanami app environment as determined from the environment.
+  #
+  # Checks the following environment variables in order:
+  #
+  # - `HANAMI_ENV`
+  # - `APP_ENV`
+  # - `RACK_ENV`
+  #
+  # Defaults to `:development` if no environment variable is set.
   #
   # @example
   #   Hanami.env # => :development
   #
-  # @return [Symbol] the environment name (default: :development)
+  # @return [Symbol] the environment name
   #
   # @api public
   # @since 2.0.0

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -138,17 +138,19 @@ module Hanami
     end
   end
 
-  # Returns the Hanami app environment as loaded from the `HANAMI_ENV` environment variable.
+  # Returns the Hanami app environment from the `HANAMI_ENV` environment
+  # variable or in this order one of the fallbacks `APP_ENV`, `RACK_ENV` and
+  # ultimately `:development`.
   #
   # @example
   #   Hanami.env # => :development
   #
-  # @return [Symbol] the environment name
+  # @return [Symbol] the environment name (default: :development)
   #
   # @api public
   # @since 2.0.0
   def self.env(e: ENV)
-    e.fetch("HANAMI_ENV") { e.fetch("RACK_ENV", "development") }.to_sym
+    (e["HANAMI_ENV"] || e["APP_ENV"] || e["RACK_ENV"] || :development).to_sym
   end
 
   # Returns true if {.env} matches any of the given names

--- a/spec/unit/hanami/env_spec.rb
+++ b/spec/unit/hanami/env_spec.rb
@@ -3,30 +3,27 @@
 RSpec.describe Hanami, ".env" do
   subject { described_class.env(e: env) }
 
-  context "HANAMI_ENV in ENV" do
-    let(:env) { {"HANAMI_ENV" => "test"} }
+  context "HANAMI_ENV, APP_ENV and RACK_ENV in ENV" do
+    let(:env) { { "HANAMI_ENV" => "test", "APP_ENV" => "development", "RACK_ENV" => "production" } }
 
     it "is the value of HANAMI_ENV" do
       is_expected.to eq(:test)
+    end
+  end
+
+  context "APP_ENV and RACK_ENV in ENV" do
+    let(:env) { {"APP_ENV" => "development", "RACK_ENV" => "production" } }
+
+    it "is the value of APP_ENV" do
+      is_expected.to eq(:development)
     end
   end
 
   context "RACK_ENV in ENV" do
-    let(:env) { {"HANAMI_ENV" => "test"} }
+    let(:env) { { "RACK_ENV" => "production" } }
 
     it "is the value of RACK_ENV" do
-      is_expected.to eq(:test)
-    end
-  end
-
-  context "both HANAMI_ENV and RACK_ENV in ENV" do
-    let(:env) do
-      {"HANAMI_ENV" => "test",
-       "RACK_ENV" => "production"}
-    end
-
-    it "is the value of HANAMI_ENV" do
-      is_expected.to eq(:test)
+      is_expected.to eq(:production)
     end
   end
 


### PR DESCRIPTION
Deprecate `RACK_ENV` in favor of `APP_ENV` as the alternative and fallback to `HANAMI_ENV`.

Background: The [purpose of`RACK_ENV` in `Rack::Server`](https://github.com/rack/rack/issues/1546) is different from setting the environment of the application.
