### PR TITLE
Support optional nonce in Rack requests, CSP header rules and view helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Check `ENV["APP_ENV"]` for the Hanami env if `ENV["HANAMI_ENV"]` is not set. The order of environment variable checks is now `HANAMI_ENV`->`APP_ENV`->`RACK_ENV` (@svoop in #1487).
+- Support optional nonce in Rack requests, CSP header rules and view helpers (@svoop in #1500)
 
 ### Changed
 

--- a/lib/hanami/config/actions.rb
+++ b/lib/hanami/config/actions.rb
@@ -138,6 +138,10 @@ module Hanami
         end
       end
 
+      # @api public
+      # @since x.x.x
+      def content_security_policy? = !!@content_security_policy
+
       private
 
       # Apply defaults for base config

--- a/lib/hanami/config/actions.rb
+++ b/lib/hanami/config/actions.rb
@@ -74,6 +74,23 @@ module Hanami
       # @since 2.0.0
       attr_accessor :content_security_policy
 
+      # Returns the proc to generate Content Security Policy nonce values.
+      #
+      # The current Rack request object is provided as an optional argument
+      # to the proc, enabling the generation of nonces based on session IDs.
+      #
+      # @example Independent random nonce (default)
+      #   -> { SecureRandom.urlsafe_base64(16) }
+      #
+      # @example Session dependent nonce
+      #   ->(request) { Digest::SHA256.base64digest(request.session[:uuid])[0, 16] }
+      #
+      # @return [Proc]
+      #
+      # @api public
+      # @since x.x.x
+      setting :content_security_policy_nonce_generator, default: -> { SecureRandom.urlsafe_base64(16) }
+
       # @!attribute [rw] method_override
       #   Sets or returns whether HTTP method override should be enabled for action classes.
       #

--- a/lib/hanami/config/actions/content_security_policy.rb
+++ b/lib/hanami/config/actions/content_security_policy.rb
@@ -96,6 +96,29 @@ module Hanami
           @policy.delete(key)
         end
 
+        # Returns true if 'nonce' is used in any of the policies.
+        #
+        # @return [Boolean]
+        #
+        # @api public
+        # @since x.x.x
+        def nonce?
+          @policy.any? { _2.match?(/'nonce'/) }
+        end
+
+        # Returns an array of middleware name to support 'nonce' in
+        # policies, or an empty array if 'nonce' is not used.
+        #
+        # @return [Array<(Symbol, Array)>]
+        #
+        # @api public
+        # @since x.x.x
+        def middleware
+          return [] unless nonce?
+
+          [Hanami::Middleware::ContentSecurityPolicyNonce]
+        end
+
         # @since 2.0.0
         # @api private
         def to_s

--- a/lib/hanami/constants.rb
+++ b/lib/hanami/constants.rb
@@ -56,4 +56,7 @@ module Hanami
   # @api private
   RB_EXT_REGEXP = %r{.rb$}
   private_constant :RB_EXT_REGEXP
+
+  # @api private
+  CONTENT_SECURITY_POLICY_NONCE_REQUEST_KEY = "hanami.content_security_policy_nonce"
 end

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -172,6 +172,16 @@ module Hanami
               @request
             end
 
+            # Returns true if the view is rendered from within an action and a request is available.
+            #
+            # @return [Boolean]
+            #
+            # @api public
+            # @since 2.1.0
+            def request?
+              !!@request
+            end
+
             # Returns the app's routes helper.
             #
             # @return [Hanami::Slice::RoutesHelper] the routes helper

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -177,7 +177,7 @@ module Hanami
             # @return [Boolean]
             #
             # @api public
-            # @since 2.1.0
+            # @since x.x.x
             def request?
               !!@request
             end

--- a/lib/hanami/helpers/assets_helper.rb
+++ b/lib/hanami/helpers/assets_helper.rb
@@ -2,6 +2,7 @@
 
 require "uri"
 require "hanami/view"
+require "../constants"
 
 # rubocop:disable Metrics/ModuleLength
 
@@ -713,7 +714,7 @@ module Hanami
       def content_security_policy_nonce
         return unless _context.request?
 
-        _context.request.env["hanami.content_security_policy_nonce"]
+        _context.request.env[CONTENT_SECURITY_POLICY_NONCE_REQUEST_KEY]
       end
 
       private

--- a/lib/hanami/helpers/assets_helper.rb
+++ b/lib/hanami/helpers/assets_helper.rb
@@ -711,7 +711,7 @@ module Hanami
       #
       #   <script nonce="<%= content_security_policy_nonce %>">
       def content_security_policy_nonce
-        _context.request.env['hanami.content_security_policy_nonce']
+        _context.request.env["hanami.content_security_policy_nonce"]
       rescue Hanami::ComponentLoadError
         nil
       end

--- a/lib/hanami/helpers/assets_helper.rb
+++ b/lib/hanami/helpers/assets_helper.rb
@@ -2,7 +2,7 @@
 
 require "uri"
 require "hanami/view"
-require "../constants"
+require_relative "../constants"
 
 # rubocop:disable Metrics/ModuleLength
 

--- a/lib/hanami/helpers/assets_helper.rb
+++ b/lib/hanami/helpers/assets_helper.rb
@@ -711,9 +711,9 @@ module Hanami
       #
       #   <script nonce="<%= content_security_policy_nonce %>">
       def content_security_policy_nonce
+        return unless _context.request?
+
         _context.request.env["hanami.content_security_policy_nonce"]
-      rescue Hanami::ComponentLoadError
-        nil
       end
 
       private

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -27,7 +27,9 @@ module Hanami
       def call(env)
         return @app.call(env) unless Hanami.app.config.actions.content_security_policy?
 
-        request_nonce = generate_nonce
+        args = nonce_generator.arity == 1 ? [Rack::Request.new(env)] : []
+        request_nonce = nonce_generator.call(*args)
+
         env[CONTENT_SECURITY_POLICY_NONCE_REQUEST_KEY] = request_nonce
 
         _, headers, _ = response = @app.call(env)
@@ -39,8 +41,8 @@ module Hanami
 
       private
 
-      def generate_nonce
-        SecureRandom.urlsafe_base64(16)
+      def nonce_generator
+        Hanami.app.config.actions.content_security_policy_nonce_generator
       end
 
       def sub_nonce(string, nonce)

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rack"
+require "securerandom"
+
+module Hanami
+  module Middleware
+    # Generate a random per request nonce value like `A12OggyZ`, write
+    # it to `hanami.content_security_policy_nonce` and replace all
+    # occurrences of `'nonce'` in the Content-Security-Policy header
+    # with `'nonce-A12OggyZ'`.
+    #
+    # @see Hanami::Middleware::ContentSecurityPolicyNonce
+    #
+    # @api private
+    # @since x.x.x
+    class ContentSecurityPolicyNonce
+      # @api private
+      # @since x.x.x
+      def initialize(app)
+        @app = app
+        @nonce = random_nonce
+      end
+
+      # @api private
+      # @since x.x.x
+      def call(env)
+        if Hanami.app.config.actions.content_security_policy == false
+          @app.call(env)
+        else
+          env['hanami.content_security_policy_nonce'] = @nonce
+          @app.call(env).tap do |response|
+            headers = response[1]
+            headers["Content-Security-Policy"] = sub_nonce headers["Content-Security-Policy"]
+          end
+        end
+      end
+
+      private
+
+      def random_nonce
+        SecureRandom.alphanumeric(8)
+      end
+
+      def sub_nonce(string)
+        string.gsub(/'nonce'/, "'nonce-#{@nonce}'")
+      end
+    end
+  end
+end

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -2,6 +2,7 @@
 
 require "rack"
 require "securerandom"
+require "../constants"
 
 module Hanami
   module Middleware
@@ -28,7 +29,7 @@ module Hanami
         if Hanami.app.config.actions.content_security_policy == false
           @app.call(env)
         else
-          env["hanami.content_security_policy_nonce"] = @nonce
+          env[CONTENT_SECURITY_POLICY_NONCE_REQUEST_KEY] = @nonce
           @app.call(env).tap do |response|
             headers = response[1]
             headers["Content-Security-Policy"] = sub_nonce headers["Content-Security-Policy"]

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -29,10 +29,12 @@ module Hanami
 
         request_nonce = generate_nonce
         env[CONTENT_SECURITY_POLICY_NONCE_REQUEST_KEY] = request_nonce
-        @app.call(env).tap do |response|
-          headers = response[1]
-          headers["Content-Security-Policy"] = sub_nonce(headers["Content-Security-Policy"], request_nonce)
-        end
+
+        _, headers, _ = response = @app.call(env)
+
+        headers["Content-Security-Policy"] = sub_nonce(headers["Content-Security-Policy"], request_nonce)
+
+        response
       end
 
       private

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -28,7 +28,7 @@ module Hanami
         if Hanami.app.config.actions.content_security_policy == false
           @app.call(env)
         else
-          env['hanami.content_security_policy_nonce'] = @nonce
+          env["hanami.content_security_policy_nonce"] = @nonce
           @app.call(env).tap do |response|
             headers = response[1]
             headers["Content-Security-Policy"] = sub_nonce headers["Content-Security-Policy"]
@@ -43,7 +43,7 @@ module Hanami
       end
 
       def sub_nonce(string)
-        string.gsub(/'nonce'/, "'nonce-#{@nonce}'")
+        string&.gsub("'nonce'", "'nonce-#{@nonce}'")
       end
     end
   end

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -5,10 +5,10 @@ require "securerandom"
 
 module Hanami
   module Middleware
-    # Generate a random per request nonce value like `A12OggyZ`, write
-    # it to `hanami.content_security_policy_nonce` and replace all
-    # occurrences of `'nonce'` in the Content-Security-Policy header
-    # with `'nonce-A12OggyZ'`.
+    # Generates a random per request nonce value like `mSMnSwfVZVe+LyQy1SPCGw==`, stores it as
+    # `"hanami.content_security_policy_nonce"` in the Rack environment, and replaces all occurrences
+    # of `'nonce'` in the `Content-Security-Policy header with the actual nonce value for the
+    # request, e.g. `'nonce-mSMnSwfVZVe+LyQy1SPCGw=='`.
     #
     # @see Hanami::Middleware::ContentSecurityPolicyNonce
     #

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -26,14 +26,12 @@ module Hanami
       # @api private
       # @since x.x.x
       def call(env)
-        if Hanami.app.config.actions.content_security_policy == false
-          @app.call(env)
-        else
-          env[CONTENT_SECURITY_POLICY_NONCE_REQUEST_KEY] = @nonce
-          @app.call(env).tap do |response|
-            headers = response[1]
-            headers["Content-Security-Policy"] = sub_nonce headers["Content-Security-Policy"]
-          end
+        return @app.call(env) unless Hanami.app.config.actions.content_security_policy?
+
+        env[CONTENT_SECURITY_POLICY_NONCE_REQUEST_KEY] = @nonce
+        @app.call(env).tap do |response|
+          headers = response[1]
+          headers["Content-Security-Policy"] = sub_nonce headers["Content-Security-Policy"]
         end
       end
 

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -38,7 +38,7 @@ module Hanami
       private
 
       def random_nonce
-        SecureRandom.alphanumeric(8)
+        SecureRandom.urlsafe_base64(16)
       end
 
       def sub_nonce(string)

--- a/lib/hanami/middleware/content_security_policy_nonce.rb
+++ b/lib/hanami/middleware/content_security_policy_nonce.rb
@@ -2,7 +2,7 @@
 
 require "rack"
 require "securerandom"
-require "../constants"
+require_relative "../constants"
 
 module Hanami
   module Middleware

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -1050,6 +1050,11 @@ module Hanami
             if config.actions.sessions.enabled?
               use(*config.actions.sessions.middleware)
             end
+
+            if config.actions.content_security_policy && # rubocop:disable Style/SafeNavigation
+               config.actions.content_security_policy.nonce?
+              use(*config.actions.content_security_policy.middleware)
+            end
           end
 
           if Hanami.bundled?("hanami-assets") && config.assets.serve

--- a/spec/integration/assets/cross_slice_assets_helpers_spec.rb
+++ b/spec/integration/assets/cross_slice_assets_helpers_spec.rb
@@ -123,7 +123,6 @@ RSpec.describe "Cross-slice assets via helpers", :app_integration do
     compile_assets!
 
     output = Admin::Slice["views.posts.show"].call.to_s
-
     expect(output).to match(%r{<link href="/assets/app-[A-Z0-9]{8}.css" type="text/css" rel="stylesheet">})
     expect(output).to match(%r{<script src="/assets/app-[A-Z0-9]{8}.js" type="text/javascript"></script>})
   end

--- a/spec/integration/web/content_security_policy_nonce_spec.rb
+++ b/spec/integration/web/content_security_policy_nonce_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+RSpec.describe "Web / Content security policy nonce", :app_integration do
+  include Rack::Test::Methods
+
+  let(:app) { Hanami.app }
+
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Routes
+            get "index", to: "index"
+          end
+        end
+      RUBY
+
+      write "app/actions/index.rb", <<~RUBY
+        module TestApp
+          module Actions
+            class Index < Hanami::Action
+            end
+          end
+        end
+      RUBY
+
+      write "app/views/index.rb", <<~RUBY
+        module TestApp
+          module Views
+            class Index < Hanami::View
+              config.layout = false
+            end
+          end
+        end
+      RUBY
+
+      write "app/templates/index.html.erb", <<~HTML
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <%= stylesheet_tag "app" %>
+          </head>
+          <body>
+            <style nonce="<%= content_security_policy_nonce %>"></style>
+            <%= javascript_tag "app" %>
+          </body>
+        </html>
+      HTML
+
+      write "package.json", <<~JSON
+        {
+          "type": "module"
+        }
+      JSON
+
+      write "config/assets.js", <<~JS
+        import * as assets from "hanami-assets";
+        await assets.run();
+      JS
+
+      write "app/assets/js/app.js", <<~JS
+        import "../css/app.css";
+      JS
+
+      write "app/assets/css/app.css", <<~CSS
+      CSS
+
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+      compile_assets!
+    end
+  end
+
+  describe "HTML request" do
+    context "CSP enabled" do
+      def before_prepare
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+              config.middleware.use Hanami::Middleware::ContentSecurityPolicyNonce
+              config.actions.content_security_policy[:script_src] = "'self' 'nonce'"
+            end
+          end
+        RUBY
+      end
+
+      it "sets 'hanami.content_security_policy_nonce' in Rack env" do
+        get "/index"
+
+        expect(last_request.env['hanami.content_security_policy_nonce']).to match(/\A[a-z\d]{8}\z/i)
+      end
+
+      it "substitutes 'nonce' in the CSP header" do
+        get "/index"
+        nonce = last_request.env['hanami.content_security_policy_nonce']
+
+        expect(last_response.get_header("Content-Security-Policy")).to match(/script-src 'self' 'nonce-#{nonce}'/)
+      end
+
+      it "enables the content_security_policy_nonce helper" do
+        get "/index"
+        nonce = last_request.env['hanami.content_security_policy_nonce']
+
+        expect(last_response.body).to match(/<style nonce="#{nonce}">/)
+      end
+
+      it "adds the nonce attribute to the javascript_tag helper" do
+        get "/index"
+        nonce = last_request.env['hanami.content_security_policy_nonce']
+
+        expect(last_response.body).to match(/<script[^>]*\s+nonce="#{nonce}"/)
+      end
+
+      it "adds the nonce attribute to the stylesheet_tag helper" do
+        get "/index"
+        nonce = last_request.env['hanami.content_security_policy_nonce']
+
+        expect(last_response.body).to match(/<link[^>]*\s+nonce="#{nonce}"/)
+      end
+    end
+
+    context "CSP disabled" do
+      def before_prepare
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+              config.middleware.use Hanami::Middleware::ContentSecurityPolicyNonce
+              config.actions.content_security_policy = false
+            end
+          end
+        RUBY
+      end
+
+      it "does not set 'hanami.content_security_policy_nonce' in Rack env" do
+        get "/index"
+
+        expect(last_request.env).to_not have_key 'hanami.content_security_policy_nonce'
+      end
+
+      it "does not produce a CSP header" do
+        get "/index"
+
+        expect(last_response.headers).to_not have_key "Content-Security-Policy"
+      end
+
+      it "disables the content_security_policy_nonce helper" do
+        get "/index"
+
+        expect(last_response.body).to match(/<style nonce="">/)
+      end
+
+      it "doesn't add' the nonce attribute to the javascript_tag helper" do
+        get "/index"
+
+        expect(last_response.body).to match(/<script(?![^>]*\s+nonce=)/)
+      end
+
+      it "doesn't add the nonce attribute to the stylesheet_tag helper" do
+        get "/index"
+
+        expect(last_response.body).to match(/<link(?![^>]*\s+nonce=)/)
+      end
+    end
+  end
+end

--- a/spec/integration/web/content_security_policy_nonce_spec.rb
+++ b/spec/integration/web/content_security_policy_nonce_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
             class App < Hanami::App
               config.middleware.use Hanami::Middleware::ContentSecurityPolicyNonce
               config.actions.content_security_policy[:script_src] = "'self' 'nonce'"
+
+              config.logger.stream = File::NULL
             end
           end
         RUBY
@@ -131,6 +133,8 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
             class App < Hanami::App
               config.middleware.use Hanami::Middleware::ContentSecurityPolicyNonce
               config.actions.content_security_policy = false
+
+              config.logger.stream = File::NULL
             end
           end
         RUBY

--- a/spec/integration/web/content_security_policy_nonce_spec.rb
+++ b/spec/integration/web/content_security_policy_nonce_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
 
           module TestApp
             class App < Hanami::App
-              config.middleware.use Hanami::Middleware::ContentSecurityPolicyNonce
               config.actions.content_security_policy[:script_src] = "'self' 'nonce'"
 
               config.logger.stream = File::NULL
@@ -131,7 +130,6 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
 
           module TestApp
             class App < Hanami::App
-              config.middleware.use Hanami::Middleware::ContentSecurityPolicyNonce
               config.actions.content_security_policy = false
 
               config.logger.stream = File::NULL

--- a/spec/integration/web/content_security_policy_nonce_spec.rb
+++ b/spec/integration/web/content_security_policy_nonce_spec.rb
@@ -88,10 +88,17 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
         RUBY
       end
 
-      it "sets hanami.content_security_policy_nonce in Rack env" do
-        get "/index"
+      it "sets unique and per-request hanami.content_security_policy_nonce in Rack env" do
+        previous_nonces = []
+        3.times do
+          get "/index"
+          nonce = last_request.env["hanami.content_security_policy_nonce"]
 
-        expect(last_request.env["hanami.content_security_policy_nonce"]).to match(/\A[A-Za-z0-9\-_]{22}\z/)
+          expect(nonce).to match(/\A[A-Za-z0-9\-_]{22}\z/)
+          expect(previous_nonces).not_to include nonce
+
+          previous_nonces << nonce
+        end
       end
 
       it "substitutes 'nonce' in the CSP header" do

--- a/spec/integration/web/content_security_policy_nonce_spec.rb
+++ b/spec/integration/web/content_security_policy_nonce_spec.rb
@@ -64,8 +64,7 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
         import "../css/app.css";
       JS
 
-      write "app/assets/css/app.css", <<~CSS
-      CSS
+      write "app/assets/css/app.css", ""
 
       before_prepare if respond_to?(:before_prepare)
       require "hanami/prepare"
@@ -88,36 +87,36 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
         RUBY
       end
 
-      it "sets 'hanami.content_security_policy_nonce' in Rack env" do
+      it "sets hanami.content_security_policy_nonce in Rack env" do
         get "/index"
 
-        expect(last_request.env['hanami.content_security_policy_nonce']).to match(/\A[a-z\d]{8}\z/i)
+        expect(last_request.env["hanami.content_security_policy_nonce"]).to match(/\A[a-z\d]{8}\z/i)
       end
 
       it "substitutes 'nonce' in the CSP header" do
         get "/index"
-        nonce = last_request.env['hanami.content_security_policy_nonce']
+        nonce = last_request.env["hanami.content_security_policy_nonce"]
 
         expect(last_response.get_header("Content-Security-Policy")).to match(/script-src 'self' 'nonce-#{nonce}'/)
       end
 
       it "enables the content_security_policy_nonce helper" do
         get "/index"
-        nonce = last_request.env['hanami.content_security_policy_nonce']
+        nonce = last_request.env["hanami.content_security_policy_nonce"]
 
         expect(last_response.body).to match(/<style nonce="#{nonce}">/)
       end
 
       it "adds the nonce attribute to the javascript_tag helper" do
         get "/index"
-        nonce = last_request.env['hanami.content_security_policy_nonce']
+        nonce = last_request.env["hanami.content_security_policy_nonce"]
 
         expect(last_response.body).to match(/<script[^>]*\s+nonce="#{nonce}"/)
       end
 
       it "adds the nonce attribute to the stylesheet_tag helper" do
         get "/index"
-        nonce = last_request.env['hanami.content_security_policy_nonce']
+        nonce = last_request.env["hanami.content_security_policy_nonce"]
 
         expect(last_response.body).to match(/<link[^>]*\s+nonce="#{nonce}"/)
       end
@@ -137,10 +136,10 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
         RUBY
       end
 
-      it "does not set 'hanami.content_security_policy_nonce' in Rack env" do
+      it "does not set hanami.content_security_policy_nonce in Rack env" do
         get "/index"
 
-        expect(last_request.env).to_not have_key 'hanami.content_security_policy_nonce'
+        expect(last_request.env).to_not have_key "hanami.content_security_policy_nonce"
       end
 
       it "does not produce a CSP header" do
@@ -155,7 +154,7 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
         expect(last_response.body).to match(/<style nonce="">/)
       end
 
-      it "doesn't add' the nonce attribute to the javascript_tag helper" do
+      it "doesn't add the nonce attribute to the javascript_tag helper" do
         get "/index"
 
         expect(last_response.body).to match(/<script(?![^>]*\s+nonce=)/)

--- a/spec/integration/web/content_security_policy_nonce_spec.rb
+++ b/spec/integration/web/content_security_policy_nonce_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
       it "sets hanami.content_security_policy_nonce in Rack env" do
         get "/index"
 
-        expect(last_request.env["hanami.content_security_policy_nonce"]).to match(/\A[a-z\d]{8}\z/i)
+        expect(last_request.env["hanami.content_security_policy_nonce"]).to match(/\A[A-Za-z0-9\-_]{22}\z/)
       end
 
       it "substitutes 'nonce' in the CSP header" do
@@ -104,21 +104,21 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
         get "/index"
         nonce = last_request.env["hanami.content_security_policy_nonce"]
 
-        expect(last_response.body).to match(/<style nonce="#{nonce}">/)
+        expect(last_response.body).to match(/<style nonce="#{Regexp.escape(nonce)}">/)
       end
 
       it "adds the nonce attribute to the javascript_tag helper" do
         get "/index"
         nonce = last_request.env["hanami.content_security_policy_nonce"]
 
-        expect(last_response.body).to match(/<script[^>]*\s+nonce="#{nonce}"/)
+        expect(last_response.body).to match(/<script[^>]*\s+nonce="#{Regexp.escape(nonce)}"/)
       end
 
       it "adds the nonce attribute to the stylesheet_tag helper" do
         get "/index"
         nonce = last_request.env["hanami.content_security_policy_nonce"]
 
-        expect(last_response.body).to match(/<link[^>]*\s+nonce="#{nonce}"/)
+        expect(last_response.body).to match(/<link[^>]*\s+nonce="#{Regexp.escape(nonce)}"/)
       end
     end
 

--- a/spec/integration/web/content_security_policy_nonce_spec.rb
+++ b/spec/integration/web/content_security_policy_nonce_spec.rb
@@ -101,6 +101,22 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
         end
       end
 
+      it "accepts custom nonce generator proc without arguments" do
+        Hanami.app.config.actions.content_security_policy_nonce_generator = -> { "foobar" }
+
+        get "/index"
+
+        expect(last_request.env["hanami.content_security_policy_nonce"]).to eql("foobar")
+      end
+
+      it "accepts custom nonce generator proc with Rack request as argument" do
+        Hanami.app.config.actions.content_security_policy_nonce_generator = ->(request) { request }
+
+        get "/index"
+
+        expect(last_request.env["hanami.content_security_policy_nonce"]).to be_a(Rack::Request)
+      end
+
       it "substitutes 'nonce' in the CSP header" do
         get "/index"
         nonce = last_request.env["hanami.content_security_policy_nonce"]

--- a/spec/integration/web/content_security_policy_nonce_spec.rb
+++ b/spec/integration/web/content_security_policy_nonce_spec.rb
@@ -128,6 +128,13 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
 
         expect(last_response.body).to match(/<link[^>]*\s+nonce="#{Regexp.escape(nonce)}"/)
       end
+
+      it "behaves the same with explicitly added middleware" do
+        Hanami.app.config.middleware.use Hanami::Middleware::ContentSecurityPolicyNonce
+        get "/index"
+
+        expect(last_request.env["hanami.content_security_policy_nonce"]).to match(/\A[A-Za-z0-9\-_]{22}\z/)
+      end
     end
 
     context "CSP disabled" do
@@ -173,6 +180,13 @@ RSpec.describe "Web / Content security policy nonce", :app_integration do
         get "/index"
 
         expect(last_response.body).to match(/<link(?![^>]*\s+nonce=)/)
+      end
+
+      it "behaves the same with explicitly added middleware" do
+        Hanami.app.config.middleware.use Hanami::Middleware::ContentSecurityPolicyNonce
+        get "/index"
+
+        expect(last_response.headers).to_not have_key "Content-Security-Policy"
       end
     end
   end

--- a/spec/unit/hanami/config/actions/content_security_policy_spec.rb
+++ b/spec/unit/hanami/config/actions/content_security_policy_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Hanami::Config::Actions, "#content_security_policy" do
       ].join(";")
 
       expect(content_security_policy.to_s).to eq(expected)
+      expect(content_security_policy.nonce?).to be(false)
     end
   end
 
@@ -67,6 +68,12 @@ RSpec.describe Hanami::Config::Actions, "#content_security_policy" do
 
       expect(content_security_policy[:a_custom_key]).to eq("foo")
       expect(content_security_policy.to_s).to match("a-custom-key foo")
+    end
+
+    it "uses 'nonce' in value" do
+      content_security_policy[:javascript_src] = "'self' 'nonce'"
+
+      expect(content_security_policy.nonce?).to be(true)
     end
   end
 


### PR DESCRIPTION
If the `Hanami::Middleware::ContentSecurityPolicyNonce` middleware is in use:

* A random unique 8 character nonce is generated on every request and written to the Rack env `hanami.content_security_policy_nonce`key.
* All occurrences of the placeholder `'nonce'` in the generated CSP header are replaced with its current specific incarnation like `'nonce-A12OggyZ'`.
* The new `content_security_policy_nonce` view helper returns the current nonce.
* The `javascript_tag` and `stylesheet_tag` view helpers are decorated with an nonce attribute like `nonce=A12OggyZ`.

A few things to check when this PR is reviewed:

* Is the use of `Hanami.app.config.actions.content_security_policy` in the Rack middleware permissible? (Plan B: Don't assume a CSP header to be present, but in this case, the Rack env nonce key is always generated whether it is needed or not.)
* The helper is named `content_security_policy_nonce` which appears a bit verbose since most apps don't use other nonces. However, you never know and as the corresponding helper in Rails has this verbose name as well, it might ease the transition to Hanami just a tiny little bit.
* The tests are not where other helpers like `javascript_tag` are tested because it takes a real request for this to work.