### PR TITLE
Add i18n view helpers

### DIFF
--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -100,12 +100,14 @@ module Hanami
               routes: nil,
               assets: nil,
               request: nil,
+              i18n: nil,
               **args
             )
               @inflector = inflector
               @routes = routes
               @assets = assets
               @request = request
+              @i18n = i18n
 
               @content_for = {}
 
@@ -190,6 +192,22 @@ module Hanami
               end
 
               @routes
+            end
+
+            # Returns the slice's i18n backend.
+            #
+            # @return [Hanami::Providers::I18n::Backend] the i18n backend
+            #
+            # @raise [Hanami::ComponentLoadError] if the i18n gem is not bundled
+            #
+            # @api public
+            # @since x.x.x
+            def i18n
+              unless @i18n
+                raise Hanami::ComponentLoadError, "the i18n gem is required to access translations"
+              end
+
+              @i18n
             end
 
             # @overload content_for(key, value = nil, &block)

--- a/lib/hanami/extensions/view/slice_configured_context.rb
+++ b/lib/hanami/extensions/view/slice_configured_context.rb
@@ -39,15 +39,18 @@ module Hanami
         #   - the configured inflector as `inflector`
         #   - "routes" from the app container as `routes`
         #   - "assets" from the app container as `assets`
+        #   - "i18n" from the slice container as `i18n`
         def define_new
           inflector = slice.inflector
           resolve_routes = method(:resolve_routes)
           resolve_assets = method(:resolve_assets)
+          resolve_i18n = method(:resolve_i18n)
 
           define_method :new do |**kwargs|
             kwargs[:inflector] ||= inflector
             kwargs[:routes] ||= resolve_routes.()
             kwargs[:assets] ||= resolve_assets.()
+            kwargs[:i18n] ||= resolve_i18n.()
 
             super(**kwargs)
           end
@@ -59,6 +62,10 @@ module Hanami
 
         def resolve_assets
           slice["assets"] if slice.key?("assets")
+        end
+
+        def resolve_i18n
+          slice["i18n"] if slice.key?("i18n")
         end
       end
     end

--- a/lib/hanami/extensions/view/standard_helpers.rb
+++ b/lib/hanami/extensions/view/standard_helpers.rb
@@ -16,6 +16,10 @@ module Hanami
         if Hanami.bundled?("hanami-assets")
           include Helpers::AssetsHelper
         end
+
+        if Hanami.bundled?("i18n")
+          include Helpers::I18nHelper
+        end
       end
     end
   end

--- a/lib/hanami/helpers/i18n_helper.rb
+++ b/lib/hanami/helpers/i18n_helper.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "hanami/view"
+
+module Hanami
+  module Helpers
+    # Helper methods for translating and localizing content using the slice's i18n backend.
+    #
+    # These helpers will be automatically available in your view templates, part classes, and scope
+    # classes when the `i18n` gem is bundled.
+    #
+    # @api public
+    # @since x.x.x
+    module I18nHelper
+      # Matches keys whose final segment is `html` or whose final segment ends in `_html`. These
+      # translated values are treated as HTML-safe and any string interpolation values are
+      # HTML-escaped before substitution.
+      #
+      # @api private
+      HTML_SAFE_TRANSLATION_KEY = /(\b|_)html\z/
+
+      # Translates the given key using the slice's i18n backend.
+      #
+      # When the key's final segment is `html` or ends in `_html`, the result is marked HTML-safe
+      # and any string interpolation values are HTML-escaped first.
+      #
+      # When a translation is missing and neither `:default` nor `:raise` was supplied, returns a
+      # `<span class="translation_missing">` element containing the missing key, useful for
+      # spotting missing translations during development.
+      #
+      # @param key [String, Symbol] the translation key to look up
+      # @param options [Hash] translation options forwarded to the backend (`:locale`, `:scope`,
+      #   `:default`, `:count`, `:raise`, etc.), plus any interpolation values
+      #
+      # @return [String, Hanami::View::HTML::SafeString] the translated string
+      #
+      # @example Basic translation
+      #   <%= translate("messages.welcome") %>
+      #   # => "Welcome"
+      #
+      # @example HTML-safe translation
+      #   # en.yml
+      #   #   greeting_html: "Hello, <strong>%{name}</strong>!"
+      #   <%= translate("greeting_html", name: "<script>") %>
+      #   # => "Hello, <strong>&lt;script&gt;</strong>!" (marked HTML-safe)
+      #
+      # @example Missing translation
+      #   <%= translate("missing.key") %>
+      #   # => '<span class="translation_missing" title="...">missing.key</span>'
+      #
+      # @api public
+      # @since x.x.x
+      def translate(key, **options)
+        html_safe = _html_safe_translation_key?(key)
+
+        options = _escape_translation_options(options) if html_safe
+
+        result =
+          if options.key?(:default) || options[:raise]
+            _context.i18n.translate(key, **options)
+          else
+            begin
+              _context.i18n.translate(key, **options, raise: true)
+            rescue ::I18n::MissingTranslationData => exception
+              return _missing_translation_markup(key, exception)
+            end
+          end
+
+        html_safe ? result.to_s.html_safe : result
+      end
+
+      # @api public
+      # @since x.x.x
+      alias_method :t, :translate
+
+      # Translates the given key, raising an exception if the translation is missing.
+      #
+      # @param (see #translate)
+      #
+      # @return [String, Hanami::View::HTML::SafeString] the translated string
+      #
+      # @raise [I18n::MissingTranslationData] if the translation is missing
+      #
+      # @example
+      #   <%= translate!("messages.welcome") %>
+      #
+      # @api public
+      # @since x.x.x
+      def translate!(key, **options)
+        translate(key, **options, raise: true)
+      end
+
+      # @api public
+      # @since x.x.x
+      alias_method :t!, :translate!
+
+      # Localizes the given object (e.g. a date, time, or number) using the slice's i18n backend.
+      #
+      # @param object [Date, Time, DateTime, Numeric] the object to localize
+      # @param options [Hash] localization options forwarded to the backend (`:locale`, `:format`,
+      #   etc.)
+      #
+      # @return [String] the localized string
+      #
+      # @example
+      #   <%= localize(Date.today, format: :long) %>
+      #
+      # @api public
+      # @since x.x.x
+      def localize(object, **options)
+        _context.i18n.localize(object, **options)
+      end
+
+      # @api public
+      # @since x.x.x
+      alias_method :l, :localize
+
+      private
+
+      def _html_safe_translation_key?(key)
+        HTML_SAFE_TRANSLATION_KEY.match?(key.to_s)
+      end
+
+      def _escape_translation_options(options)
+        options.each_with_object({}) do |(key, value), result|
+          result[key] =
+            if ::I18n::RESERVED_KEYS.include?(key) || !value.is_a?(String) || value.html_safe?
+              value
+            else
+              escape_html(value)
+            end
+        end
+      end
+
+      def _missing_translation_markup(key, error)
+        title = escape_html(error.message)
+        body = escape_html(key.to_s)
+        %(<span class="translation_missing" title="#{title}">#{body}</span>).html_safe
+      end
+    end
+  end
+end

--- a/spec/integration/view/context/i18n_spec.rb
+++ b/spec/integration/view/context/i18n_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "hanami"
+
+RSpec.describe "App view / Context / I18n", :app_integration do
+  subject(:context) { context_class.new }
+  let(:context_class) { TestApp::Views::Context }
+
+  before do
+    with_directory(make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "app/views/context.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view/context"
+
+        module TestApp
+          module Views
+            class Context < Hanami::View::Context
+            end
+          end
+        end
+      RUBY
+
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  describe "#i18n" do
+    context "i18n gem bundled" do
+      it "is the app's i18n backend" do
+        expect(context.i18n).to be TestApp::App["i18n"]
+      end
+    end
+
+    context "i18n gem not bundled" do
+      def before_prepare
+        # This must be here instead of an ordinary before hook because the Hanami.bundled? check for
+        # i18n is done as part of requiring "hanami/prepare" above.
+        allow(Hanami).to receive(:bundled?).and_call_original
+        allow(Hanami).to receive(:bundled?).with("i18n").and_return(false)
+      end
+
+      it "raises error" do
+        expect { context.i18n }.to raise_error(Hanami::ComponentLoadError, /i18n gem is required/)
+      end
+    end
+
+    context "injected i18n" do
+      subject(:context) {
+        context_class.new(i18n: i18n)
+      }
+
+      let(:i18n) { double(:i18n) }
+
+      it "is the injected i18n" do
+        expect(context.i18n).to be i18n
+      end
+    end
+  end
+end

--- a/spec/integration/view/helpers/i18n_helper_spec.rb
+++ b/spec/integration/view/helpers/i18n_helper_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe "App view / Helpers / I18n helper", :app_integration do
+  before do
+    with_directory(make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/view.rb", <<~RUBY
+        # auto_register: false
+
+        require "hanami/view"
+
+        module TestApp
+          class View < Hanami::View
+            config.layout = nil
+          end
+        end
+      RUBY
+
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  describe "app view" do
+    def before_prepare
+      write "config/i18n/en.yml", <<~YAML
+        en:
+          messages:
+            welcome: "Welcome to Hanami"
+          greeting_html: "Hello, <strong>%{name}</strong>!"
+      YAML
+
+      write "app/views/posts/show.rb", <<~RUBY
+        module TestApp
+          module Views
+            module Posts
+              class Show < TestApp::View
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/templates/posts/show.html.erb", <<~ERB
+        <h1><%= t("messages.welcome") %></h1>
+        <p><%= t("greeting_html", name: "<Alice>") %></p>
+        <time><%= l(Date.new(2026, 5, 11), format: :short) %></time>
+        <span><%= t("missing.key") %></span>
+      ERB
+    end
+
+    it "makes translate and localize available in templates" do
+      output = TestApp::App["views.posts.show"].call.to_s
+
+      expect(output).to include "<h1>Welcome to Hanami</h1>"
+      expect(output).to include "<p>Hello, <strong>&lt;Alice&gt;</strong>!</p>"
+      expect(output).to include "<time>11 May</time>"
+      expect(output).to include %(<span class="translation_missing")
+    end
+  end
+
+  describe "slice view" do
+    def before_prepare
+      write "slices/main/config/i18n/en.yml", <<~YAML
+        en:
+          posts:
+            title: "Posts in Main"
+      YAML
+
+      write "slices/main/view.rb", <<~RUBY
+        module Main
+          class View < TestApp::View
+          end
+        end
+      RUBY
+
+      write "slices/main/views/posts/show.rb", <<~RUBY
+        module Main
+          module Views
+            module Posts
+              class Show < Main::View
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/templates/posts/show.html.erb", <<~ERB
+        <h1><%= t("posts.title") %></h1>
+        <time><%= l(Date.new(2026, 5, 11), format: :short) %></time>
+      ERB
+    end
+
+    it "makes translate and localize available in templates" do
+      output = Main::Slice["views.posts.show"].call.to_s
+
+      expect(output).to include "<h1>Posts in Main</h1>"
+      expect(output).to include "<time>11 May</time>"
+    end
+  end
+end

--- a/spec/unit/hanami/helpers/i18n_helper_spec.rb
+++ b/spec/unit/hanami/helpers/i18n_helper_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "date"
+require "dry/system"
+require "i18n"
+
+RSpec.describe Hanami::Helpers::I18nHelper do
+  subject(:helper) {
+    Class.new {
+      include Hanami::View::Helpers::EscapeHelper
+      include Hanami::Helpers::I18nHelper
+
+      attr_reader :_context
+
+      def initialize(context)
+        @_context = context
+      end
+    }.new(context)
+  }
+
+  let(:context) { double(i18n:) }
+
+  let(:i18n) do
+    raw_backend = I18n::Backend::Simple.new
+    raw_backend.load_translations(Hanami::Providers::I18n::BUNDLED_DEFAULTS_PATH)
+    raw_backend.store_translations(
+      :en, {
+        hello: "Hello",
+        greeting: "Hello, %{name}!",
+        messages: {welcome: "Welcome"},
+        greeting_html: "Hello, <strong>%{name}</strong>!",
+        legal: {html: "<p>Read the <a href=\"/terms\">terms</a>.</p>"}
+      }
+    )
+
+    Hanami::Providers::I18n::Backend.new(
+      raw_backend,
+      default_locale: :en,
+      available_locales: [:en]
+    )
+  end
+
+  describe "#translate" do
+    it "translates the given key" do
+      expect(helper.translate("hello")).to eq "Hello"
+    end
+
+    it "interpolates string options" do
+      expect(helper.translate("greeting", name: "Alice")).to eq "Hello, Alice!"
+    end
+
+    it "is aliased as #t" do
+      expect(helper.t("hello")).to eq "Hello"
+    end
+
+    it "respects an explicit :locale" do
+      expect(helper.translate("hello", locale: :en)).to eq "Hello"
+    end
+
+    it "respects an explicit :default for missing translations" do
+      expect(helper.translate("missing.key", default: "Fallback")).to eq "Fallback"
+    end
+
+    it "raises when given raise: true and the translation is missing" do
+      expect { helper.translate("missing.key", raise: true) }
+        .to raise_error(I18n::MissingTranslationData)
+    end
+
+    context "missing translation" do
+      it "returns a translation_missing span" do
+        result = helper.translate("missing.key")
+
+        expect(result).to be_html_safe
+        expect(result).to include 'class="translation_missing"'
+        expect(result).to include "missing.key</span>"
+      end
+
+      it "escapes the key in the markup" do
+        result = helper.translate("a<b>c")
+        expect(result).to include "a&lt;b&gt;c"
+      end
+    end
+
+    context "HTML-safe keys" do
+      it "marks results from `_html`-suffixed keys as HTML-safe" do
+        result = helper.translate("greeting_html", name: "Alice")
+        expect(result).to be_html_safe
+        expect(result).to eq "Hello, <strong>Alice</strong>!"
+      end
+
+      it "marks results from keys whose final segment is `html` as HTML-safe" do
+        result = helper.translate("legal.html")
+        expect(result).to be_html_safe
+        expect(result).to include "<p>Read the"
+      end
+
+      it "escapes interpolated string values to prevent injection" do
+        result = helper.translate("greeting_html", name: "<script>alert(1)</script>")
+        expect(result).to be_html_safe
+        expect(result).to eq "Hello, <strong>&lt;script&gt;alert(1)&lt;/script&gt;</strong>!"
+      end
+
+      it "leaves already-html-safe interpolation values untouched" do
+        safe_name = "<em>Alice</em>".html_safe
+        result = helper.translate("greeting_html", name: safe_name)
+        expect(result).to eq "Hello, <strong><em>Alice</em></strong>!"
+      end
+
+      it "does not raise on non-string interpolation values" do
+        expect { helper.translate("greeting_html", name: 42) }.not_to raise_error
+      end
+    end
+
+    context "non-HTML keys" do
+      it "does not mark results as HTML-safe" do
+        expect(helper.translate("hello")).not_to be_html_safe
+      end
+
+      it "does not pre-escape interpolation values" do
+        expect(helper.translate("greeting", name: "<Alice>"))
+          .to eq "Hello, <Alice>!"
+      end
+    end
+  end
+
+  describe "#translate!" do
+    it "translates the given key" do
+      expect(helper.translate!("hello")).to eq "Hello"
+    end
+
+    it "raises for missing translations" do
+      expect { helper.translate!("missing.key") }
+        .to raise_error I18n::MissingTranslationData
+    end
+
+    it "is aliased as #t!" do
+      expect { helper.t!("missing.key") }
+        .to raise_error I18n::MissingTranslationData
+    end
+
+    it "marks `_html` results as HTML-safe and escapes interpolations" do
+      result = helper.translate!("greeting_html", name: "<script>")
+      expect(result).to be_html_safe
+      expect(result).to eq "Hello, <strong>&lt;script&gt;</strong>!"
+    end
+  end
+
+  describe "#localize" do
+    it "localizes the given object with a symbol format" do
+      expect(helper.localize(Date.new(2026, 5, 11), format: :short)).to eq "11 May"
+    end
+
+    it "localizes with a locale-dependent strftime format string" do
+      expect(helper.localize(Date.new(2026, 5, 11), format: "%B %d")).to eq "May 11"
+    end
+
+    it "is aliased as #l" do
+      expect(helper.l(Date.new(2026, 5, 11), format: :short)).to eq "11 May"
+    end
+
+    it "respects an explicit :locale" do
+      expect(helper.localize(Date.new(2026, 5, 11), format: :short, locale: :en))
+        .to eq "11 May"
+    end
+  end
+end


### PR DESCRIPTION
Make `translate`, `translate!`, and `localize` (plus their shorthand counterparts) available in the view layer via helpers.

These helpers delegate to the slice's own i18n backend via a new `#i18n` accessor on the view context (matching our existing `#assets` and `#routes` patterns).

Translations with keys ending in `_html` (or whose final segment is `html`) are returned as HTML-safe, with string interpolation values escaped first.

Missing translations (when neither `:default` nor `:raise` is supplied) render a `<span class="translation_missing">` element instead of the raw key, making gaps easy to spot during development.