### PR TITLE
Use new prefixed repo names in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,14 +13,14 @@ if ENV["RACK_VERSION_CONSTRAINT"]
   gem "rack", ENV["RACK_VERSION_CONSTRAINT"]
 end
 
-gem "hanami-utils", github: "hanami/utils", branch: "main"
-gem "hanami-db", github: "hanami/db", branch: "main"
-gem "hanami-router", github: "hanami/router", branch: "main"
-gem "hanami-controller", github: "hanami/controller", branch: "main"
-gem "hanami-cli", github: "hanami/cli", branch: "main"
-gem "hanami-view", github: "hanami/view", branch: "main"
-gem "hanami-assets", github: "hanami/assets", branch: "main"
-gem "hanami-webconsole", github: "hanami/webconsole", branch: "main"
+gem "hanami-utils", github: "hanami/hanami-utils", branch: "main"
+gem "hanami-db", github: "hanami/hanami-db", branch: "main"
+gem "hanami-router", github: "hanami/hanami-router", branch: "main"
+gem "hanami-controller", github: "hanami/hanami-controller", branch: "main"
+gem "hanami-cli", github: "hanami/hanami-cli", branch: "main"
+gem "hanami-view", github: "hanami/hanami-view", branch: "main"
+gem "hanami-assets", github: "hanami/hanami-assets", branch: "main"
+gem "hanami-webconsole", github: "hanami/hanami-webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 


### PR DESCRIPTION
The old way still worked, because Github is handling the redirect, but it's better to be explicitly correct here.