### PR TITLE
Bundle English i18n defaults, add new `shared_load_path` setting

### DIFF
--- a/lib/hanami/config/i18n.rb
+++ b/lib/hanami/config/i18n.rb
@@ -45,14 +45,16 @@ module Hanami
       setting :available_locales, default: Providers::I18n::DEFAULT_AVAILABLE_LOCALES
 
       # @!attribute [rw] load_path
-      #   Sets or returns the array of file path patterns for loading translation files.
+      #   Sets or returns the array of file path patterns for loading per-slice translation files.
       #
       #   Patterns can be:
       #
-      #   - Relative paths/globs (resolved against the app/slice root)
+      #   - Relative paths/globs (resolved against the slice's own root)
       #   - Absolute paths (used as-is)
       #
       #   Defaults to `["config/i18n/**/*.{yml,yaml,json,rb}"]`.
+      #
+      #   See {#shared_load_path} for common translations that should be loaded into every slice.
       #
       #   @return [Array<String>]
       #
@@ -65,6 +67,32 @@ module Hanami
       #   @api public
       #   @since x.x.x
       setting :load_path, default: Providers::I18n::DEFAULT_LOAD_PATH
+
+      # @!attribute [rw] shared_load_path
+      #   Sets or returns the array of file path patterns for loading translation files that
+      #   should be shared across every slice in the app.
+      #
+      #   Relative patterns are resolved against the **app root**, regardless of which slice is
+      #   being loaded. Absolute paths are used as-is. Files matched by these patterns are loaded
+      #   into every slice's i18n backend before that slice's own {#load_path} files, so
+      #   slice-specific translations override shared ones on key conflicts.
+      #
+      #   This is the recommended place for foundational translation data needed by every slice,
+      #   such as the `date.*` and `time.*` keys used by `localize`.
+      #
+      #   Defaults to `["config/i18n/shared/**/*.{yml,yaml,json,rb}"]`.
+      #
+      #   @return [Array<String>]
+      #
+      #   @example Disable shared translations
+      #     config.i18n.shared_load_path = []
+      #
+      #   @example Add another shared source
+      #     config.i18n.shared_load_path += ["vendor/translations/**/*.yml"]
+      #
+      #   @api public
+      #   @since x.x.x
+      setting :shared_load_path, default: Providers::I18n::DEFAULT_SHARED_LOAD_PATH
 
       # @!attribute [rw] fallbacks
       #   Sets or returns the locale fallbacks configuration for missing translations.

--- a/lib/hanami/providers/i18n.rb
+++ b/lib/hanami/providers/i18n.rb
@@ -4,16 +4,24 @@ module Hanami
   module Providers
     # @api private
     class I18n < Hanami::Provider::Source
-      SLICE_CONFIGURED_SETTINGS = %i[default_locale available_locales load_path fallbacks].freeze
+      SLICE_CONFIGURED_SETTINGS = %i[
+        default_locale available_locales load_path shared_load_path fallbacks
+      ].freeze
 
       DEFAULT_LOCALE = :en
       DEFAULT_AVAILABLE_LOCALES = [].freeze
       DEFAULT_LOAD_PATH = ["config/i18n/**/*.{yml,yaml,json,rb}"].freeze
+      DEFAULT_SHARED_LOAD_PATH = ["config/i18n/shared/**/*.{yml,yaml,json,rb}"].freeze
+
+      # Built-in English baseline for date/time localization. Loaded into every slice before any
+      # user translation files, so users can supply overrides if desired.
+      BUNDLED_DEFAULTS_PATH = File.expand_path("i18n/locale/en.yml", __dir__).freeze
 
       setting :default_locale, default: DEFAULT_LOCALE
       setting :available_locales, default: DEFAULT_AVAILABLE_LOCALES
       setting :backend
       setting :load_path, default: DEFAULT_LOAD_PATH
+      setting :shared_load_path, default: DEFAULT_SHARED_LOAD_PATH
       setting :fallbacks
 
       def prepare
@@ -56,8 +64,13 @@ module Hanami
         # Only load translation files if using the default backend. Custom backends are expected to
         # handle their own initialization.
         unless config.backend
-          translation_files = resolve_load_paths(Array(config.load_path))
-          backend.load_translations(*translation_files) if translation_files.any?
+          translation_files = [
+            BUNDLED_DEFAULTS_PATH,
+            *resolve_load_paths(Array(config.shared_load_path), root: slice.app.root),
+            *resolve_load_paths(Array(config.load_path), root: slice.root)
+          ].uniq
+
+          backend.load_translations(*translation_files)
         end
 
         register "i18n", Backend.new(
@@ -73,15 +86,14 @@ module Hanami
       private
 
       # Resolves load path patterns to actual file paths. Relative patterns are resolved against
-      # slice.root. Absolute paths are used as-is.
-      def resolve_load_paths(patterns)
+      # the given `root`. Absolute paths are used as-is.
+      def resolve_load_paths(patterns, root:)
         patterns.flat_map do |pattern|
           if absolute_path?(pattern)
             # Absolute path or already-globbed absolute paths
             File.exist?(pattern) ? [pattern] : Dir.glob(pattern)
           else
-            # Relative pattern - resolve against slice/app root
-            Dir.glob(slice.root.join(pattern))
+            Dir.glob(root.join(pattern))
           end
         end
       end

--- a/lib/hanami/providers/i18n/locale/en.yml
+++ b/lib/hanami/providers/i18n/locale/en.yml
@@ -1,0 +1,57 @@
+en:
+  date:
+    formats:
+      default: "%a, %-d %b %Y"
+      short: "%-d %b"
+      long: "%-d %B %Y"
+    day_names:
+      - Sunday
+      - Monday
+      - Tuesday
+      - Wednesday
+      - Thursday
+      - Friday
+      - Saturday
+    abbr_day_names:
+      - Sun
+      - Mon
+      - Tue
+      - Wed
+      - Thu
+      - Fri
+      - Sat
+    month_names:
+      - ~
+      - January
+      - February
+      - March
+      - April
+      - May
+      - June
+      - July
+      - August
+      - September
+      - October
+      - November
+      - December
+    abbr_month_names:
+      - ~
+      - Jan
+      - Feb
+      - Mar
+      - Apr
+      - May
+      - Jun
+      - Jul
+      - Aug
+      - Sep
+      - Oct
+      - Nov
+      - Dec
+  time:
+    formats:
+      default: "%a, %-d %b %Y %H:%M:%S %:z"
+      short: "%-d %b %-I:%M %P"
+      long: "%-d %B %Y %-I:%M %P"
+    am: "am"
+    pm: "pm"

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -995,7 +995,7 @@ module Hanami
         if Hanami.bundled?("i18n")
           require_relative "providers/i18n"
 
-          if i18n_config_dir? && !container.providers[:i18n]
+          if register_i18n_provider? && !container.providers[:i18n]
             register_provider(:i18n, source: Providers::I18n)
           end
         end
@@ -1148,8 +1148,14 @@ module Hanami
         source_path.join("assets").directory?
       end
 
-      def i18n_config_dir?
-        root.join("config", "i18n").directory?
+      # Ensures an i18n provider is available in every slice.
+      #
+      # For the app, this will always be a standalone provider. For slices, this will be a
+      # standalone provider unless the slice is configured to share the app's "i18n" component.
+      def register_i18n_provider?
+        return true if self == app
+
+        !config.shared_app_component_keys.include?("i18n")
       end
 
       def register_db_provider?

--- a/spec/integration/i18n/i18n_spec.rb
+++ b/spec/integration/i18n/i18n_spec.rb
@@ -601,7 +601,7 @@ RSpec.describe "I18n", :app_integration do
       end
     end
 
-    it "does not register the provider when config/i18n/ directory does not exist" do
+    it "registers the i18n provider with bundled English defaults even without user translations" do
       with_tmp_directory(Dir.mktmpdir) do
         write "config/app.rb", <<~'RUBY'
           require "hanami"
@@ -612,12 +612,63 @@ RSpec.describe "I18n", :app_integration do
           end
         RUBY
 
-        # No config/i18n/ directory exists
+        write "slices/admin/action.rb", <<~RUBY
+          module Admin
+            class Action
+            end
+          end
+        RUBY
+
+        # No config/i18n/ directory exists; only the bundled defaults are available.
 
         require "hanami/prepare"
 
-        # Provider should not be registered
-        expect(Hanami.app.key?("i18n")).to be false
+        # Provider registers in the app and in slices, so `l(Date.today, format: :short)` produces
+        # sensible output out of the box.
+        date = Date.new(2026, 5, 22)
+        time = Time.new(2026, 5, 22, 9, 5, 30, "+10:00")
+
+        expect(Hanami.app["i18n"].l(date, format: :default)).to eq "Fri, 22 May 2026"
+        expect(Hanami.app["i18n"].l(date, format: :short)).to eq "22 May"
+        expect(Hanami.app["i18n"].l(date, format: :long)).to eq "22 May 2026"
+
+        expect(Hanami.app["i18n"].l(time, format: :default)).to eq "Fri, 22 May 2026 09:05:30 +10:00"
+        expect(Hanami.app["i18n"].l(time, format: :short)).to eq "22 May 9:05 am"
+        expect(Hanami.app["i18n"].l(time, format: :long)).to eq "22 May 2026 9:05 am"
+
+        # Bundled defaults reach slices too.
+        expect(Admin::Slice["i18n"].l(date, format: :short)).to eq "22 May"
+        expect(Admin::Slice["i18n"].l(time, format: :short)).to eq "22 May 9:05 am"
+      end
+    end
+
+    it "lets user translations override bundled English defaults" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "config/i18n/en.yml", <<~YAML
+          en:
+            date:
+              formats:
+                short: "%d/%m/%Y"
+        YAML
+
+        require "hanami/prepare"
+
+        date = Date.new(2026, 5, 22)
+
+        # User format overrides the bundled `date.formats.short`.
+        expect(Hanami.app["i18n"].l(date, format: :short)).to eq "22/05/2026"
+
+        # Bundled keys the user didn't override still apply.
+        expect(Hanami.app["i18n"].l(date, format: :long)).to eq "22 May 2026"
       end
     end
 
@@ -961,6 +1012,193 @@ RSpec.describe "I18n", :app_integration do
           expect(search_i18n).not_to be(app_i18n)
           expect(search_i18n.t("search_message")).to eq "Search only"
           expect(search_i18n.t("shared")).to eq "shared" # Missing
+        end
+      end
+
+      # Pattern: Common translations via `config/i18n/shared/`.
+      #
+      # - The app's `config/i18n/shared/` directory is loaded into every slice's backend by
+      #   default, providing common trnaslations without needing to duplicate these per-slice.
+      # - Each slice still has its own i18n instance with its own locale state.
+      # - Slice-specific translations are loaded on top of shared ones, so slices can override
+      #   shared keys.
+      # - Files directly under `config/i18n/` (not in `shared/`) remain app-slice-only.
+      specify "shared translations via config/i18n/shared/ are loaded into every slice" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.i18n.default_locale = :en
+              end
+            end
+          RUBY
+
+          write "config/i18n/en.yml", <<~YAML
+            en:
+              app_only: App slice only
+          YAML
+
+          write "config/i18n/shared/en.yml", <<~YAML
+            en:
+              shared_greeting: Hello from shared
+              date:
+                month_names: [~, January, February, March, April, May, June, July, August, September, October, November, December]
+          YAML
+
+          write "slices/admin/config/i18n/en.yml", <<~YAML
+            en:
+              admin_only: Admin slice only
+              shared_greeting: Hello from admin override
+          YAML
+
+          write "slices/main/action.rb", <<~RUBY
+            module Main
+              class Action
+              end
+            end
+          RUBY
+
+          require "hanami/prepare"
+
+          app_i18n = Hanami.app["i18n"]
+          admin_i18n = Admin::Slice["i18n"]
+          main_i18n = Main::Slice["i18n"]
+
+          # Each slice has its own instance
+          expect(app_i18n).not_to be(admin_i18n)
+          expect(admin_i18n).not_to be(main_i18n)
+
+          # Shared translations reach every slice (including the app slice)
+          expect(app_i18n.t("shared_greeting")).to eq "Hello from shared"
+          expect(main_i18n.t("shared_greeting")).to eq "Hello from shared"
+          expect(app_i18n.t("date.month_names")[5]).to eq "May"
+          expect(main_i18n.t("date.month_names")[5]).to eq "May"
+
+          # App-only translations stay in the app slice
+          expect(app_i18n.t("app_only")).to eq "App slice only"
+          expect(admin_i18n.t("app_only")).to eq "app_only" # Missing
+          expect(main_i18n.t("app_only")).to eq "app_only" # Missing
+
+          # Slice-specific translations override shared keys for that slice
+          expect(admin_i18n.t("shared_greeting")).to eq "Hello from admin override"
+          expect(admin_i18n.t("admin_only")).to eq "Admin slice only"
+
+          # And don't leak to other slices
+          expect(main_i18n.t("admin_only")).to eq "admin_only" # Missing
+        end
+      end
+
+      specify "shared_load_path can be disabled by setting it to []" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.i18n.default_locale = :en
+                config.i18n.shared_load_path = []
+              end
+            end
+          RUBY
+
+          write "config/i18n/shared/en.yml", <<~YAML
+            en:
+              shared_greeting: Hello from shared
+          YAML
+
+          write "slices/admin/action.rb", <<~RUBY
+            module Admin
+              class Action
+              end
+            end
+          RUBY
+
+          require "hanami/prepare"
+
+          # Admin slice doesn't get the shared translations
+          expect(Admin::Slice["i18n"].t("shared_greeting")).to eq "shared_greeting"
+        end
+      end
+
+      specify "shared_load_path can be relocated to another directory" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.i18n.default_locale = :en
+                config.i18n.shared_load_path = ["config/i18n_baseline/**/*.yml"]
+              end
+            end
+          RUBY
+
+          write "config/i18n_baseline/en.yml", <<~YAML
+            en:
+              baseline: From the baseline dir
+          YAML
+
+          write "slices/admin/action.rb", <<~RUBY
+            module Admin
+              class Action
+              end
+            end
+          RUBY
+
+          require "hanami/prepare"
+
+          expect(Hanami.app["i18n"].t("baseline")).to eq "From the baseline dir"
+          expect(Admin::Slice["i18n"].t("baseline")).to eq "From the baseline dir"
+        end
+      end
+
+      specify "a slice can opt out of shared translations independently" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write "config/app.rb", <<~'RUBY'
+            require "hanami"
+
+            module TestApp
+              class App < Hanami::App
+                config.i18n.default_locale = :en
+              end
+            end
+          RUBY
+
+          write "config/i18n/shared/en.yml", <<~YAML
+            en:
+              shared_greeting: Hello from shared
+          YAML
+
+          write "config/slices/main.rb", <<~RUBY
+            module Main
+              class Slice < Hanami::Slice
+                config.i18n.shared_load_path = []
+              end
+            end
+          RUBY
+
+          write "slices/main/config/i18n/en.yml", <<~YAML
+            en:
+              own: Just my own stuff
+          YAML
+
+          write "slices/admin/action.rb", <<~RUBY
+            module Admin
+              class Action
+              end
+            end
+          RUBY
+
+          require "hanami/prepare"
+
+          # Admin slice (default) gets the shared translations
+          expect(Admin::Slice["i18n"].t("shared_greeting")).to eq "Hello from shared"
+
+          # Main slice (opted out) does not
+          expect(Main::Slice["i18n"].t("shared_greeting")).to eq "shared_greeting"
+          expect(Main::Slice["i18n"].t("own")).to eq "Just my own stuff"
         end
       end
     end


### PR DESCRIPTION
The i18n `#localize` method looks up `date.*` and `time.*` keys to resolve symbol formats (like `:short`) and locale-dependent strftime codes (`%a`, `%B`, etc.). We've already changed `#localize` to load from slice-isolated i18n backends, which means that it will no longer work without those translations being provided. Here we bundle them and load them into every slice ahead of the user's own files.

Alongside this, to allow for the user to supply their *own* common translations, introduce a `config.i18n.shared_load_path` setting for translations that should reach every slice. This defaults to `config/i18n/shared/**/*.{yml,yaml,json,rb}` _resolved from the app root_ and loads before each slice's own `load_path`.

Now that we can provide i18n functionality even without user-provided translations (via our bundled translations), load the i18n provider regardless of whether the user has their own i18n config dir. If the user doesn't want i18n, they can unload the gem.