### PR TITLE
Prevent Hanami::View integration from breaking DI

### DIFF
--- a/lib/hanami/extensions/action.rb
+++ b/lib/hanami/extensions/action.rb
@@ -67,15 +67,33 @@ module Hanami
         #   These dependencies are injected automatically so that a call to `.new` (with no
         #   arguments) returns a fully integrated action.
         #
+        #   WARNING: This is prepended into a class intended for dependency injection, so the
+        #   implementation of this method using `**kwargs` instead of named keyword arguments
+        #   is intentional. Adding named kwargs will break Dry::AutoInject.
+        #
+        #   @param view [Hanami::View]
+        #   @param view_context_class [Hanami::View::Context]
+        #   @param rack_monitor [Dry::Monitor::Rack::Middleware]
         #   @param routes [Hanami::Slice::RoutesHelper]
         #
         #   @api public
         #   @since 2.0.0
-        def initialize(view: nil, view_context_class: nil, rack_monitor: nil, routes: nil, **kwargs)
-          @view = view
-          @view_context_class = view_context_class
-          @routes = routes
-          @rack_monitor = rack_monitor
+        def initialize(**kwargs)
+          if kwargs.key?(:view)
+            @view = kwargs.delete(:view)
+          end
+
+          if kwargs.key?(:view_context_class)
+            @view_context_class = kwargs.delete(:view_context_class)
+          end
+
+          if kwargs.key?(:rack_monitor)
+            @rack_monitor = kwargs.delete(:rack_monitor)
+          end
+
+          if kwargs.key?(:routes)
+            @routes = kwargs.delete(:routes)
+          end
 
           super(**kwargs)
         end

--- a/spec/integration/action/dependency_injection_spec.rb
+++ b/spec/integration/action/dependency_injection_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe "App action / Dependency injection", :app_integration do
+  specify "Custom view injection works as intended" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/logger", <<~RUBY
+        require "logger"
+
+        module TestApp
+          class Logger < ::Logger
+            def initialize
+              super(STDOUT)
+            end
+          end
+        end
+      RUBY
+
+      write "app/action.rb", <<~RUBY
+        # auto_register: false
+
+        module TestApp
+          class Action < Hanami::Action
+            include Deps["logger"]
+          end
+        end
+      RUBY
+
+      write "app/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module TestApp
+          class View < Hanami::View
+          end
+        end
+      RUBY
+
+      write "app/actions/users/show.rb", <<~RUBY
+        module TestApp
+          module Actions
+            module Users
+              class Show < TestApp::Action
+                include Deps[view: "views.users.show"]
+
+                def handle(req, res)
+                  res.render view
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/views/users/show.rb", <<~RUBY
+        module TestApp
+          module Views
+            module Users
+              class Show < TestApp::View
+              end
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      action = TestApp::App["actions.users.show"]
+
+      expect(action.view).to be_a TestApp::Views::Users::Show
+    end
+  end
+end


### PR DESCRIPTION
This is a weird case that requires multiple things to line up. Because Hanami::Extensions::Action::InstanceMethods is _prepended_ into Hanami::Action, this makes the implementation of `initialize` interfere with `define_initialize` from Dry::AutoInject.

If any injected dependency happens to share the name of an argument in the prepended method, _and_ a dependency is injected in a parent action that does **not** define a dependency with that name, then it will cause the dependency to get nilled out.

This is particularly problematic for `:view` here because this is public interface. Our guides explicitly show injecting a custom view as a dependency named `view`, which will trigger this bug.