### PR TITLE
Allow setting log level for DB queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 - New setting `:default_template_engine` that sets which template engine should be used by default when doing `hanami generate`. (@katafrakt in #1564)
 - Added `Hanami::Settings::CompositeStore`, which can be used to chain setting lookups from multiple stores. (@aaronmallen in #1572)
 - Support `HANAMI_LOG_LEVEL` env var to set the log level (e.g. `HANAMI_LOG_LEVEL=warn bundle exec hanami server`). Takes precedence over `config.logger.level` set in `config/app.rb`.
-- New setting `:sql_log_level` for `db`, allowing to override default `:info` level for SQL logs
+- New setting `:log_level` for `db`, allowing to override default `:info` level for SQL logs
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 - New setting `:default_template_engine` that sets which template engine should be used by default when doing `hanami generate`. (@katafrakt in #1564)
 - Added `Hanami::Settings::CompositeStore`, which can be used to chain setting lookups from multiple stores. (@aaronmallen in #1572)
 - Support `HANAMI_LOG_LEVEL` env var to set the log level (e.g. `HANAMI_LOG_LEVEL=warn bundle exec hanami server`). Takes precedence over `config.logger.level` set in `config/app.rb`.
+- New setting `:sql_log_level` for `db`, allowing to override default `:info` level for SQL logs
 
 ### Changed
 

--- a/lib/hanami/config/db.rb
+++ b/lib/hanami/config/db.rb
@@ -15,7 +15,7 @@ module Hanami
 
       setting :import_from_parent, default: false
 
-      setting :sql_log_level, default: :info
+      setting :log_level, default: :info
 
       private
 

--- a/lib/hanami/config/db.rb
+++ b/lib/hanami/config/db.rb
@@ -15,6 +15,8 @@ module Hanami
 
       setting :import_from_parent, default: false
 
+      setting :sql_log_level, default: :info
+
       private
 
       def method_missing(name, *args, &block)

--- a/lib/hanami/logger/sql_logger.rb
+++ b/lib/hanami/logger/sql_logger.rb
@@ -14,12 +14,13 @@ module Hanami
     #
     # @api private
     class SQLLogger
-      attr_reader :logger
+      attr_reader :logger, :level
 
       # @param logger [#tagged, #info] a Hanami-compatible logger (typically a
       #   Dry::Logger::Dispatcher or a {Hanami::UniversalLogger}-wrapped logger)
-      def initialize(logger)
+      def initialize(logger, level: :info)
         @logger = logger
+        @level = level
       end
 
       # Subscribes to `:sql` notification events.
@@ -37,7 +38,7 @@ module Hanami
       # @param query [String] the SQL query string
       def log_query(time:, name:, query:)
         logger.tagged(:sql) do
-          logger.info do
+          logger.public_send(@level) do
             {query:, db: name, elapsed: time.round(3), elapsed_unit: "ms"}
           end
         end

--- a/lib/hanami/providers/db_logging.rb
+++ b/lib/hanami/providers/db_logging.rb
@@ -10,7 +10,9 @@ module Hanami
 
       def start
         require "hanami/logger/sql_logger"
-        Hanami::Logger::SQLLogger.new(slice["logger"]).subscribe(slice["notifications"])
+        Hanami::Logger::SQLLogger
+          .new(slice["logger"], level: slice.config.db.sql_log_level)
+          .subscribe(slice["notifications"])
       end
     end
   end

--- a/lib/hanami/providers/db_logging.rb
+++ b/lib/hanami/providers/db_logging.rb
@@ -11,7 +11,7 @@ module Hanami
       def start
         require "hanami/logger/sql_logger"
         Hanami::Logger::SQLLogger
-          .new(slice["logger"], level: slice.config.db.sql_log_level)
+          .new(slice["logger"], level: slice.config.db.log_level)
           .subscribe(slice["notifications"])
       end
     end

--- a/spec/integration/db/logging_spec.rb
+++ b/spec/integration/db/logging_spec.rb
@@ -78,6 +78,67 @@ RSpec.describe "DB / Logging", :app_integration do
     end
   end
 
+  it "allows configuring log level" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.db.sql_log_level = :debug
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/setup"
+
+      logger_stream = StringIO.new
+      Hanami.app.config.logger.stream = logger_stream
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      # Manually run a migration and add a test record
+      gateway = Hanami.app["db.gateway"]
+      migration = gateway.migration do
+        change do
+          create_table :posts do
+            primary_key :id
+            column :title, :text, null: false
+          end
+
+          create_table :authors do
+            primary_key :id
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES ('Together breakfast')")
+
+      relation = Hanami.app["relations.posts"]
+      expect(relation.select(:title).to_a).to eq [{title: "Together breakfast"}]
+
+      logger_stream.rewind
+      log_lines = logger_stream.read.split("\n")
+
+      expect(log_lines.length).to eq 1
+      expect(strip_ansi(log_lines.first)).to match(/\[test_app\] \[DEBUG\] \[.*\] SQL sqlite \d+(\.\d+)?ms SELECT `posts`.`title` FROM `posts` ORDER BY `posts`.`id`/)
+    end
+  end
+
   describe "slices sharing app db config" do
     it "logs SQL queries" do
       with_tmp_directory(Dir.mktmpdir) do

--- a/spec/integration/db/logging_spec.rb
+++ b/spec/integration/db/logging_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "DB / Logging", :app_integration do
 
         module TestApp
           class App < Hanami::App
-            config.db.sql_log_level = :debug
+            config.db.log_level = :debug
           end
         end
       RUBY


### PR DESCRIPTION
This came up on Discord once, when someone asked how to make SQL logs log on `:debug` level, so they can be excluded in production. This adds `:log_level` setting for `:db`, allowing to set that. I don't imagine anyone would set it to something else than `:debug`, but it's theoretically possible now.