### PR TITLE
Don't capture on absolute URL detection

### DIFF
--- a/lib/hanami/helpers/assets_helper.rb
+++ b/lib/hanami/helpers/assets_helper.rb
@@ -703,7 +703,7 @@ module Hanami
       # @since 2.1.0
       # @api private
       def _absolute_url?(source)
-        ABSOLUTE_URL_MATCHER.match(source)
+        ABSOLUTE_URL_MATCHER.match?(source)
       end
 
       # @since 1.2.0


### PR DESCRIPTION
The URI parser regexp contain capture groups and are quite large to begin with. We can save a cycle or two by ignoring the capture groups here.