### PR TITLE
Add `console` to configuration

### DIFF
--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -6,6 +6,7 @@ require "dry/configurable"
 require "dry/inflector"
 
 require_relative "constants"
+require_relative "config/console"
 
 module Hanami
   # Hanami app config
@@ -183,6 +184,18 @@ module Hanami
       "Hanami::Router::NotAllowedError" => :not_found,
       "Hanami::Router::NotFoundError" => :not_found,
     )
+
+    # @!attribute [rw] console
+    #   Returns the app's console config
+    # 
+    #   @example
+    #     config.console.engine # => :irb
+    # 
+    #   @return [Hanami::Config::Console]
+    # 
+    #   @api public
+    #   @since 2.3.0
+    setting :console, default: Hanami::Config::Console.new
 
     # Returns the app or slice's {Hanami::SliceName slice_name}.
     #

--- a/lib/hanami/config/console.rb
+++ b/lib/hanami/config/console.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "dry/configurable"
+
+module Hanami
+  class Config
+    # Hanami console config
+    #
+    # @since 2.3.0
+    # @api public
+    class Console
+      include Dry::Configurable
+
+      # @!attribute [rw] engine
+      #  Sets or returns the interactive console engine to be used by `hanami console`.
+      #  Supported values are `:irb` (default) and `:pry`.
+      #
+      #  @example
+      #    config.console.engine = :pry
+      #
+      #  @return [Symbol]
+      #
+      #  @api public
+      #  @since 2.3.0
+      setting :engine, default: :irb
+
+      # Returns the complete list of extensions to be used in the console
+      #
+      # @example
+      #   config.console.include MyExtension, OtherExtension
+      #   config.console.include ThirdExtension
+      #
+      #   config.console.extensions
+      #   # => [MyExtension, OtherExtension, ThirdExtension]
+      #
+      # @return [Array<Module>]
+      #
+      # @api public
+      # @since 2.3.0
+      def extensions = @extensions.dup.freeze
+
+      # Define a module extension to be included in the console
+      #
+      # @param mod [Module] one or more modules to be included in the console
+      # @return [void]
+      #
+      # @api public
+      # @since 2.3.0
+      def include(*mod)
+        @extensions.concat(mod).uniq!
+      end
+
+      # @api private
+      def initialize
+        @extensions = []
+      end
+
+      private
+
+      # @api private
+      def initialize_copy(source)
+        super
+        @extensions = [*source.extensions]
+      end
+
+      def method_missing(name, *args, &block)
+        if config.respond_to?(name)
+          config.public_send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, _include_all = false)
+        config.respond_to?(name) || super
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/config/console_spec.rb
+++ b/spec/unit/hanami/config/console_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "hanami/config"
+
+RSpec.describe Hanami::Config, "#console" do
+  let(:config) { described_class.new(app_name: app_name, env: :development) }
+  let(:app_name) { "MyApp::App" }
+
+  subject(:console) { config.console }
+
+  it "is a full console configuration" do
+    is_expected.to be_an_instance_of(Hanami::Config::Console)
+
+    is_expected.to respond_to(:engine)
+    is_expected.to respond_to(:include)
+    is_expected.to respond_to(:extensions)
+  end
+
+  it "can be finalized" do
+    is_expected.to respond_to(:finalize!)
+  end
+end


### PR DESCRIPTION
Relates to #1538

This creates a configuration object for users to define custom modules to include in the console context. Also supports a permanent change in engine setting.