### PR TITLE
Fix misnaming of “create” resource routes

### DIFF
--- a/lib/hanami/slice/router.rb
+++ b/lib/hanami/slice/router.rb
@@ -251,10 +251,11 @@ module Hanami
 
         def route_name(action, prefix)
           name = route_name_base
-          name = @inflector.pluralize(name) if action == :index
+          name = @inflector.pluralize(name) if plural? && PLURALIZED_NAME_ACTIONS.include?(action)
 
           [prefix, name]
         end
+        PLURALIZED_NAME_ACTIONS = %i[index create].freeze
 
         def route_name_base
           @route_name_base ||=

--- a/spec/integration/router/resource_routes_spec.rb
+++ b/spec/integration/router/resource_routes_spec.rb
@@ -215,7 +215,6 @@ RSpec.describe "Router / Resource routes" do
       expect(router.path("cafe_reviews", cafe_id: 1)).to eq "/cafes/1/reviews"
       expect(router.path("cafe_review_comments", cafe_id: 1, review_id: 1)).to eq "/cafes/1/reviews/1/comments"
       expect(router.path("new_cafe_review_comment", cafe_id: 1, review_id: 1)).to eq "/cafes/1/reviews/1/comments/new"
-      expect(router.path("cafe_review_comment", cafe_id: 1, review_id: 1)).to eq "/cafes/1/reviews/1/comments"
 
       expect(routed("GET", "/profile")).to eq %(actions.profile.show)
       expect(routed("GET", "/profile/avatar")).to eq %(actions.profile.avatar.show)


### PR DESCRIPTION
For collection (plural) resources, create routes should be named with a plural name, not singular.