### PR TITLE
Respect slice isolation in I18n #localize

### DIFF
--- a/lib/hanami/providers/i18n/backend.rb
+++ b/lib/hanami/providers/i18n/backend.rb
@@ -127,11 +127,15 @@ module Hanami
           translate(key, **options.merge(raise: true))
         end
 
-        # Localizes the given object (e.g., date, time, number).
+        # Localizes the given date or time.
         #
-        # @param object [Date, Time, DateTime, Numeric] the object to localize
+        # Resolves symbol formats through this instance's translations (e.g. `:short` becomes
+        # `date.formats.short` or `time.formats.short`). Also resolves locale-dependent strftime
+        # codes (e.g. `%a`, `%A`, `%b`, `%B`, `%p`, `%P`).
+        #
+        # @param object [Date, Time, DateTime] the object to localize
         # @param locale [Symbol, String, nil] the locale to use (defaults to current locale)
-        # @param format [Symbol, String, nil] the format to use for localization
+        # @param format [Symbol, String] the format to use for localization
         # @param options [Hash] additional localization options
         #
         # @return [String] the localized string representation
@@ -144,9 +148,27 @@ module Hanami
         #
         # @api public
         # @since x.x.x
-        def localize(object, locale: nil, format: nil, **options)
+        def localize(object, locale: nil, format: :default, **options)
           locale ||= self.locale
-          @backend.localize(locale, object, format, options)
+
+          return options[:default] if object.nil? && options.key?(:default)
+
+          unless object.respond_to?(:strftime)
+            raise ArgumentError, <<~MSG
+              Object must be a Date, DateTime or Time object. #{object.inspect} given.
+            MSG
+          end
+
+          if format.is_a?(Symbol)
+            type = object.respond_to?(:sec) ? "time" : "date"
+            format = translate(
+              :"#{type}.formats.#{format}",
+              **options, locale:, object:, raise: true
+            )
+          end
+
+          format = expand_localization_format(locale, object, format)
+          object.strftime(format)
         end
 
         # @api public
@@ -308,6 +330,39 @@ module Hanami
           key = missing_translation.key
           key.to_s
         end
+
+        # rubocop:disable Layout/LineLength, Style/NestedTernaryOperator, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        # Expands locale-dependent strftime codes (`%a`, `%A`, `%b`, `%B`, `%p`, `%P` and their
+        # uppercase `^` variants) by looking up day/month names and meridiem markers through this
+        # backend.
+        #
+        # This is a deliberate port of `I18n::Backend::Base#translate_localization_format`. We can't
+        # call this upstream method directly because it's private and also hardcodes `I18n.t!` (the
+        # global module) for every lookup, which defeats our per-slice isolated backends.
+        #
+        # This set of locale-dependent strftime codes is fixed by the C `strftime` spec and has not
+        # changed in the upstream gem since at least 2010, so this table is effectively frozen.
+        def expand_localization_format(locale, object, format)
+          format.to_s.gsub(/%(|\^)[aAbBpP]/) do |match|
+            case match
+            when "%a"   then t!(:"date.abbr_day_names",   locale:, format:)[object.wday]
+            when "%^a"  then t!(:"date.abbr_day_names",   locale:, format:)[object.wday].upcase
+            when "%A"   then t!(:"date.day_names",        locale:, format:)[object.wday]
+            when "%^A"  then t!(:"date.day_names",        locale:, format:)[object.wday].upcase
+            when "%b"   then t!(:"date.abbr_month_names", locale:, format:)[object.mon]
+            when "%^b"  then t!(:"date.abbr_month_names", locale:, format:)[object.mon].upcase
+            when "%B"   then t!(:"date.month_names",      locale:, format:)[object.mon]
+            when "%^B"  then t!(:"date.month_names",      locale:, format:)[object.mon].upcase
+            when "%p"   then t!(:"time.#{(object.respond_to?(:hour) ? object.hour : 0) < 12 ? :am : :pm}", locale:, format:).upcase
+            when "%P"   then t!(:"time.#{(object.respond_to?(:hour) ? object.hour : 0) < 12 ? :am : :pm}", locale:, format:).downcase
+            end
+          end
+        rescue ::I18n::MissingTranslationData => exception
+          exception.message
+        end
+
+        # rubocop:enable Layout/LineLength, Style/NestedTernaryOperator, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       end
     end
   end

--- a/spec/unit/hanami/providers/i18n/backend_spec.rb
+++ b/spec/unit/hanami/providers/i18n/backend_spec.rb
@@ -110,19 +110,74 @@ RSpec.describe Hanami::Providers::I18n::Backend do
   end
 
   describe "#localize and #l" do
-    it "delegates to backend localize method" do
-      time = Time.now
-      allow(i18n_backend).to receive(:localize).with(:en, time, nil, {}).and_return("localized time")
+    let(:date) { Date.new(2026, 5, 11) }
 
-      result = backend.localize(time)
-      expect(result).to eq("localized time")
+    before do
+      i18n_backend.store_translations(
+        :en, {
+          date: {
+            formats: {short: "%B %d", numeric: "%Y-%m-%d"},
+            month_names: [
+              nil, "January", "February", "March", "April", "May", "June",
+              "July", "August", "September", "October", "November", "December"
+            ],
+            abbr_month_names: [
+              nil, "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+              "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+            ]
+          }
+        }
+      )
+
+      i18n_backend.store_translations(
+        :fr, {
+          date: {
+            formats: {short: "%d %B"},
+            month_names: [
+              nil, "janvier", "février", "mars", "avril", "mai", "juin",
+              "juillet", "août", "septembre", "octobre", "novembre", "décembre"
+            ]
+          }
+        }
+      )
     end
 
-    it "aliases #l to #localize" do
-      time = Time.now
-      allow(i18n_backend).to receive(:localize).and_return("localized")
+    it "localizes a date with a symbol format" do
+      expect(backend.localize(date, format: :short)).to eq("May 11")
+    end
 
-      expect(backend.l(time)).to eq(backend.localize(time))
+    it "localizes with a locale-dependent strftime code" do
+      expect(backend.localize(date, format: "%B %d")).to eq("May 11")
+    end
+
+    it "localizes with an abbreviated month code" do
+      expect(backend.localize(date, format: "%b")).to eq("May")
+    end
+
+    it "localizes with a locale-independent strftime code" do
+      expect(backend.localize(date, format: "%Y-%m-%d")).to eq("2026-05-11")
+    end
+
+    it "resolves format and codes through the given :locale" do
+      expect(backend.localize(date, format: :short, locale: :fr)).to eq("11 mai")
+    end
+
+    it "uses the current locale when none is given" do
+      backend.locale = :fr
+      expect(backend.localize(date, format: :short)).to eq("11 mai")
+    end
+
+    it "raises when given a non-strftime-able object" do
+      expect { backend.localize("not a date") }
+        .to raise_error(ArgumentError, /must be a Date, DateTime or Time/)
+    end
+
+    it "returns the :default when object is nil" do
+      expect(backend.localize(nil, default: "n/a")).to eq("n/a")
+    end
+
+    it "is aliased as #l" do
+      expect(backend.l(date, format: :short)).to eq(backend.localize(date, format: :short))
     end
   end
 


### PR DESCRIPTION
`Hanami::Providers::I18n::Backend` exists to isolate i18n lookups within each slice.

Previously, its `#localize` would delegate to the underlying `I18n` gem backend, which internally calls the global `I18n.t!` method to resolve format symbols (`:short`) and locale-dependent strftime codes (`%B`, `%a`, etc.). This defeated the slice isolation promised by Hanami’s i18n setup, and could lead to `I18n::InvalidLocale` errors in Hanami apps that don’t also configure the global module.

To fix this, route these lookups through the Hanami backend’s own `#translate` instead, keeping everything contained within the slice.

While here, adjust `#localize`'s params signature to match what it actually does:

- Change `format:` default from `nil` to `:default` (the old `nil` would silently producing empty-string output by overriding the i18n gem's own default of `:default`),
- Drop `Numeric` from the YARD type for `object`. This isn't supported by the I18n gem.
- Drop `nil` from the YARD type for `format`, which isn't supported. You must supply a format.

### Known limitation: missing default translations

While this PR fixes the isolation for `#localize`, it doesn't ship any baseline translation data. In a fresh app with no translation files, calls like `l(Date.today, format: :short)` will still fail.

For basic localization work out of the box, we'll need to ship a small set of English defaults, required by the by the strftime substitutions in `#expand_localization_format`. I'll address this in a follow-up PR.