### PR TITLE
Remove upper limit on bundler version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Security
 
+[unreleased]: https://github.com/hanami/hanami/compare/v2.3.2...HEAD
+
+## [v2.3.2] - 2025-12-04
+
+### Fixed
+
+- Support the newly released Bundler v4 by removing upper version bound our dependency on it. Require at least Bundler 2.0 as well. (@timriley in #1559)
+
+[v2.3.2]: https://github.com/hanami/hanami/compare/v2.3.1...v2.3.2
+
 ## [v2.3.1] - 2025-11-14
 
 ### Fixed
@@ -1591,7 +1601,6 @@ end
 - [Luca Guidi] Official support for MRI 2.0
 
 
-[unreleased]: https://github.com/hanami/hanami/compare/v2.3.1...HEAD
 [v2.3.1]: https://github.com/hanami/hanami/compare/v2.3.0...v2.3.1
 [v2.3.0]: https://github.com/hanami/hanami/compare/v2.3.0.beta2...v2.3.0
 [v2.3.0.beta2]: https://github.com/hanami/hanami/compare/v2.3.0.beta1...v2.3.0.beta2

--- a/hanami.gemspec
+++ b/hanami.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.add_dependency "bundler",          ">= 1.16", "< 3"
+  spec.add_dependency "bundler",          ">= 2.0"
   spec.add_dependency "dry-configurable", "~> 1.0", ">= 1.2.0", "< 2"
   spec.add_dependency "dry-core",         "~> 1.0", "< 2"
   spec.add_dependency "dry-inflector",    "~> 1.0", ">= 1.1.0", "< 2"


### PR DESCRIPTION
This will allow the newly-released Bundler v4 to be used with Hanami.

While here, set a minimum version of 2.0. The last 1.x verison of bundler was published 7 years ago.

Fixes #1558