### PR TITLE
Add i18n helpers to Hanami::Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 - Integrate hanami-mailer gem when bundled. (@timriley in #1597, #1600)
 
     Load templates from `templates/mailers/`. Register a `"mailers.delivery_method"`, which is either an SMTP mailer when `SMTP_ADDRESS`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_AUTHENTICATION` env vars are present. These can also be prefixed with a slice name. Register a test delivery always in the test env, and also in other envs when the env vars are absent.
-- Integrate i18n gem when bundled. (@timriley in #1562, #1589, #1590, #1591, #1592)
+- Integrate i18n gem when bundled. (@timriley in #1562, #1589, #1590, #1591, #1592, #1593)
 
     Register an `"i18n"` component in each slice, which may be configured via `config.i18n` or a dedicated `:i18n` provider. Load translations from `config/i18n/` within each slice. Load shared translations from `config/i18n/shared/` at the app-level only. Bundle default English translations for `#localize`. Make helpers available in views and actions, which also prefix relative keys (with a leading ".") with their own dot-delimited template or action names.
 - Wrap the configured app logger with `Hanami::UniversalLogger`, to provide a consistent logging interface regardless of the underlying logger. The app can now be depended upon to support (1) structured logging via keyword args passed to log methods, and (2) tagged logging via `#tagged`. (@timriley in #1567, #1568)

--- a/lib/hanami/extensions/action.rb
+++ b/lib/hanami/extensions/action.rb
@@ -43,8 +43,7 @@ module Hanami
         # @api private
         attr_reader :view_context_class
 
-        # Returns the app or slice's {Hanami::Slice::RoutesHelper RoutesHelper} for use within
-        # action instance methods.
+        # Returns the slice's {Hanami::Slice::RoutesHelper RoutesHelper}.
         #
         # @return [Hanami::Slice::RoutesHelper]
         #
@@ -52,14 +51,21 @@ module Hanami
         # @since 2.0.0
         attr_reader :routes
 
-        # Returns the app or slice's `Dry::Monitor::Rack::Middleware` for use within
-        # action instance methods.
+        # Returns the slice's `Dry::Monitor::Rack::Middleware`.
         #
         # @return [Dry::Monitor::Rack::Middleware]
         #
         # @api public
         # @since 2.0.0
         attr_reader :rack_monitor
+
+        # Returns the slice's i18n backend.
+        #
+        # @return [Hanami::Providers::I18n::Backend]
+        #
+        # @api public
+        # @since x.x.x
+        attr_reader :i18n
 
         # @overload def initialize(routes: nil, **kwargs)
         #   Returns a new `Hanami::Action` with app components injected as dependencies.
@@ -71,11 +77,12 @@ module Hanami
         #
         #   @api public
         #   @since 2.0.0
-        def initialize(view: nil, view_context_class: nil, rack_monitor: nil, routes: nil, **kwargs)
+        def initialize(view: nil, view_context_class: nil, rack_monitor: nil, routes: nil, i18n: nil, **kwargs)
           @view = view
           @view_context_class = view_context_class
           @routes = routes
           @rack_monitor = rack_monitor
+          @i18n = i18n
 
           super(**kwargs)
         end
@@ -132,3 +139,9 @@ module Hanami
 end
 
 Hanami::Action.include(Hanami::Extensions::Action)
+
+if Hanami.bundled?("i18n")
+  require_relative "action/i18n_helper"
+  Hanami::Action.setting(:i18n_key_base)
+  Hanami::Action.include(Hanami::Extensions::Action::I18nHelper)
+end

--- a/lib/hanami/extensions/action/i18n_helper.rb
+++ b/lib/hanami/extensions/action/i18n_helper.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Extensions
+    module Action
+      # Action translation and localization helpers.
+      #
+      # These helpers are automatically available on `Hanami::Action` when the `i18n` gem is
+      # bundled.
+      #
+      # When relative translation keys (with a leading dot) are given, they are expanded against a
+      # the action's name. For example, `t(".not_found")` within `Main::Actions::Posts::Show`
+      # becomes `"posts.show.not_found"`.
+      #
+      # @example Basic translation in an action
+      #   module Main
+      #     module Actions
+      #       module Posts
+      #         class Create < Main::Action
+      #           def handle(req, res)
+      #             res.flash[:notice] = t("messages.post_created")
+      #             res.redirect_to routes.path(:posts)
+      #           end
+      #         end
+      #       end
+      #     end
+      #   end
+      #
+      # @example Relative key lookup
+      #   # In Main::Actions::Posts::Show, this looks up "posts.show.not_found"
+      #   t(".not_found")
+      #
+      # @see Hanami::Helpers::I18nHelper::Methods
+      #
+      # @api public
+      # @since x.x.x
+      module I18nHelper
+        include Hanami::Helpers::I18nHelper::Methods
+
+        private
+
+        def _i18n
+          i18n
+        end
+
+        def _resolve_i18n_key(key)
+          return key unless key.to_s.start_with?(".")
+
+          key_base = self.class.config.i18n_key_base
+
+          unless key_base
+            raise(
+              ::I18n::ArgumentError,
+              "Cannot use relative translation key #{key.inspect} outside of a slice-configured action. " \
+              "Use an absolute key (without a leading dot) instead."
+            )
+          end
+
+          "#{key_base}#{key}"
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/extensions/action/name_inferrer.rb
+++ b/lib/hanami/extensions/action/name_inferrer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Extensions
+    module Action
+      # Infers an action's name (e.g. `posts.show`) from its class name relative to its slice
+      # namespace.
+      #
+      # @api private      # @since x.x.x
+      class NameInferrer
+        class << self
+          # @example
+          #   NameInferrer.call(action_class_name: "Main::Actions::Posts::Show", slice: Main::Slice)
+          #   # => "posts.show"
+          #
+          # @param action_class_name [String, nil] the action class name
+          # @param slice [Hanami::Slice] the slice the action belongs to
+          #
+          # @return [String, nil] the inferred name, or nil if `action_class_name` is nil
+          def call(action_class_name:, slice:)
+            return nil unless action_class_name
+
+            slice
+              .inflector
+              .underscore(action_class_name)
+              .sub(%r{^#{slice.slice_name.path}#{PATH_DELIMITER}}, "")
+              .sub(%r{^#{slice.config.actions.name_inference_base}#{PATH_DELIMITER}}, "")
+              .gsub("/", CONTAINER_KEY_DELIMITER)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/extensions/action/slice_configured_action.rb
+++ b/lib/hanami/extensions/action/slice_configured_action.rb
@@ -3,11 +3,12 @@
 module Hanami
   module Extensions
     module Action
+      require_relative "name_inferrer"
+
       # Provides slice-specific configuration and behavior for any action class defined
       # within a slice's module namespace.
       #
       # @api private
-      # @since 2.0.0
       class SliceConfiguredAction < Module
         attr_reader :slice
 
@@ -18,7 +19,9 @@ module Hanami
 
         def extended(action_class)
           configure_action(action_class)
+          configure_action_i18n(action_class)
           extend_behavior(action_class)
+          define_inherited
           define_new
         end
 
@@ -34,6 +37,7 @@ module Hanami
           view_context_class = method(:view_context_class)
           resolve_routes = method(:resolve_routes)
           resolve_rack_monitor = method(:resolve_rack_monitor)
+          resolve_i18n = method(:resolve_i18n)
 
           define_method(:new) do |**kwargs|
             super(
@@ -41,8 +45,21 @@ module Hanami
               view_context_class: kwargs.fetch(:view_context_class) { view_context_class.() },
               routes: kwargs.fetch(:routes) { resolve_routes.() },
               rack_monitor: kwargs.fetch(:rack_monitor) { resolve_rack_monitor.() },
+              i18n: kwargs.fetch(:i18n) { resolve_i18n.() },
               **kwargs,
             )
+          end
+        end
+
+        # Defines an `inherited` hook on this module so each subclass of the slice-configured
+        # action gets its own `config.i18n_key_base`, inferred from its class name. Mirrors the
+        # approach used by `SliceConfiguredView` for `config.template`.
+        def define_inherited
+          configure_action_i18n = method(:configure_action_i18n)
+
+          define_method(:inherited) do |subclass|
+            super(subclass)
+            configure_action_i18n.call(subclass)
           end
         end
 
@@ -98,6 +115,14 @@ module Hanami
           end
         end
 
+        def configure_action_i18n(action_class)
+          return unless action_class.config.respond_to?(:i18n_key_base=)
+
+          action_class.config.i18n_key_base = NameInferrer.call(
+            action_class_name: action_class.name, slice:
+          )
+        end
+
         def extend_behavior(action_class)
           if actions_config.sessions.enabled?
             require "hanami/action/session"
@@ -150,6 +175,10 @@ module Hanami
 
         def resolve_rack_monitor
           slice.app["rack.monitor"] if slice.app.key?("rack.monitor")
+        end
+
+        def resolve_i18n
+          slice["i18n"] if slice.key?("i18n")
         end
 
         def actions_config

--- a/lib/hanami/helpers/i18n_helper.rb
+++ b/lib/hanami/helpers/i18n_helper.rb
@@ -1,139 +1,225 @@
 # frozen_string_literal: true
 
-require "hanami/view"
+require "cgi/escape"
 
 module Hanami
   module Helpers
-    # Helper methods for translating and localizing content using the slice's i18n backend.
+    # View-layer translation and localization helpers.
     #
-    # These helpers will be automatically available in your view templates, part classes, and scope
-    # classes when the `i18n` gem is bundled.
+    # These helpers are automatically available in your view templates, part classes, and scope
+    # classes when the `i18n` gem is bundled. They provide `translate`/`t`, `translate!`/`t!`, and
+    # `localize`/`l`, sourcing the i18n backend from the view context and expanding relative
+    # (leading-dot) translation keys against the currently-rendering template name.
+    #
+    # The shared `translate`/`localize` logic lives in {Methods}, which is also included by the
+    # action-layer i18n helper ({Hanami::Extensions::Action::I18nHelper}). This module supplies
+    # the two view-specific concrete implementations of {Methods}'s abstract hooks: {#_i18n}
+    # returns the i18n backend from the view context, and {#_resolve_i18n_key} expands relative
+    # keys against the template name.
+    #
+    # @example Basic translation
+    #   <%= translate("messages.welcome") %>
+    #   # => "Welcome"
+    #
+    # @example HTML-safe translation
+    #   # en.yml
+    #   #   greeting_html: "Hello, <strong>%{name}</strong>!"
+    #   <%= translate("greeting_html", name: "<script>") %>
+    #   # => "Hello, <strong>&lt;script&gt;</strong>!" (marked HTML-safe)
+    #
+    # @example Missing translation
+    #   <%= translate("missing.key") %>
+    #   # => '<span class="translation_missing" title="...">missing.key</span>'
+    #
+    # @example Relative key lookup
+    #   # In app/templates/users/index.html.erb:
+    #   <%= translate(".title") %>
+    #   # Looks up "users.index.title"
+    #
+    #   # In app/templates/users/_form.html.erb (a partial):
+    #   <%= translate(".label") %>
+    #   # Looks up "users._form.label"
     #
     # @api public
     # @since x.x.x
     module I18nHelper
-      # Matches keys whose final segment is `html` or whose final segment ends in `_html`. These
-      # translated values are treated as HTML-safe and any string interpolation values are
-      # HTML-escaped before substitution.
+      # Shared `translate` / `localize` (and shorthand) helper methods used by both view-layer
+      # consumers and action-layer consumers.
       #
-      # @api private
-      HTML_SAFE_TRANSLATION_KEY = /(\b|_)html\z/
-
-      # Translates the given key using the slice's i18n backend.
+      # **This module is abstract.** Including modules must override two private hooks:
       #
-      # When the key's final segment is `html` or ends in `_html`, the result is marked HTML-safe
-      # and any string interpolation values are HTML-escaped first.
-      #
-      # When a translation is missing and neither `:default` nor `:raise` was supplied, returns a
-      # `<span class="translation_missing">` element containing the missing key, useful for
-      # spotting missing translations during development.
-      #
-      # When the key begins with a `.`, it is treated as relative to the currently-rendering
-      # template and expanded against its name (slashes become dots; partial basenames keep
-      # their leading underscore). For example, `translate(".title")` inside
-      # `users/index.html.erb` resolves to `users.index.title`, and `translate(".label")`
-      # inside `users/_form.html.erb` resolves to `users._form.label`. Raises
-      # `I18n::ArgumentError` if called outside a template render.
-      #
-      # @param key [String, Symbol] the translation key to look up
-      # @param options [Hash] translation options forwarded to the backend (`:locale`, `:scope`,
-      #   `:default`, `:count`, `:raise`, etc.), plus any interpolation values
-      #
-      # @return [String, Hanami::View::HTML::SafeString] the translated string
-      #
-      # @example Basic translation
-      #   <%= translate("messages.welcome") %>
-      #   # => "Welcome"
-      #
-      # @example HTML-safe translation
-      #   # en.yml
-      #   #   greeting_html: "Hello, <strong>%{name}</strong>!"
-      #   <%= translate("greeting_html", name: "<script>") %>
-      #   # => "Hello, <strong>&lt;script&gt;</strong>!" (marked HTML-safe)
-      #
-      # @example Missing translation
-      #   <%= translate("missing.key") %>
-      #   # => '<span class="translation_missing" title="...">missing.key</span>'
-      #
-      # @example Relative key lookup
-      #   # In app/templates/users/index.html.erb:
-      #   <%= translate(".title") %>
-      #   # Looks up "users.index.title"
-      #
-      #   # In app/templates/users/_form.html.erb (a partial):
-      #   <%= translate(".label") %>
-      #   # Looks up "users._form.label"
+      # - {#_i18n} — returns the i18n backend to delegate to.
+      # - {#_resolve_i18n_key} — expands relative (leading-dot) keys against the consumer's
+      #   context, and is a no-op for absolute keys.
       #
       # @api public
       # @since x.x.x
-      def translate(key, **options)
-        key = _resolve_i18n_key(key)
+      module Methods
+        # Matches keys whose final segment is `html` or whose final segment ends in `_html`. These
+        # translated values are treated as HTML-safe and any string interpolation values are
+        # HTML-escaped before substitution.
+        #
+        # @api private
+        HTML_SAFE_TRANSLATION_KEY = /(\b|_)html\z/
 
-        html_safe = _html_safe_translation_key?(key)
+        # Translates the given key using the slice's i18n backend.
+        #
+        # When the key's final segment is `html` or ends in `_html`, the result is marked HTML-safe
+        # and any string interpolation values are HTML-escaped first.
+        #
+        # When a translation is missing and neither `:default` nor `:raise` was supplied, returns a
+        # `<span class="translation_missing">` element containing the missing key, useful for
+        # spotting missing translations during development.
+        #
+        # When the key begins with a `.`, it is treated as relative to the consumer's context and
+        # expanded by {#_resolve_i18n_key}.
+        #
+        # @param key [String, Symbol] the translation key to look up
+        # @param options [Hash] translation options forwarded to the backend (`:locale`, `:scope`,
+        #   `:default`, `:count`, `:raise`, etc.), plus any interpolation values
+        #
+        # @return [String] the translated string (marked HTML-safe when hanami-view is bundled and
+        #   the key ends in `_html` or `html`)
+        #
+        # @api public
+        # @since x.x.x
+        def translate(key, **options)
+          key = _resolve_i18n_key(key)
 
-        options = _escape_translation_options(options) if html_safe
+          html_safe = _html_safe_translation_key?(key)
 
-        result =
-          if options.key?(:default) || options[:raise]
-            _context.i18n.translate(key, **options)
-          else
-            begin
-              _context.i18n.translate(key, **options, raise: true)
-            rescue ::I18n::MissingTranslationData => exception
-              return _missing_translation_markup(key, exception)
+          options = _escape_translation_options(options) if html_safe
+
+          result =
+            if options.key?(:default) || options[:raise]
+              _i18n.translate(key, **options)
+            else
+              begin
+                _i18n.translate(key, **options, raise: true)
+              rescue ::I18n::MissingTranslationData => exception
+                return _missing_translation_markup(key, exception)
+              end
             end
+
+          html_safe ? _i18n_mark_html_safe(result.to_s) : result
+        end
+
+        # @api public
+        # @since x.x.x
+        alias_method :t, :translate
+
+        # Translates the given key, raising an exception if the translation is missing.
+        #
+        # @param (see #translate)
+        #
+        # @return [String] the translated string (marked HTML-safe when hanami-view is bundled and
+        #   the key ends in `_html` or `html`)
+        #
+        # @raise [I18n::MissingTranslationData] if the translation is missing
+        #
+        # @api public
+        # @since x.x.x
+        def translate!(key, **options)
+          translate(key, **options, raise: true)
+        end
+
+        # @api public
+        # @since x.x.x
+        alias_method :t!, :translate!
+
+        # Localizes the given object (e.g. a date, time, or number) using the slice's i18n backend.
+        #
+        # @param object [Date, Time, DateTime, Numeric] the object to localize
+        # @param options [Hash] localization options forwarded to the backend (`:locale`, `:format`,
+        #   etc.)
+        #
+        # @return [String] the localized string
+        #
+        # @api public
+        # @since x.x.x
+        def localize(object, **options)
+          _i18n.localize(object, **options)
+        end
+
+        # @api public
+        # @since x.x.x
+        alias_method :l, :localize
+
+        private
+
+        # Returns the i18n backend the helper methods delegate to.
+        #
+        # Including modules must override this method to return an I18n backend instance.
+        #
+        # @return [Hanami::Providers::I18n::Backend]
+        def _i18n
+          raise NoMethodError, "#{self.class} must implement #_i18n to return an i18n backend"
+        end
+
+        # Resolves the given key, returning it unchanged by default.
+        #
+        # Override this hook to expand relative (leading-dot) keys against a context.
+        #
+        # @param key [String, Symbol]
+        #
+        # @return [String, Symbol] the resolved key
+        def _resolve_i18n_key(key)
+          key
+        end
+
+        def _html_safe_translation_key?(key)
+          HTML_SAFE_TRANSLATION_KEY.match?(key.to_s)
+        end
+
+        def _escape_translation_options(options)
+          options.each_with_object({}) do |(key, value), result|
+            result[key] =
+              if ::I18n::RESERVED_KEYS.include?(key) || !value.is_a?(String) || _i18n_html_safe?(value)
+                value
+              else
+                _i18n_html_escape(value)
+              end
           end
+        end
 
-        html_safe ? result.to_s.html_safe : result
+        def _missing_translation_markup(key, error)
+          title = _i18n_html_escape(error.message)
+          body = _i18n_html_escape(key.to_s)
+          _i18n_mark_html_safe(%(<span class="translation_missing" title="#{title}">#{body}</span>))
+        end
+
+        # Escapes `value` for HTML. Prefers `Hanami::View::Helpers::EscapeHelper#escape_html` when
+        # Hanami View's EscapeHelper is included, falling back to stdlib `CGI.escapeHTML` so the
+        # helper works in API-only apps that don't bundle hanami-view.
+        def _i18n_html_escape(value)
+          if respond_to?(:escape_html)
+            escape_html(value)
+          else
+            CGI.escapeHTML(value.to_s)
+          end
+        end
+
+        # Marks the given string as HTML-safe when Hanami View is loaded, otherwise returns the
+        # string unchanged.
+        #
+        # The HTML-safe marker is only meaningful to Hanami View's template rendering, so there's
+        # nothing to do in its absence.
+        def _i18n_mark_html_safe(str)
+          str.respond_to?(:html_safe) ? str.html_safe : str
+        end
+
+        def _i18n_html_safe?(value)
+          value.respond_to?(:html_safe?) && value.html_safe?
+        end
       end
 
-      # @api public
-      # @since x.x.x
-      alias_method :t, :translate
-
-      # Translates the given key, raising an exception if the translation is missing.
-      #
-      # @param (see #translate)
-      #
-      # @return [String, Hanami::View::HTML::SafeString] the translated string
-      #
-      # @raise [I18n::MissingTranslationData] if the translation is missing
-      #
-      # @example
-      #   <%= translate!("messages.welcome") %>
-      #
-      # @api public
-      # @since x.x.x
-      def translate!(key, **options)
-        translate(key, **options, raise: true)
-      end
-
-      # @api public
-      # @since x.x.x
-      alias_method :t!, :translate!
-
-      # Localizes the given object (e.g. a date, time, or number) using the slice's i18n backend.
-      #
-      # @param object [Date, Time, DateTime, Numeric] the object to localize
-      # @param options [Hash] localization options forwarded to the backend (`:locale`, `:format`,
-      #   etc.)
-      #
-      # @return [String] the localized string
-      #
-      # @example
-      #   <%= localize(Date.today, format: :long) %>
-      #
-      # @api public
-      # @since x.x.x
-      def localize(object, **options)
-        _context.i18n.localize(object, **options)
-      end
-
-      # @api public
-      # @since x.x.x
-      alias_method :l, :localize
+      include Methods
 
       private
+
+      def _i18n
+        _context.i18n
+      end
 
       def _resolve_i18n_key(key)
         return key unless key.to_s.start_with?(".")
@@ -149,27 +235,6 @@ module Hanami
         end
 
         "#{template_name.tr("/", ".")}#{key}"
-      end
-
-      def _html_safe_translation_key?(key)
-        HTML_SAFE_TRANSLATION_KEY.match?(key.to_s)
-      end
-
-      def _escape_translation_options(options)
-        options.each_with_object({}) do |(key, value), result|
-          result[key] =
-            if ::I18n::RESERVED_KEYS.include?(key) || !value.is_a?(String) || value.html_safe?
-              value
-            else
-              escape_html(value)
-            end
-        end
-      end
-
-      def _missing_translation_markup(key, error)
-        title = escape_html(error.message)
-        body = escape_html(key.to_s)
-        %(<span class="translation_missing" title="#{title}">#{body}</span>).html_safe
       end
     end
   end

--- a/spec/integration/action/i18n_spec.rb
+++ b/spec/integration/action/i18n_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "date"
+
+RSpec.describe "App action / I18n", :app_integration do
+  describe "translate and localize in an app-level action" do
+    specify "delegates to the app slice's i18n backend" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App; end
+          end
+        RUBY
+
+        write "config/i18n/en.yml", <<~YAML
+          en:
+            messages:
+              welcome: "Welcome to Hanami"
+            greeting_html: "Hello, <strong>%{name}</strong>!"
+        YAML
+
+        write "app/action.rb", <<~RUBY
+          # auto_register: false
+
+          module TestApp
+            class Action < Hanami::Action; end
+          end
+        RUBY
+
+        write "app/actions/home/index.rb", <<~RUBY
+          module TestApp
+            module Actions
+              module Home
+                class Index < TestApp::Action
+                  def handle(req, res)
+                    res.body = [
+                      t("messages.welcome"),
+                      t("greeting_html", name: "<Alice>"),
+                      l(Date.new(2026, 5, 11), format: :short)
+                    ].join("|")
+                  end
+                end
+              end
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+
+        response = TestApp::App["actions.home.index"].call({})
+        expect(response.body).to eq [
+          "Welcome to Hanami|Hello, <strong>&lt;Alice&gt;</strong>!|11 May"
+        ]
+      end
+    end
+  end
+
+  describe "relative key lookup" do
+    specify "expands a leading-dot key against the action's name" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App; end
+          end
+        RUBY
+
+        write "config/i18n/en.yml", <<~YAML
+          en:
+            posts:
+              show:
+                title: "Post title"
+        YAML
+
+        write "app/action.rb", <<~RUBY
+          # auto_register: false
+
+          module TestApp
+            class Action < Hanami::Action; end
+          end
+        RUBY
+
+        write "app/actions/posts/show.rb", <<~RUBY
+          module TestApp
+            module Actions
+              module Posts
+                class Show < TestApp::Action
+                  def handle(req, res)
+                    res.body = t(".title")
+                  end
+                end
+              end
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+
+        response = TestApp::App["actions.posts.show"].call({})
+        expect(response.body).to eq ["Post title"]
+      end
+    end
+  end
+
+  describe "slice isolation" do
+    specify "each slice's action resolves keys against its own backend" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App; end
+          end
+        RUBY
+
+        write "app/action.rb", <<~RUBY
+          # auto_register: false
+
+          module TestApp
+            class Action < Hanami::Action; end
+          end
+        RUBY
+
+        write "slices/main/config/i18n/en.yml", <<~YAML
+          en:
+            posts:
+              show:
+                title: "Main title"
+        YAML
+
+        write "slices/admin/config/i18n/en.yml", <<~YAML
+          en:
+            posts:
+              show:
+                title: "Admin title"
+        YAML
+
+        write "slices/main/action.rb", <<~RUBY
+          module Main
+            class Action < TestApp::Action; end
+          end
+        RUBY
+
+        write "slices/admin/action.rb", <<~RUBY
+          module Admin
+            class Action < TestApp::Action; end
+          end
+        RUBY
+
+        write "slices/main/actions/posts/show.rb", <<~RUBY
+          module Main
+            module Actions
+              module Posts
+                class Show < Main::Action
+                  def handle(req, res)
+                    res.body = t(".title")
+                  end
+                end
+              end
+            end
+          end
+        RUBY
+
+        write "slices/admin/actions/posts/show.rb", <<~RUBY
+          module Admin
+            module Actions
+              module Posts
+                class Show < Admin::Action
+                  def handle(req, res)
+                    res.body = t(".title")
+                  end
+                end
+              end
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+
+        expect(Main::Slice["actions.posts.show"].call({}).body).to eq ["Main title"]
+        expect(Admin::Slice["actions.posts.show"].call({}).body).to eq ["Admin title"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make I18n helpers available within `Hanami::Action` when the i18n gem is bundled. The helpers delegate to the slice's own i18n backend via a new `#i18n` accessor on the action, automatically filled by our app-level action extension.

Expand relative translation keys (with a leading dot) against the action class's name, relative to its slice namespace. For example, `t(".title")` inside `Main::Actions::Posts::Show` resolves to `posts.show.title`.

Store this name in a new `config.i18n_key_base` setting on actions, set per-class by `SliceConfiguredAction`.

Since the i18n helper logic is now used by both the view and action layers, extract the common logic into a `Hanami::Helpers::I18nHelper::Methods`, which expects implementations to be provided for `#_i18n` (providing the i18n backend) and `#_resolve_i18n_key` (for relative key expansion). Implement each of these through dedicated helper modules for the action and view.

To ensure the action helper has no hard dependency on hanami-view, provide fallback HTML escaping via `CGI.escapeHTML` when hanami-view is not bundled.