### PR TITLE
Update Contact section to point Chat URL to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can give back to Open Source, by supporting Hanami development via [GitHub S
 * [Guides](https://guides.hanamirb.org)
 * [Issues](https://github.com/hanami/hanami/issues)
 * [Forum](https://discourse.hanamirb.org)
-* [Chat](http://chat.hanamirb.org)
+* [Chat](https://discord.gg/KFCxDmk3JQ)
 
 ## Community
 


### PR DESCRIPTION
Small change, noticed that it's now pointing to Discord on Contributing.md so wanted this change to be consistent