### PR TITLE
Use hanami-asset-js#44 to prepare assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: npm install
-      - name: Build assets
-        run: npm run build
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: npm install
+      - name: Build assets
+        run: npm run build
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build": "npm --prefix node_modules/hanami-assets run build"
+  },
   "devDependencies": {
     "typescript": "^5.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
-  "scripts": {
-    "build": "npm --prefix node_modules/hanami-assets run build"
-  },
   "devDependencies": {
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "hanami-assets": "github:hanami/assets-js#main"
+    "hanami-assets": "github:hanami/assets-js#fix-prepare-for-git-install"
   }
 }


### PR DESCRIPTION
Fix needed due to https://github.com/hanami/hanami-assets-js/pull/43

Testing CI here ~then I will put in repo-sync once we confirm it's correct~

Changed approach here to test the fix on a branch for https://github.com/hanami/hanami-assets-js/pull/44. This appears to validate that fix is correct.

This can be closed (and not merged!) once that is good.