### PR TITLE
Replace fast_generate with generate (json)

### DIFF
--- a/lib/hanami/web/rack_logger.rb
+++ b/lib/hanami/web/rack_logger.rb
@@ -108,7 +108,7 @@ module Hanami
         # @api private
         def info(message = nil, **payload)
           payload[:message] = message if message
-          logger.info(JSON.fast_generate(payload))
+          logger.info(JSON.generate(payload))
         end
 
         # @see info
@@ -117,7 +117,7 @@ module Hanami
         # @api private
         def error(message = nil, **payload)
           payload[:message] = message if message
-          logger.info(JSON.fast_generate(payload))
+          logger.info(JSON.generate(payload))
         end
       end
 


### PR DESCRIPTION
Resolves https://github.com/hanami/hanami/issues/1545
JSON release notes mention that this method was not actually faster, thus deprecation