### PR TITLE
Keep base `Hanami::View::Context` unmodified by app integration

### DIFF
--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -65,7 +65,7 @@ module Hanami
           # A marker indicating the context class has had Hanami app-specific behaviour mixed in.
           #
           # Checked by {ClassMethods#configure_for_slice} so a chain of slice-configured subclasses
-          # does not re-apply the integration. This matters for the prepended `#initialize`, which
+          # does not re-apply the integration. This matters for the prepended {Initializer}, which
           # would otherwise fire once per slice in the chain instead of once per instance.
           #
           # @api private
@@ -77,7 +77,8 @@ module Hanami
             # @api private
             def configure_for_slice(slice)
               unless is_a?(IntegratedContext)
-                prepend InstanceMethods
+                prepend Initializer
+                include InstanceMethods
                 extend IntegratedContext
               end
 
@@ -85,21 +86,14 @@ module Hanami
             end
           end
 
-          # @api public
-          # @since 2.1.0
-          module InstanceMethods
-            # Returns the app's inflector.
-            #
-            # @return [Dry::Inflector] the inflector
-            #
-            # @api public
-            # @since 2.1.0
-            attr_reader :inflector
-
+          # Captures the integration kwargs into ivars. Prepended so it runs before any
+          # user-defined initializer in the subclass.
+          #
+          # @api private
+          module Initializer
             # @see SliceConfiguredContext#define_new
             #
             # @api private
-            # @since 2.1.0
             def initialize(
               inflector: nil,
               routes: nil,
@@ -129,6 +123,21 @@ module Hanami
               # state across distinct view renderings.
               @content_for = source.instance_variable_get(:@content_for).dup
             end
+          end
+
+          # Readers exposing the ivars captured by {Initializer}. Included rather than prepended
+          # so user subclasses can override them naturally.
+          #
+          # @api public
+          # @since 2.1.0
+          module InstanceMethods
+            # Returns the app's inflector.
+            #
+            # @return [Dry::Inflector] the inflector
+            #
+            # @api public
+            # @since 2.1.0
+            attr_reader :inflector
 
             # Returns the app's assets.
             #

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -16,7 +16,6 @@ module Hanami
           # a class named `Views::Context` within the slice's namespace.
           #
           # @api private
-          # @since 2.1.0
           def context_class(slice)
             views_namespace = views_namespace(slice)
 
@@ -31,8 +30,15 @@ module Hanami
 
           private
 
-          # @api private
-          # @since 2.1.0
+          def views_namespace(slice)
+            # TODO: this could be moved into the top-level Extensions::View
+            if slice.namespace.const_defined?(:Views)
+              slice.namespace.const_get(:Views)
+            else
+              slice.namespace.const_set(:Views, Module.new)
+            end
+          end
+
           def context_superclass(slice)
             return Hanami::View::Context if Hanami.app.equal?(slice)
 
@@ -46,36 +52,35 @@ module Hanami
               Hanami::View::Context
             end
           end
-
-          # @api private
-          # @since 2.1.0
-          def views_namespace(slice)
-            # TODO: this could be moved into the top-level Extensions::View
-            if slice.namespace.const_defined?(:Views)
-              slice.namespace.const_get(:Views)
-            else
-              slice.namespace.const_set(:Views, Module.new)
-            end
-          end
         end
 
-        # @api private
-        # @since 2.1.0
         module ClassExtension
           def self.included(context_class)
             super
 
             context_class.extend(Hanami::SliceConfigurable)
             context_class.extend(ClassMethods)
-            context_class.prepend(InstanceMethods)
+          end
+
+          # A marker indicating the context class has had Hanami app-specific behaviour mixed in.
+          #
+          # Checked by {ClassMethods#configure_for_slice} so a chain of slice-configured subclasses
+          # does not re-apply the integration. This matters for the prepended `#initialize`, which
+          # would otherwise fire once per slice in the chain instead of once per instance.
+          #
+          # @api private
+          module IntegratedContext
           end
 
           # @api private
-          # @since 2.1.0
           module ClassMethods
             # @api private
-            # @since 2.1.0
             def configure_for_slice(slice)
+              unless is_a?(IntegratedContext)
+                prepend InstanceMethods
+                extend IntegratedContext
+              end
+
               extend SliceConfiguredContext.new(slice)
             end
           end
@@ -115,7 +120,6 @@ module Hanami
             end
 
             # @api private
-            # @since 2.1.0
             def initialize_copy(source)
               # The standard implementation of initialize_copy will make shallow copies of all
               # instance variables from the source. This is fine for most of our ivars.

--- a/lib/hanami/slice_configurable.rb
+++ b/lib/hanami/slice_configurable.rb
@@ -31,11 +31,9 @@ module Hanami
 
         inherited_mod = Module.new do
           define_method(:inherited) do |subclass|
-            unless Hanami.app?
-              raise ComponentLoadError, "Class #{klass} must be defined within an Hanami app"
-            end
-
             super(subclass)
+
+            return unless Hanami.app?
 
             subclass.instance_variable_set(:@configured_for_slices, configured_for_slices.dup)
 

--- a/spec/unit/hanami/extensions/view/context_spec.rb
+++ b/spec/unit/hanami/extensions/view/context_spec.rb
@@ -1,60 +1,117 @@
 # frozen_string_literal: true
 
+require "hanami"
 require "hanami/view"
 require "hanami/view/context"
 require "hanami/extensions/view/context"
 
-RSpec.describe(Hanami::View::Context) do
-  subject(:context) { described_class.new(**args) }
-  let(:args) { {} }
-
-  describe "#assets" do
-    context "assets given" do
-      let(:args) { {assets: assets} }
-      let(:assets) { double(:assets) }
-
-      it "returns the assets" do
-        expect(context.assets).to be assets
-      end
+RSpec.describe Hanami::Extensions::View::Context do
+  describe "leaving the base Hanami::View::Context class unmodified" do
+    it "does not prepend the integrated instance methods onto the base class" do
+      expect(Hanami::View::Context.include?(described_class::ClassExtension::InstanceMethods))
+        .to be false
     end
 
-    context "no assets given" do
-      it "raises a Hanami::ComponentLoadError" do
-        expect { context.assets }.to raise_error Hanami::ComponentLoadError
+    it "leaves Hanami::View::Context.new usable with no arguments" do
+      expect { Hanami::View::Context.new }.not_to raise_error
+    end
+
+    context "after a Hanami app has booted and used a slice-configured context", :app_integration do
+      before do
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+
+        Hanami.prepare
+
+        module TestApp
+          module Views
+            class Context < Hanami::View::Context
+            end
+          end
+        end
+      end
+
+      it "still does not prepend the integrated instance methods onto the base class" do
+        expect(Hanami::View::Context.include?(described_class::ClassExtension::InstanceMethods))
+          .to be false
+      end
+
+      it "still leaves Hanami::View::Context.new usable with no arguments" do
+        expect { Hanami::View::Context.new }.not_to raise_error
       end
     end
   end
 
-  describe "#request" do
-    context "request given" do
-      let(:args) { {request: request} }
-      let(:request) { double(:request) }
+  describe "a slice-configured context class", :app_integration do
+    before do
+      module TestApp
+        class App < Hanami::App
+        end
+      end
 
-      it "returns the request" do
-        expect(context.request).to be request
+      Hanami.prepare
+
+      module TestApp
+        module Views
+          class Context < Hanami::View::Context
+          end
+        end
       end
     end
 
-    context "no request given" do
-      it "raises a Hanami::ComponentLoadError" do
-        expect { context.request }.to raise_error Hanami::ComponentLoadError
+    subject(:context) { TestApp::Views::Context.new(**args) }
+    let(:args) { {} }
+
+    describe "#assets" do
+      context "assets given" do
+        let(:args) { {assets: assets} }
+        let(:assets) { double(:assets) }
+
+        it "returns the assets" do
+          expect(context.assets).to be assets
+        end
+      end
+
+      context "no assets given" do
+        it "raises a Hanami::ComponentLoadError" do
+          expect { context.assets }.to raise_error Hanami::ComponentLoadError
+        end
       end
     end
-  end
 
-  describe "#routes" do
-    context "routes given" do
-      let(:args) { {routes: routes} }
-      let(:routes) { double(:routes) }
+    describe "#request" do
+      context "request given" do
+        let(:args) { {request: request} }
+        let(:request) { double(:request) }
 
-      it "returns the routes" do
-        expect(context.routes).to be routes
+        it "returns the request" do
+          expect(context.request).to be request
+        end
+      end
+
+      context "no request given" do
+        it "raises a Hanami::ComponentLoadError" do
+          expect { context.request }.to raise_error Hanami::ComponentLoadError
+        end
       end
     end
 
-    context "no routes given" do
-      it "raises a Hanami::ComponentLoadError" do
-        expect { context.routes }.to raise_error Hanami::ComponentLoadError
+    describe "#routes" do
+      context "routes given" do
+        let(:args) { {routes: routes} }
+        let(:routes) { double(:routes) }
+
+        it "returns the routes" do
+          expect(context.routes).to be routes
+        end
+      end
+
+      context "no routes given" do
+        it "raises a Hanami::ComponentLoadError" do
+          expect { context.routes }.to raise_error Hanami::ComponentLoadError
+        end
       end
     end
   end

--- a/spec/unit/hanami/helpers/form_helper_spec.rb
+++ b/spec/unit/hanami/helpers/form_helper_spec.rb
@@ -17,11 +17,23 @@ RSpec.describe Hanami::Helpers::FormHelper do
   }
 
   let(:context) {
-    Hanami::View::Context.new(request: request, inflector: Dry::Inflector.new)
+    Class.new(Hanami::View::Context) {
+      attr_reader :request, :inflector
+
+      def initialize(request:, inflector:, **args)
+        @request = request
+        @inflector = inflector
+        super(**args)
+      end
+
+      def csrf_token
+        request.session[Hanami::Action::CSRFProtection::CSRF_TOKEN]
+      end
+    }.new(request:, inflector: Dry::Inflector.new)
   }
 
   let(:request) {
-    Hanami::Action::Request.new(env: rack_request, params: params, session_enabled: true)
+    Hanami::Action::Request.new(env: rack_request, params:, session_enabled: true)
   }
 
   let(:rack_request) {


### PR DESCRIPTION
Previously, `Hanami::Extensions::View::Context::ClassExtension::InstanceMethods` was prepended onto `Hanami::View::Context` itself at gem load time. This meant that any subclass, even one intending to serve in a standalone capacity, would receive all our app-integrated behavior: a specific `#initialize` and a whole bunch of instance methods. There was no way to opt out.

To address this, move the prepend into `ClassMethods#configure_for_slice` so it only applies to classes living legitimately within a Hanami app. This keeps the base class clean of any app-specific behavior.

A few implementation notes on how we support this change:

- Avoid a double-prepend in slice-subclass chains (e.g. `Main::Views::Context < TestApp::Views::Context`), by marking integrated classes via an `IntegratedContext` module. Skip the prepend on classes that already have that marker.
- Change `Hanami::SliceConfigurable` so it early returns rather than raises if there is no Hanami app defined. This is what allows a gem to `require "hanami"` (which adds `SliceConfigurable` to `Hanami::View::Context`) and still go on to subclass `Hanami::View::Context` even before an actual Hanami app is defined.
- Split out a small `Initializer` module from `InstanceMethods`, containing the `#initialize` method, which is the only method really requiring a prepend. `InstanceMethods` is now now included rather than prepended, so user subclasses can override its methods naturally.

**NOTE:** This change addresses `Hanami::View::Context` _only_. This has a small enough blast radius that I feel comfortable squeezing it into our impending release. I want to revisit our extensions system more broadly and make things nicer for third-party extensions and even more standalone usage of individual components, but that is a much larger change, and something that will need to wait until a later Hanami release.

Fixes #1522