### PR TITLE
Add tags for zeitwerk loaders

### DIFF
--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -169,6 +169,7 @@ module Hanami
 
       def prepare_autoloader
         autoloader.tag = "hanami.app.#{slice_name.name}"
+
         # Component dirs are automatically pushed to the autoloader by dry-system's zeitwerk plugin.
         # This method adds other dirs that are not otherwise configured as component dirs.
 

--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -168,6 +168,7 @@ module Hanami
       end
 
       def prepare_autoloader
+        autoloader.tag = "hanami.app.#{slice_name.name}"
         # Component dirs are automatically pushed to the autoloader by dry-system's zeitwerk plugin.
         # This method adds other dirs that are not otherwise configured as component dirs.
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -955,9 +955,9 @@ module Hanami
 
       def prepare_autoloader
         autoloader.tag = "hanami.slices.#{slice_name.to_s}"
-        # Component dirs are automatically pushed to the autoloader by dry-system's
-        # zeitwerk plugin. This method adds other dirs that are not otherwise configured
-        # as component dirs.
+
+        # Component dirs are automatically pushed to the autoloader by dry-system's zeitwerk plugin.
+        # This method adds other dirs that are not otherwise configured as component dirs.
 
         # Everything in the slice root can be autoloaded except `config/` and `slices/`,
         # which are framework-managed directories

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -954,6 +954,7 @@ module Hanami
       end
 
       def prepare_autoloader
+        autoloader.tag = "hanami.slices.#{slice_name.to_s}"
         # Component dirs are automatically pushed to the autoloader by dry-system's
         # zeitwerk plugin. This method adds other dirs that are not otherwise configured
         # as component dirs.

--- a/spec/integration/container/autoloader_spec.rb
+++ b/spec/integration/container/autoloader_spec.rb
@@ -70,11 +70,13 @@ RSpec.describe "App autoloader", :app_integration do
       expect(NonApp::Thing).to be
 
       expect(TestApp::NBAJam::GetThatOuttaHere).to be
+      expect(TestApp::App.autoloader.tag).to eq("hanami.app.test_app")
 
       expect(Admin::Slice["operations.create_game"]).to be_an_instance_of(Admin::Operations::CreateGame)
       expect(Admin::Slice["operations.create_game"].call).to be_an_instance_of(Admin::Entities::Game)
 
       expect(Admin::Entities::Quarter).to be
+      expect(Admin::Slice.autoloader.tag).to eq("hanami.slices.admin")
     end
   end
 end


### PR DESCRIPTION
When debugging [this issue](https://github.com/hanami/hanami/compare/add-tag-for-zeitwerk-loader?expand=1) from the forums, I saw some Zeitwerk loaders had `tag`s that were just random hex strings, while all the others had clear labels for them. I realized we weren't setting tags in this repo, so this fixes that.