### PR TITLE
Integrate Hanami Mailer into apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "hanami-router", github: "hanami/hanami-router", branch: "main"
 gem "hanami-action", github: "hanami/hanami-action", branch: "main"
 gem "hanami-cli", github: "hanami/hanami-cli", branch: "main"
 gem "hanami-view", github: "hanami/hanami-view", branch: "main"
+gem "hanami-mailer", github: "hanami/hanami-mailer", branch: "main"
 gem "hanami-assets", github: "hanami/hanami-assets", branch: "main"
 gem "hanami-webconsole", github: "hanami/hanami-webconsole", branch: "main"
 

--- a/lib/hanami/extensions.rb
+++ b/lib/hanami/extensions.rb
@@ -20,6 +20,11 @@ if Hanami.bundled?("hanami-router")
   require_relative "extensions/router/errors"
 end
 
+if Hanami.bundled?("hanami-mailer")
+  require "hanami/mailer"
+  require_relative "extensions/mailer"
+end
+
 if Hanami.bundled?("dry-operation")
   require_relative "extensions/operation"
 end

--- a/lib/hanami/extensions/mailer.rb
+++ b/lib/hanami/extensions/mailer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "hanami/mailer"
+require_relative "mailer/slice_configured_mailer"
+
+module Hanami
+  module Extensions
+    # Integrated behavior for `Hanami::Mailer` classes within Hanami apps.
+    #
+    # @api private
+    module Mailer
+      def self.included(mailer_class)
+        super
+
+        mailer_class.extend(Hanami::SliceConfigurable)
+        mailer_class.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def configure_for_slice(slice)
+          extend SliceConfiguredMailer.new(slice)
+        end
+      end
+    end
+  end
+end
+
+Hanami::Mailer.include(Hanami::Extensions::Mailer)

--- a/lib/hanami/extensions/mailer/slice_configured_mailer.rb
+++ b/lib/hanami/extensions/mailer/slice_configured_mailer.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Extensions
+    module Mailer
+      # Provides slice-specific configuration and behavior for any mailer class defined within a
+      # slice's module namespace.
+      #
+      # This injects the slice's `"mailers.delivery_method"` component into mailer instances, and
+      # points the mailer's view at a slice-configured view class so that mailer templates behave
+      # like regular Hanami view templates — sharing the slice's view context, parts, scopes and
+      # helpers (including i18n). The only behavior not available to mailer views is
+      # request-related state (`request`/`session`/`flash`/`csrf_token`), since mailers are not
+      # rendered from a request.
+      #
+      # @api private
+      class SliceConfiguredMailer < Module
+        attr_reader :slice
+
+        def initialize(slice)
+          super()
+          @slice = slice
+        end
+
+        def extended(mailer_class)
+          configure_mailer(mailer_class)
+          define_new
+        end
+
+        def inspect
+          "#<#{self.class.name}[#{slice.name}]>"
+        end
+
+        private
+
+        def define_new
+          resolve_delivery_method = method(:resolve_delivery_method)
+
+          define_method(:new) do |**kwargs|
+            super(
+              delivery_method: kwargs.fetch(:delivery_method) { resolve_delivery_method.() },
+              **kwargs
+            )
+          end
+        end
+
+        def resolve_delivery_method
+          slice["mailers.delivery_method"] if slice.key?("mailers.delivery_method")
+        end
+
+        def configure_mailer(mailer_class)
+          return unless Hanami.bundled?("hanami-view")
+
+          # Build the mailer's view from a slice-configured view class, so it inherits the slice's
+          # context, parts, scopes, paths and helpers. The mailer only needs to supply its own
+          # template name.
+          mailer_class.config.view_class = mailer_view_class
+
+          if (template = template_name(mailer_class))
+            mailer_class.config.template = template
+          end
+        end
+
+        # Returns the view class that mailer views are built from, defining a `Mailers::View` within
+        # the slice if one is not already present.
+        #
+        # This mirrors how the view extension defines a `Views::Context`: because the class is
+        # defined within the slice's namespace, it is configured automatically (paths, context,
+        # parts, scopes, helpers) just like any other view in the slice. A user may define their own
+        # `<Slice>::Mailers::View` to customize mailer rendering; it is used when present.
+        def mailer_view_class
+          namespace = mailers_namespace
+
+          if namespace.const_defined?(:View, _inherit = false)
+            namespace.const_get(:View)
+          else
+            namespace.const_set(:View, define_mailer_view)
+          end
+        end
+
+        # Defines and configures a view class for the slice's mailers, inheriting from the slice's
+        # own base view class if present, otherwise from the plain `Hanami::View`.
+        def define_mailer_view
+          superclass =
+            begin
+              slice.inflector.constantize("#{slice.namespace.name}::View")
+            rescue NameError
+              Hanami::View
+            end
+
+          Class.new(superclass).tap { |klass|
+            # Call configure_for_slice explicitly, since this is an anonymous class at this point,
+            # so the slice cannot be inferred from its name.
+            klass.configure_for_slice(slice)
+          }
+        end
+
+        def mailers_namespace
+          if slice.namespace.const_defined?(:Mailers, _inherit = false)
+            slice.namespace.const_get(:Mailers)
+          else
+            slice.namespace.const_set(:Mailers, Module.new)
+          end
+        end
+
+        # Returns the template name for the mailer, retaining the `mailers/` segment from the
+        # mailer's namespace so templates resolve under `templates/mailers/` within the slice.
+        #
+        # For example, `App::Mailers::Welcome` will use template `"mailers/welcome"`.
+        def template_name(mailer_class)
+          return unless mailer_class.name
+
+          slice.inflector
+            .underscore(mailer_class.name)
+            .sub(/^#{slice.slice_name.path}\//, "")
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -25,6 +25,8 @@ module Hanami
             end
 
             views_namespace.const_set(:Context, Class.new(context_superclass(slice)).tap { |klass|
+              # Call configure_for_slice explicitly, since this is an anonymous class at this point,
+              # so the slice cannot be inferred from its name.
               klass.configure_for_slice(slice)
             })
           end

--- a/lib/hanami/extensions/view/part.rb
+++ b/lib/hanami/extensions/view/part.rb
@@ -27,6 +27,8 @@ module Hanami
             extend SliceConfiguredPart.new(slice)
 
             const_set :PartHelpers, Class.new(PartHelpers) { |klass|
+              # Call configure_for_slice explicitly, since this is an anonymous class at this point,
+              # so the slice cannot be inferred from its name.
               klass.configure_for_slice(slice)
             }
           end

--- a/lib/hanami/extensions/view/slice_configured_part.rb
+++ b/lib/hanami/extensions/view/slice_configured_part.rb
@@ -57,6 +57,8 @@ module Hanami
           define_method(:new) do |**args|
             return super(**args) if args.key?(:rendering)
 
+            # Call configure_for_slice explicitly, since this is an anonymous class at this point,
+            # so the slice cannot be inferred from its name.
             slice_rendering = Class.new(Hanami::View)
               .configure_for_slice(slice)
               .new

--- a/lib/hanami/extensions/view/slice_configured_view.rb
+++ b/lib/hanami/extensions/view/slice_configured_view.rb
@@ -185,8 +185,8 @@ module Hanami
               views_namespace.const_get(:Part)
             else
               views_namespace.const_set(:Part, Class.new(part_superclass).tap { |klass|
-                # Give the slice to `configure_for_slice`, since it cannot be inferred when it is
-                # called via `.inherited`, because the class is anonymous at this point
+                # Call configure_for_slice explicitly, since this is an anonymous class at this point,
+                # so the slice cannot be inferred from its name.
                 klass.configure_for_slice(slice)
               })
             end
@@ -208,8 +208,8 @@ module Hanami
               views_namespace.const_get(:Scope)
             else
               views_namespace.const_set(:Scope, Class.new(scope_superclass).tap { |klass|
-                # Give the slice to `configure_for_slice`, since it cannot be inferred when it is
-                # called via `.inherited`, since the class is anonymous at this point
+                # Call configure_for_slice explicitly, since this is an anonymous class at this point,
+                # so the slice cannot be inferred from its name.
                 klass.configure_for_slice(slice)
               })
             end

--- a/lib/hanami/providers/mailers.rb
+++ b/lib/hanami/providers/mailers.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Providers
+    # Registers the `"mailers.delivery_method"` component. This is an SMTP delivery method built
+    # from SMTP environment variables when present, otherwise the test delivery method.
+    #
+    # SMTP env vars may take a per-slice prefix derived from the slice name (e.g. an "admin" slice
+    # reads `ADMIN__SMTP_ADDRESS`, falling back to `SMTP_ADDRESS`). Register your own `:mailers`
+    # provider if you need to use another delivery method or different setup logic.
+    #
+    # @api private
+    class Mailers < Hanami::Provider::Source
+      # Maps SMTP environment variable names to their compatible delivery option keys.
+      #
+      # Example values:
+      #
+      #   SMTP_ADDRESS=smtp.example.com
+      #   SMTP_PORT=587
+      #   SMTP_USERNAME=postmaster@example.com
+      #   SMTP_PASSWORD=s3cr3t
+      #   SMTP_AUTHENTICATION=plain
+      SMTP_ENV_VARS = {
+        "SMTP_ADDRESS" => :address,
+        "SMTP_PORT" => :port,
+        "SMTP_USERNAME" => :user_name,
+        "SMTP_PASSWORD" => :password,
+        "SMTP_AUTHENTICATION" => :authentication
+      }.freeze
+
+      # Coercions applied to SMTP env var values, keyed by option. Options not listed here are
+      # passed through unchanged (as strings).
+      SMTP_COERCIONS = Hash.new(:itself.to_proc).update(
+        port: ->(value) { Integer(value) },
+        authentication: ->(value) { value.to_sym }
+      ).freeze
+
+      def start
+        require "hanami/mailer"
+
+        register "delivery_method", build_delivery_method
+      end
+
+      private
+
+      # Builds an SMTP delivery method when SMTP env vars are present; otherwise the test
+      # delivery method. In production with no SMTP configuration, warns noisily before falling
+      # back to the test delivery method (mail will not be sent) — but never raises, so an app
+      # whose mail setup is still a work in progress can boot.
+      def build_delivery_method
+        smtp_options = smtp_options_from_env
+
+        return Hanami::Mailer::Delivery::SMTP.new(**smtp_options) if smtp_options.key?(:address)
+
+        warn_missing_smtp if Hanami.env?(:production)
+
+        Hanami::Mailer::Delivery::Test.new
+      end
+
+      def smtp_options_from_env
+        SMTP_ENV_VARS.each_with_object({}) do |(var, option), options|
+          value = env_value(var)
+          next if value.nil?
+
+          coercion = SMTP_COERCIONS[option]
+          options[option] = coercion ? coercion.call(value) : value
+        end
+      end
+
+      # Reads an SMTP env var, preferring a per-slice prefixed name (e.g. `ADMIN__SMTP_ADDRESS`)
+      # and falling back to the unprefixed name shared across slices.
+      def env_value(var)
+        return ENV[var] if slice.app?
+
+        slice_prefixed_var = "#{slice.slice_name.name.gsub("/", "__").upcase}__#{var}"
+        ENV[slice_prefixed_var] || ENV[var]
+      end
+
+      def warn_missing_smtp
+        message = \
+          "No SMTP configuration found for #{slice.slice_name.name} in production; " \
+          "falling back to the test delivery method — mail will NOT be sent. " \
+          "Set SMTP_ADDRESS (and related SMTP_* variables), or register a custom :mailers provider."
+
+        slice.app["logger"].warn(message)
+      end
+    end
+
+    Dry::System.register_provider_source(
+      :mailers,
+      source: Mailers,
+      group: :hanami,
+      provider_options: {namespace: true}
+    )
+  end
+end

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -960,7 +960,7 @@ module Hanami
         )
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def prepare_container_providers
         # Check here for the `routes` definition only, not `router` itself, because the
         # `router` requires the slice to be prepared before it can be loaded, and at this
@@ -999,8 +999,19 @@ module Hanami
             register_provider(:i18n, source: Providers::I18n)
           end
         end
+
+        if Hanami.bundled?("hanami-mailer")
+          # Explicit require here to ensure the provider source registers itself, to allow the
+          # user to configure it within their own concrete provider file.
+          require_relative "providers/mailers"
+
+          # Only register the provider if the user hasn't provided their own.
+          unless container.providers[:mailers]
+            register_provider(:mailers, namespace: true, source: Providers::Mailers)
+          end
+        end
       end
-      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def prepare_autoloader
         autoloader.tag = "hanami.slices.#{slice_name}"

--- a/spec/integration/mailers/mailers_spec.rb
+++ b/spec/integration/mailers/mailers_spec.rb
@@ -1,0 +1,336 @@
+# frozen_string_literal: true
+
+RSpec.describe "Mailers", :app_integration do
+  # Restore the environment after each example, since examples set SMTP_* / HANAMI_ENV vars.
+  around do |example|
+    env = ENV.to_h
+    example.run
+  ensure
+    ENV.replace(env)
+  end
+
+  def write_app(view: true)
+    write "config/app.rb", <<~RUBY
+      require "hanami"
+
+      module TestApp
+        class App < Hanami::App
+        end
+      end
+    RUBY
+
+    return unless view
+
+    write "app/view.rb", <<~RUBY
+      module TestApp
+        class View < Hanami::View
+        end
+      end
+    RUBY
+  end
+
+  def write_welcome_mailer
+    write "app/mailers/welcome.rb", <<~RUBY
+      module TestApp
+        module Mailers
+          class Welcome < Hanami::Mailer
+            from "noreply@example.com"
+            to { |user:| user[:email] }
+            subject "Welcome!"
+
+            expose :user
+          end
+        end
+      end
+    RUBY
+  end
+
+  describe "delivery method provider" do
+    it "registers the test delivery method by default" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        require "hanami/prepare"
+
+        expect(Hanami.app["mailers.delivery_method"])
+          .to be_a(Hanami::Mailer::Delivery::Test)
+      end
+    end
+
+    it "builds an SMTP delivery method from SMTP_* env vars, with coercion" do
+      ENV["SMTP_ADDRESS"] = "smtp.example.com"
+      ENV["SMTP_PORT"] = "2525"
+      ENV["SMTP_USERNAME"] = "user"
+      ENV["SMTP_PASSWORD"] = "secret"
+      ENV["SMTP_AUTHENTICATION"] = "plain"
+
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        require "hanami/prepare"
+
+        delivery_method = Hanami.app["mailers.delivery_method"]
+        expect(delivery_method).to be_a(Hanami::Mailer::Delivery::SMTP)
+        expect(delivery_method.instance_variable_get(:@options)).to eq(
+          address: "smtp.example.com",
+          port: 2525,
+          user_name: "user",
+          password: "secret",
+          authentication: :plain
+        )
+      end
+    end
+
+    it "reads per-slice SMTP env vars, leaving other slices on the default" do
+      ENV["ADMIN__SMTP_ADDRESS"] = "smtp.admin.example.com"
+
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write "slices/admin/mailers/welcome.rb", <<~RUBY
+          module Admin
+            module Mailers
+              class Welcome < Hanami::Mailer
+                from "noreply@example.com"
+                to "user@example.com"
+                subject "Hi"
+              end
+            end
+          end
+        RUBY
+        require "hanami/prepare"
+
+        expect(Hanami.app["mailers.delivery_method"])
+          .to be_a(Hanami::Mailer::Delivery::Test)
+
+        admin = Hanami.app.slices[:admin]
+        expect(admin["mailers.delivery_method"]).to be_a(Hanami::Mailer::Delivery::SMTP)
+        expect(admin["mailers.delivery_method"].instance_variable_get(:@options))
+          .to eq(address: "smtp.admin.example.com")
+      end
+    end
+
+    it "falls back to unprefixed SMTP env vars for slices without their own" do
+      ENV["SMTP_ADDRESS"] = "smtp.shared.example.com"
+
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write "slices/admin/mailers/welcome.rb", <<~RUBY
+          module Admin
+            module Mailers
+              class Welcome < Hanami::Mailer
+                from "noreply@example.com"
+                to "user@example.com"
+                subject "Hi"
+              end
+            end
+          end
+        RUBY
+        require "hanami/prepare"
+
+        admin = Hanami.app.slices[:admin]
+        expect(admin["mailers.delivery_method"]).to be_a(Hanami::Mailer::Delivery::SMTP)
+        expect(admin["mailers.delivery_method"].instance_variable_get(:@options))
+          .to eq(address: "smtp.shared.example.com")
+      end
+    end
+
+    it "does not override a user-registered :mailers provider" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write "config/providers/mailers.rb", <<~RUBY
+          Hanami.app.register_provider(:mailers, namespace: true) do
+            start do
+              require "hanami/mailer"
+              register "delivery_method", Hanami::Mailer::Delivery::SMTP.new(address: "custom.example.com")
+            end
+          end
+        RUBY
+        require "hanami/prepare"
+
+        delivery_method = Hanami.app["mailers.delivery_method"]
+        expect(delivery_method).to be_a(Hanami::Mailer::Delivery::SMTP)
+        expect(delivery_method.instance_variable_get(:@options))
+          .to eq(address: "custom.example.com")
+      end
+    end
+
+    it "warns (without raising) in production when no SMTP is configured" do
+      ENV["HANAMI_ENV"] = "production"
+      logger_stream = StringIO.new
+
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        require "hanami/setup"
+        Hanami.app.config.logger.stream = logger_stream
+        require "hanami/prepare"
+
+        delivery_method = Hanami.app["mailers.delivery_method"]
+        expect(delivery_method).to be_a(Hanami::Mailer::Delivery::Test)
+
+        logger_stream.rewind
+        expect(logger_stream.read).to include("No SMTP configuration")
+      end
+    end
+  end
+
+  describe "mailer instances" do
+    it "injects the slice's delivery method" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write_welcome_mailer
+        write "app/templates/mailers/welcome.html.erb", "<h1>Hi</h1>\n"
+        require "hanami/prepare"
+
+        expect(Hanami.app["mailers.welcome"].delivery_method)
+          .to be(Hanami.app["mailers.delivery_method"])
+      end
+    end
+
+    it "allows the delivery method to be overridden per instance" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write_welcome_mailer
+        write "app/templates/mailers/welcome.html.erb", "<h1>Hi</h1>\n"
+        require "hanami/prepare"
+
+        custom = Hanami::Mailer::Delivery::Test.new
+        expect(TestApp::Mailers::Welcome.new(delivery_method: custom).delivery_method)
+          .to be(custom)
+      end
+    end
+
+    it "injects the delivery method even for mailers outside a Mailers namespace" do
+      # The :mailers provider is namespaced, so it boots when a `mailers.*` key is resolved. A
+      # mailer defined elsewhere (e.g. Notifications::Welcome → `notifications.welcome`) must still
+      # get the configured delivery method, because its constructor resolves
+      # `mailers.delivery_method`, which boots the provider regardless of the mailer's namespace.
+      ENV["SMTP_ADDRESS"] = "smtp.example.com"
+
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write "app/notifications/welcome.rb", <<~RUBY
+          module TestApp
+            module Notifications
+              class Welcome < Hanami::Mailer
+                from "noreply@example.com"
+                to "user@example.com"
+                subject "Hi"
+              end
+            end
+          end
+        RUBY
+        require "hanami/prepare"
+
+        # Resolve only the mailer (nothing in the mailers.* namespace) and confirm the provider
+        # was booted to supply an SMTP delivery method.
+        expect(Hanami.app["notifications.welcome"].delivery_method)
+          .to be_a(Hanami::Mailer::Delivery::SMTP)
+      end
+    end
+
+    it "delivers a rendered message" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write_welcome_mailer
+        write "app/templates/mailers/welcome.html.erb", "<h1>Welcome <%= user[:name] %></h1>\n"
+        require "hanami/prepare"
+
+        result = Hanami.app["mailers.welcome"].deliver(
+          user: {name: "Alice", email: "alice@example.com"}
+        )
+
+        expect(result.message.to).to eq(["alice@example.com"])
+        expect(result.message.subject).to eq("Welcome!")
+        expect(result.message.html_body).to eq("<h1>Welcome Alice</h1>\n")
+        expect(Hanami.app["mailers.delivery_method"].deliveries.length).to eq(1)
+      end
+    end
+  end
+
+  describe "view integration" do
+    it "resolves templates from templates/mailers/" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write_welcome_mailer
+        write "app/templates/mailers/welcome.html.erb", "<h1>Hi</h1>\n"
+        require "hanami/prepare"
+
+        expect(TestApp::Mailers::Welcome.config.template).to eq("mailers/welcome")
+        result = Hanami.app["mailers.welcome"].deliver(user: {email: "a@example.com"})
+        expect(result.message.html_body).to eq("<h1>Hi</h1>\n")
+      end
+    end
+
+    it "renders standard view helpers, including i18n, in mailer templates" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        # Relative key: `.greeting` resolves against the template name, `mailers.welcome`.
+        write "config/i18n/en.yml", <<~YAML
+          en:
+            mailers:
+              welcome:
+                greeting: "Hello from i18n"
+        YAML
+        write_welcome_mailer
+        write "app/templates/mailers/welcome.html.erb",
+              "<p><%= t(\".greeting\") %>, <%= user[:name] %></p>\n"
+        require "hanami/prepare"
+
+        result = Hanami.app["mailers.welcome"].deliver(user: {name: "Bob", email: "b@example.com"})
+        expect(result.message.html_body).to eq("<p>Hello from i18n, Bob</p>\n")
+      end
+    end
+
+    it "builds mailer views from a user-defined <Slice>::Mailers::View when present" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write "app/mailers/view.rb", <<~RUBY
+          module TestApp
+            module Mailers
+              class View < TestApp::View
+                expose :brand, default: "ACME"
+              end
+            end
+          end
+        RUBY
+        write_welcome_mailer
+        write "app/templates/mailers/welcome.html.erb", "<p><%= brand %>: <%= user[:name] %></p>\n"
+        require "hanami/prepare"
+
+        result = Hanami.app["mailers.welcome"].deliver(user: {name: "Bob", email: "b@example.com"})
+        expect(result.message.html_body).to eq("<p>ACME: Bob</p>\n")
+      end
+    end
+
+    it "renders mailer templates even when the slice defines no base view class" do
+      with_tmp_directory(Dir.mktmpdir) do
+        # No base view class (app/view.rb): the auto-defined Mailers::View falls back to
+        # Hanami::View and must still be configured for the slice (paths, context, helpers).
+        write_app(view: false)
+        write "config/i18n/en.yml", <<~YAML
+          en:
+            mailers:
+              greeting: "Hello from i18n"
+        YAML
+        write_welcome_mailer
+        write "app/templates/mailers/welcome.html.erb",
+              "<p><%= t(\"mailers.greeting\") %>, <%= user[:name] %></p>\n"
+        require "hanami/prepare"
+
+        result = Hanami.app["mailers.welcome"].deliver(user: {name: "Bob", email: "b@example.com"})
+        expect(result.message.html_body).to eq("<p>Hello from i18n, Bob</p>\n")
+      end
+    end
+
+    it "raises a ComponentLoadError if a mailer template uses request-related features" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_app
+        write_welcome_mailer
+        write "app/templates/mailers/welcome.html.erb", "<p><%= request.inspect %></p>\n"
+        require "hanami/prepare"
+
+        expect {
+          Hanami.app["mailers.welcome"].deliver(user: {email: "a@example.com"})
+        }.to raise_error(Hanami::ComponentLoadError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a `:mailers` provider and a `Hanami::Mailer` extension so that mailers can work inside full Hanami apps with zero boilerplate.

**The `:mailers` provider** registers a `"mailers.delivery_method"` component. If certain `SMTP_*` env vars are present, these will be used to configure an SMTP delivery method. Otherwise, a test delivery method is registered, and a warning is emitted if this happens to be in the Hanami production environment.

Like our other built-in providers, a user-specific provider will take precedence. This is how a user can take control and register a custom delivery method.

**The `Hanami::Mailer` extension** configures the class to inject this `"mailers.delivery_method"` component into new instances. It also configures a view class for the mailer that inherits from the app or slice view class, which means all of the app's standard view affordances are also available in mailer views. Finally, it configures the mailer view to load templates from `templates/mailers/`.