### PR TITLE
Logger: Support HANAMI_LOG_LEVEL env var to set default log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 - New setting `:default_template_engine` that sets which template engine should be used by default when doing `hanami generate`. (@katafrakt in #1564)
 - Added `Hanami::Settings::CompositeStore`, which can be used to chain setting lookups from multiple stores. (@aaronmallen in #1572)
-- Support `HANAMI_LOG_LEVEL` env var to set the log level for the current environment (e.g. `HANAMI_LOG_LEVEL=warn bundle exec hanami server`), which can be further overridden via `config.logger.level` in `config/app.rb`.
+- Support `HANAMI_LOG_LEVEL` env var to set the log level (e.g. `HANAMI_LOG_LEVEL=warn bundle exec hanami server`). Takes precedence over `config.logger.level` set in `config/app.rb`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 - New setting `:default_template_engine` that sets which template engine should be used by default when doing `hanami generate`. (@katafrakt in #1564)
 - Added `Hanami::Settings::CompositeStore`, which can be used to chain setting lookups from multiple stores. (@aaronmallen in #1572)
-- Support `HANAMI_LOG_LEVEL` env var to override the default log level for the current environment (e.g. `HANAMI_LOG_LEVEL=warn bundle exec hanami server`). Explicit `config.logger.level` in `config/app.rb` still takes precedence.
+- Support `HANAMI_LOG_LEVEL` env var to set the log level for the current environment (e.g. `HANAMI_LOG_LEVEL=warn bundle exec hanami server`), which can be further overridden via `config.logger.level` in `config/app.rb`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 - New setting `:default_template_engine` that sets which template engine should be used by default when doing `hanami generate`. (@katafrakt in #1564)
 - Added `Hanami::Settings::CompositeStore`, which can be used to chain setting lookups from multiple stores. (@aaronmallen in #1572)
+- Support `HANAMI_LOG_LEVEL` env var to override the default log level for the current environment (e.g. `HANAMI_LOG_LEVEL=warn bundle exec hanami server`). Explicit `config.logger.level` in `config/app.rb` still takes precedence.
 
 ### Changed
 

--- a/lib/hanami/config/logger.rb
+++ b/lib/hanami/config/logger.rb
@@ -121,17 +121,19 @@ module Hanami
         @app_name = app_name
         @env = env
 
+        default_level = ENV["HANAMI_LOG_LEVEL"]&.to_sym
+
         case env
         when :development
-          config.level = :debug
+          config.level = default_level || :debug
           config.options = {colorize: true}
           config.logger_constructor = method(:development_logger)
         when :test
-          config.level = :debug
+          config.level = default_level || :debug
           config.stream = File.join("log", "#{env}.log")
           config.logger_constructor = method(:development_logger)
         else
-          config.level = :info
+          config.level = default_level || :info
           config.formatter = :json
           config.logger_constructor = method(:production_logger)
         end

--- a/lib/hanami/config/logger.rb
+++ b/lib/hanami/config/logger.rb
@@ -122,19 +122,17 @@ module Hanami
         @app_name = app_name
         @env = env
 
-        env_log_level = ENV["HANAMI_LOG_LEVEL"]&.to_sym
-
         case env
         when :development
-          config.level = env_log_level || :debug
+          config.level = :debug
           config.options = {colorize: true}
           config.logger_constructor = method(:development_logger)
         when :test
-          config.level = env_log_level || :debug
+          config.level = :debug
           config.stream = File.join("log", "#{env}.log")
           config.logger_constructor = method(:development_logger)
         else
-          config.level = env_log_level || :info
+          config.level = :info
           config.formatter = :json
           config.logger_constructor = method(:production_logger)
         end
@@ -183,7 +181,7 @@ module Hanami
       def logger_constructor_options
         {
           stream: stream,
-          level: level,
+          level: ENV["HANAMI_LOG_LEVEL"]&.to_sym || level,
           formatter: formatter,
           filters: filters,
           template: template,

--- a/lib/hanami/config/logger.rb
+++ b/lib/hanami/config/logger.rb
@@ -28,6 +28,7 @@ module Hanami
       #   Sets or returns the logger's level.
       #
       #   Defaults to `:info` for the production environment and `:debug` for all others.
+      #   Can be set via the `HANAMI_LOG_LEVEL` environment variable.
       #
       #   @return [Symbol]
       #
@@ -121,19 +122,19 @@ module Hanami
         @app_name = app_name
         @env = env
 
-        default_level = ENV["HANAMI_LOG_LEVEL"]&.to_sym
+        env_log_level = ENV["HANAMI_LOG_LEVEL"]&.to_sym
 
         case env
         when :development
-          config.level = default_level || :debug
+          config.level = env_log_level || :debug
           config.options = {colorize: true}
           config.logger_constructor = method(:development_logger)
         when :test
-          config.level = default_level || :debug
+          config.level = env_log_level || :debug
           config.stream = File.join("log", "#{env}.log")
           config.logger_constructor = method(:development_logger)
         else
-          config.level = default_level || :info
+          config.level = env_log_level || :info
           config.formatter = :json
           config.logger_constructor = method(:production_logger)
         end

--- a/spec/unit/hanami/config/logger_spec.rb
+++ b/spec/unit/hanami/config/logger_spec.rb
@@ -39,6 +39,32 @@ RSpec.describe Hanami::Config::Logger do
     end
   end
 
+  describe "HANAMI_LOG_LEVEL env var" do
+    around do |example|
+      ENV["HANAMI_LOG_LEVEL"] = "warn"
+      example.run
+    ensure
+      ENV.delete("HANAMI_LOG_LEVEL")
+    end
+
+    it "overrides the per-environment default" do
+      expect(subject.level).to eq(:warn)
+    end
+
+    it "can still be overridden by explicit config" do
+      subject.level = :fatal
+      expect(subject.level).to eq(:fatal)
+    end
+
+    context "when :production environment" do
+      let(:env) { :production }
+
+      it "overrides the production default" do
+        expect(subject.level).to eq(:warn)
+      end
+    end
+  end
+
   describe "#stream" do
     it "defaults to $stdout" do
       expect(subject.stream).to eq($stdout)

--- a/spec/unit/hanami/config/logger_spec.rb
+++ b/spec/unit/hanami/config/logger_spec.rb
@@ -47,20 +47,20 @@ RSpec.describe Hanami::Config::Logger do
       ENV.delete("HANAMI_LOG_LEVEL")
     end
 
-    it "overrides the per-environment default" do
-      expect(subject.level).to eq(:warn)
+    it "takes precedence over the per-environment default" do
+      expect(subject.instance.level).to eq(Logger::WARN)
     end
 
-    it "can still be overridden by explicit config" do
+    it "takes precedence over explicit config.logger.level" do
       subject.level = :fatal
-      expect(subject.level).to eq(:fatal)
+      expect(subject.instance.level).to eq(Logger::WARN)
     end
 
     context "when :production environment" do
       let(:env) { :production }
 
-      it "overrides the production default" do
-        expect(subject.level).to eq(:warn)
+      it "takes precedence over the production default" do
+        expect(subject.instance.level).to eq(Logger::WARN)
       end
     end
   end


### PR DESCRIPTION
Surprised we didn't have this earlier!