### PR TITLE
Test with JRuby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
           - "3.2.0"
           - "3.2"
           - "3.1"
+          - "jruby"
+    env:
+        JRUBY_OPTS: "-X+O" # enable objectspace for Zeitwerk clearing
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,9 @@ gem "dry-types"
 gem "dry-operation", github: "dry-rb/dry-operation", branch: "main"
 
 # For testing the DB layer
-gem "sqlite3"
+
+gem "sqlite3", platforms: "mri"
+gem "jdbc-sqlite3", platforms: "jruby"
 
 group :test do
   gem "capybara"

--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -268,11 +268,21 @@ module Hanami
 
       # @api private
       # @since 2.2.0
-      DATABASE_GEMS = {
-        "mysql2" => "mysql2",
-        "postgres" => "pg",
-        "sqlite" => "sqlite3"
-      }.freeze
+      if RUBY_ENGINE == "ruby"
+        DATABASE_GEMS = {
+          "mysql2" => "mysql2",
+          "postgres" => "pg",
+          "sqlite" => "sqlite3"
+        }.freeze
+      elsif RUBY_ENGINE == "jruby"
+        DATABASE_GEMS = {
+          "mysql2" => "jdbc-mysql",
+          "postgres" => "jdbc-postgresql",
+          "sqlite" => "jdbc-sqlite3"
+        }.freeze
+      else
+        raise "unsupported RUBY_ENGINE: #{RUBY_ENGINE}"
+      end
       private_constant :DATABASE_GEMS
 
       # Raises an error if the relevant database gem for the configured database_url is not


### PR DESCRIPTION
This is an attempt to get Hanami tests running on JRuby.

A few tweaks are needed to get these green:

* JRuby does not enable full `ObjectSpace` support by default, due to the overhead it adds in order to track every object. `ObjectSpace.each_object` appears to be used during tests to clear Zeitwerk loaders. An alternative method would be preferable. Perhaps @fxn may know a better way. With this flag set, the test suite has 58 failures.
* JRuby can support SQLite through the `jdbc-sqlite` JDBC driver gem, which is wrapped by `activerecord-jdbcsqlite3-adapter` or `sequel`. Calling out to the `sqlite3` C ext gem directly during tests is a cause of roughly 34 out of the 58 remaining failures.
* Either the tests or some code called by them appears to call `fork` directly. JRuby cannot support `fork` because the JVM cannot support `fork`, and JRuby users typically spawn threads or isolated JRuby instances in the same process to achieve parallelism or isolation. The use of `fork` causes 22 failures out of the 24 remaining.
* The remaining two failures appears to be matching expected errors and are shown below.

```
  1) Logging / Exception logging unhandled exceptions logs a 500 error and full exception details when an exception is raised
     Failure/Error: expect(logs).to include("app/actions/test.rb:7:in 'TestApp::Actions::Test#handle'")
     
       expected "[test_app] [ERROR] [2025-06-14 15:55:14 +0300] GET 500 0µs 127.0.0.1 / -\n  unhandled (TestApp::Acti...\n  /Users/headius/work/jruby/lib/ruby/gems/shared/gems/rspec-core-3.13.4/exe/rspec:4:in '<main>'\n" to include "app/actions/test.rb:7:in 'TestApp::Actions::Test#handle'"
       Diff:
       @@ -1 +1,50 @@
       -app/actions/test.rb:7:in 'TestApp::Actions::Test#handle'
       +[test_app] [ERROR] [2025-06-14 15:55:14 +0300] GET 500 0µs 127.0.0.1 / -
       +  unhandled (TestApp::Actions::Test::UnhandledError)
       +  /private/var/folders/h_/tmq357111c18sxbwlyq34mh80000gn/T/d20250614-8002-h9xg8f/app/actions/test.rb:7:in 'handle'
       +  /Users/headius/work/jruby/lib/ruby/gems/shared/bundler/gems/controller-fe3faef7e2e9/lib/hanami/action.rb:329:in 'block in call'
       +  org/jruby/RubyKernel.java:1397:in 'catch'
       +  /Users/headius/work/jruby/lib/ruby/gems/shared/bundler/gems/controller-fe3faef7e2e9/lib/hanami/action.rb:310:in 'call'

 12) Settings / Using types errors raised from setting constructors are collected and re-raised in aggregate, and will prevent the app from booting
      Failure/Error:
        expect {
          require "hanami/prepare"
        }.to raise_error(
          Hanami::Settings::InvalidSettingsError,
          /#{numeric_error}.+#{flag_error}|#{flag_error}.+#{numeric_error}/m
        )
      
        expected Hanami::Settings::InvalidSettingsError with message matching /numeric: invalid value for Integer.+flag: give you up cannot be coerced|flag: give you up cannot be coerced.+numeric: invalid value for Integer/m, got #<Hanami::Settings::InvalidSettingsError:"Could not initialize settings. The following settings were ...umeric: caller binding only supported in interpreter\nflag: give you up cannot be coerced to false"> with backtrace
          # ./lib/hanami/settings.rb:174:in 'initialize'
          # ./lib/hanami/settings.rb:114:in 'load_for_slice'
          # ./lib/hanami/slice.rb:718:in 'settings'
          # ./lib/hanami/slice.rb:856:in 'prepare_settings'
          # ./lib/hanami/slice.rb:846:in 'prepare_all'
          # ./lib/hanami/app.rb:108:in 'prepare_all'
          # ./lib/hanami/slice.rb:807:in 'prepare_slice'
          # ./lib/hanami/slice.rb:274:in 'prepare'
          # ./lib/hanami.rb:212:in 'prepare'
          # ./lib/hanami/prepare.rb:5:in '<main>'
          # ./spec/integration/settings/using_types_spec.rb:73:in 'block in <main>'
          # ./spec/integration/settings/using_types_spec.rb:72:in 'block in <main>'
          # ./spec/integration/settings/using_types_spec.rb:47:in 'block in <main>'
```

Overall Hanami appears to work on JRuby just fine, but these failures indicate some dependency on CRuby extensions and features that are not supported on JRuby. I'm not sure whether these are core requirements of Hanami or if they can be replaced with JRuby-equivalent features, but the results so far are promising!