### PR TITLE
Fix Deps injector creation to occur after prepare_container block

### DIFF
--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -817,9 +817,12 @@ module Hanami
         ensure_slice_consts
         ensure_root
 
+        slice_namespace = namespace
+
         prepare_all
 
         instance_exec(container, &@prepare_container_block) if @prepare_container_block
+        slice_namespace.const_set :Deps, container.injector
         container.configured!
 
         prepare_autoloader
@@ -857,7 +860,7 @@ module Hanami
 
       def prepare_all
         prepare_settings
-        prepare_container_consts
+        prepare_container_const
         prepare_container_plugins
         prepare_container_base_config
         prepare_container_component_dirs
@@ -869,9 +872,8 @@ module Hanami
         container.register(:settings, settings) if settings
       end
 
-      def prepare_container_consts
+      def prepare_container_const
         namespace.const_set :Container, container
-        namespace.const_set :Deps, container.injector
       end
 
       def prepare_container_plugins

--- a/spec/integration/container/prepare_container_spec.rb
+++ b/spec/integration/container/prepare_container_spec.rb
@@ -1,6 +1,77 @@
 # frozen_string_literal: true
 
 RSpec.describe "Container / prepare_container", :app_integration do
+  describe "Deps reflects plugins installed via prepare_container" do
+    module MarkInjector
+      def injector(**options)
+        super.tap { |inj| inj.instance_variable_set(:@marked_by_plugin, true) }
+      end
+    end
+
+    before :context do
+      Dry::System::Plugins.register(:mark_injector, MarkInjector)
+    end
+
+    after :context do
+      Dry::System::Plugins.registry.delete(:mark_injector)
+    end
+
+    describe "in app" do
+      before :context do
+        with_directory(@dir = make_tmp_directory) do
+          write "config/app.rb", <<~'RUBY'
+            module TestApp
+              class App < Hanami::App
+                prepare_container do |c|
+                  c.use(:mark_injector)
+                end
+              end
+            end
+          RUBY
+
+          write "app/.keep", ""
+        end
+      end
+
+      it "uses the injector configured by installed plugins" do
+        with_directory(@dir) { require "hanami/prepare" }
+
+        expect(TestApp::Deps.instance_variable_get(:@marked_by_plugin)).to be(true)
+      end
+    end
+
+    describe "in slice" do
+      before :context do
+        with_directory(@dir = make_tmp_directory) do
+          write "config/app.rb", <<~'RUBY'
+            module TestApp
+              class App < Hanami::App
+              end
+            end
+          RUBY
+
+          write "slices/main/config/slice.rb", <<~'RUBY'
+            module Main
+              class Slice < Hanami::Slice
+                prepare_container do |c|
+                  c.use(:mark_injector)
+                end
+              end
+            end
+          RUBY
+
+          write "slices/main/.keep", ""
+        end
+      end
+
+      it "uses the injector configured by installed plugins" do
+        with_directory(@dir) { require "hanami/prepare" }
+
+        expect(Main::Deps.instance_variable_get(:@marked_by_plugin)).to be(true)
+      end
+    end
+  end
+
   # (Most of) the examples below make their expectations on a `container_to_prepare`,
   # which is the container yielded to the `Slice.prepare_container` block _at the moment
   # it is called_.


### PR DESCRIPTION
Currently, `Deps` is created inside `prepare_container_consts`, which runs before the user's `prepare_container` block. Any dry-system plugin installed in that block that overrides `injector` (such as `dependency_graph`) had no effect on `Deps`, since the injector was already snapshotted. `Deps` is derived from the container's configuration, so it should be created after all configuration, including the user's block, is complete.

I'm working on a dry-system plugin to visualize dependencies and ran into this issue. I don't think many people were using `Deps` in their prepare_container, so it should be fine; they can still access it via `container.injector` anyway.