### PR TITLE
Fix CI: Upgrade actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - "3.1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -38,7 +38,7 @@ jobs:
           bundler-cache: true
       - name: Cache node_modules
         id: cache-modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
@@ -46,7 +46,7 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: npm install
       - name: Setup Node ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
CI is now failing due to Github no longer supporting old version of their actions. Example: https://github.com/hanami/hanami/actions/runs/13646312642 and the link it sends us to: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

I looked up the latest versions and changed it to them, without investigating if anything needs to change. CI still passes though so I think we're in the clear.

I'm happy to do this for the other repos too. With your approval @timriley, I'll open PR's, make sure they're green, then merge without seeking code review for each one. That work for you?