### PR TITLE
Update error message assertion for latest Rack

### DIFF
--- a/spec/integration/assets/serve_static_assets_spec.rb
+++ b/spec/integration/assets/serve_static_assets_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Serve Static Assets", :app_integration do
       get "/assets/../../config/app.rb"
 
       expect(last_response.status).to eq(404)
-      expect(last_response.body).to match(/Not Found/i)
+      expect(last_response.body).to match("Hanami::Router::NotFoundError")
     end
   end
 


### PR DESCRIPTION
With the security fix [released in Rack 2.2.13](https://github.com/rack/rack/compare/v2.2.12...v2.2.13), the `Rack::Static` middleware exits immediately when given bad paths (e.g. paths trying to escape the root directory via "..", which this test exercises). This means the Hanami app ends up handling the 404 error rather than `Rack::Files`, which is what was happening for previous versions of Rack. This changes the content of the error screen seen by this test.