### PR TITLE
Ensure DB connections are closed in app_integration tests

### DIFF
--- a/spec/integration/db/db_spec.rb
+++ b/spec/integration/db/db_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "DB", :app_integration do
     ENV.replace(@env)
   end
 
-  it "sets up ROM and reigsters relations" do
+  it "sets up ROM and registers relations" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/app.rb", <<~RUBY
         require "hanami"

--- a/spec/support/app_integration.rb
+++ b/spec/support/app_integration.rb
@@ -118,7 +118,8 @@ RSpec.configure do |config|
     Hanami.instance_variable_set(:@_bundled, {})
     Hanami.remove_instance_variable(:@_app) if Hanami.instance_variable_defined?(:@_app)
 
-    # Clear cached DB gateways across slices
+    # Disconnect and clear cached DB gateways across slices
+    Hanami::Providers::DB.cache.values.map(&:disconnect)
     Hanami::Providers::DB.cache.clear
 
     $LOAD_PATH.replace(@load_paths)


### PR DESCRIPTION
Addresses https://github.com/hanami/hanami/issues/1511

More context can be found here: https://github.com/sparklemotion/sqlite3-ruby/pull/558, essentially open SQLite DB connections that exist prior to forking will trigger a warning.

This change ensures we disconnect all connections at the end of each `app_integration` test case so that we pre-emptively do so instead of letting the `sqlite3` gem do it for us and show a warning.