### PR TITLE
Add relative i18n key lookup to view helpers

### DIFF
--- a/lib/hanami/helpers/i18n_helper.rb
+++ b/lib/hanami/helpers/i18n_helper.rb
@@ -28,6 +28,13 @@ module Hanami
       # `<span class="translation_missing">` element containing the missing key, useful for
       # spotting missing translations during development.
       #
+      # When the key begins with a `.`, it is treated as relative to the currently-rendering
+      # template and expanded against its name (slashes become dots; partial basenames keep
+      # their leading underscore). For example, `translate(".title")` inside
+      # `users/index.html.erb` resolves to `users.index.title`, and `translate(".label")`
+      # inside `users/_form.html.erb` resolves to `users._form.label`. Raises
+      # `I18n::ArgumentError` if called outside a template render.
+      #
       # @param key [String, Symbol] the translation key to look up
       # @param options [Hash] translation options forwarded to the backend (`:locale`, `:scope`,
       #   `:default`, `:count`, `:raise`, etc.), plus any interpolation values
@@ -48,9 +55,20 @@ module Hanami
       #   <%= translate("missing.key") %>
       #   # => '<span class="translation_missing" title="...">missing.key</span>'
       #
+      # @example Relative key lookup
+      #   # In app/templates/users/index.html.erb:
+      #   <%= translate(".title") %>
+      #   # Looks up "users.index.title"
+      #
+      #   # In app/templates/users/_form.html.erb (a partial):
+      #   <%= translate(".label") %>
+      #   # Looks up "users._form.label"
+      #
       # @api public
       # @since x.x.x
       def translate(key, **options)
+        key = _resolve_i18n_key(key)
+
         html_safe = _html_safe_translation_key?(key)
 
         options = _escape_translation_options(options) if html_safe
@@ -116,6 +134,22 @@ module Hanami
       alias_method :l, :localize
 
       private
+
+      def _resolve_i18n_key(key)
+        return key unless key.to_s.start_with?(".")
+
+        template_name = _context.current_template_name
+
+        unless template_name
+          raise(
+            ::I18n::ArgumentError,
+            "Cannot use relative translation key #{key.inspect} outside of a template render. " \
+            "Use an absolute key (without a leading dot) instead."
+          )
+        end
+
+        "#{template_name.tr("/", ".")}#{key}"
+      end
 
       def _html_safe_translation_key?(key)
         HTML_SAFE_TRANSLATION_KEY.match?(key.to_s)

--- a/spec/integration/view/helpers/i18n_helper_spec.rb
+++ b/spec/integration/view/helpers/i18n_helper_spec.rb
@@ -104,4 +104,78 @@ RSpec.describe "App view / Helpers / I18n helper", :app_integration do
       expect(output).to include "<time>11 May</time>"
     end
   end
+
+  describe "relative key lookup" do
+    describe "in a top-level template" do
+      def before_prepare
+        write "config/i18n/en.yml", <<~YAML
+          en:
+            posts:
+              show:
+                title: "The post title"
+        YAML
+
+        write "app/views/posts/show.rb", <<~RUBY
+          module TestApp
+            module Views
+              module Posts
+                class Show < TestApp::View
+                end
+              end
+            end
+          end
+        RUBY
+
+        write "app/templates/posts/show.html.erb", <<~ERB
+          <h1><%= t(".title") %></h1>
+        ERB
+      end
+
+      it "resolves the key against the current template name" do
+        output = TestApp::App["views.posts.show"].call.to_s
+
+        expect(output).to include "<h1>The post title</h1>"
+      end
+    end
+
+    describe "in a partial" do
+      def before_prepare
+        write "config/i18n/en.yml", <<~YAML
+          en:
+            posts:
+              show:
+                title: "The post title"
+              _form:
+                label: "Post title"
+        YAML
+
+        write "app/views/posts/show.rb", <<~RUBY
+          module TestApp
+            module Views
+              module Posts
+                class Show < TestApp::View
+                end
+              end
+            end
+          end
+        RUBY
+
+        write "app/templates/posts/show.html.erb", <<~ERB
+          <h1><%= t(".title") %></h1>
+          <%= render("form") %>
+        ERB
+
+        write "app/templates/posts/_form.html.erb", <<~ERB
+          <label><%= t(".label") %></label>
+        ERB
+      end
+
+      it "resolves relative keys against the partial's own lookup name" do
+        output = TestApp::App["views.posts.show"].call.to_s
+
+        expect(output).to include "<h1>The post title</h1>"
+        expect(output).to include "<label>Post title</label>"
+      end
+    end
+  end
 end

--- a/spec/unit/hanami/helpers/i18n_helper_spec.rb
+++ b/spec/unit/hanami/helpers/i18n_helper_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Hanami::Helpers::I18nHelper do
     }.new(context)
   }
 
-  let(:context) { double(i18n:) }
+  let(:context) { double(i18n:, current_template_name:) }
+  let(:current_template_name) { nil }
 
   let(:i18n) do
     raw_backend = I18n::Backend::Simple.new
@@ -29,7 +30,18 @@ RSpec.describe Hanami::Helpers::I18nHelper do
         greeting: "Hello, %{name}!",
         messages: {welcome: "Welcome"},
         greeting_html: "Hello, <strong>%{name}</strong>!",
-        legal: {html: "<p>Read the <a href=\"/terms\">terms</a>.</p>"}
+        legal: {html: "<p>Read the <a href=\"/terms\">terms</a>.</p>"},
+        users: {
+          index: {
+            title: "Users index",
+            heading_html: "Hello, <strong>%{name}</strong>!",
+            html: "<p>raw html</p>"
+          },
+          _form: {label: "Name"}
+        },
+        admin: {users: {index: {title: "Admin users index"}}},
+        foo: {users: {index: {title: "Scoped title"}}},
+        _form: {label: "Top-level form label"}
       }
     )
 
@@ -119,6 +131,83 @@ RSpec.describe Hanami::Helpers::I18nHelper do
       it "does not pre-escape interpolation values" do
         expect(helper.translate("greeting", name: "<Alice>"))
           .to eq "Hello, <Alice>!"
+      end
+    end
+
+    context "relative keys" do
+      let(:current_template_name) { "users/index" }
+
+      it "expands a leading-dot key against the current template name" do
+        expect(helper.translate(".title")).to eq "Users index"
+      end
+
+      it "converts slashes in the template name to dots" do
+        allow(context).to receive(:current_template_name).and_return("admin/users/index")
+        expect(helper.translate(".title")).to eq "Admin users index"
+      end
+
+      it "expands symbol keys" do
+        expect(helper.translate(:".title")).to eq "Users index"
+      end
+
+      it "preserves the leading underscore in partial basenames when expanding" do
+        allow(context).to receive(:current_template_name).and_return("users/_form")
+        expect(helper.translate(".label")).to eq "Name"
+      end
+
+      it "preserves the leading underscore for a top-level partial" do
+        allow(context).to receive(:current_template_name).and_return("_form")
+        expect(helper.translate(".label")).to eq "Top-level form label"
+      end
+
+      it "includes the expanded key in the missing-translation markup" do
+        result = helper.translate(".nope")
+
+        expect(result).to be_html_safe
+        expect(result).to include "users.index.nope</span>"
+      end
+
+      it "preserves HTML safety for expanded `_html` keys and escapes interpolations" do
+        result = helper.translate(".heading_html", name: "<script>")
+
+        expect(result).to be_html_safe
+        expect(result).to eq "Hello, <strong>&lt;script&gt;</strong>!"
+      end
+
+      it "preserves HTML safety for expanded `.html` keys" do
+        result = helper.translate(".html")
+
+        expect(result).to be_html_safe
+        expect(result).to eq "<p>raw html</p>"
+      end
+
+      it "does not expand absolute keys even when a template is current" do
+        expect(helper.translate("hello")).to eq "Hello"
+      end
+
+      it "does not treat array keys as relative" do
+        # If arrays were treated as relative, calling translate with no template current
+        # would raise I18n::ArgumentError. Confirm it doesn't.
+        allow(context).to receive(:current_template_name).and_return(nil)
+        expect { helper.translate([".missing", :hello]) }.not_to raise_error
+      end
+
+      it "composes with the :scope option" do
+        expect(helper.translate(".title", scope: :foo)).to eq "Scoped title"
+      end
+
+      context "when no template is being rendered" do
+        let(:current_template_name) { nil }
+
+        it "raises I18n::ArgumentError from #translate" do
+          expect { helper.translate(".title") }
+            .to raise_error(I18n::ArgumentError, /relative translation key/)
+        end
+
+        it "raises I18n::ArgumentError from #translate!" do
+          expect { helper.translate!(".title") }
+            .to raise_error(I18n::ArgumentError, /relative translation key/)
+        end
       end
     end
   end


### PR DESCRIPTION
Update the `#translate` helper to derive template-relative i18n keys. When given a key beginning with a ".", it is expanded against the currently-rendering template's name, with slashes replaced by dots.

For example, `t(".title")` inside `app/templates/posts/show.html.erb` resolves to `posts.show.title`. The same applies inside partials, which keep their leading underscore so the relationship between the YAML key and the source file remains visually obvious: `t(".label")` inside `app/templates/posts/_form.html.erb` resolves to `posts._form.label`.

If called outside a template render (where no template name is available), `#translate` raises `I18n::ArgumentError` rather than silently producing a misleading `translation_missing` span for a literal `.title` key.