### PR TITLE
Disable component memoization in test

### DIFF
--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -911,6 +911,9 @@ module Hanami
       end
 
       def memoize_policy
+        # Do not memoize components in the test env, so they can be stubbed if required.
+        return false if config.env == :test
+
         no_memoize = config.no_memoize
 
         if no_memoize.respond_to?(:call)

--- a/spec/integration/container/memoize_spec.rb
+++ b/spec/integration/container/memoize_spec.rb
@@ -51,6 +51,47 @@ RSpec.describe "Container / Memoize components", :app_integration do
     end
   end
 
+  describe "Disabled memoization in test env" do
+    around do |example|
+      original_env = ENV["HANAMI_ENV"]
+      ENV["HANAMI_ENV"] = "test"
+      example.run
+      ENV["HANAMI_ENV"] = original_env
+    end
+
+    it "does not memoize auto-registered components" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "app/my_component.rb", <<~RUBY
+          module TestApp
+            class MyComponent
+            end
+          end
+        RUBY
+
+        write "slices/admin/my_component.rb", <<~RUBY
+          module Admin
+            class MyComponent
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+
+        expect(TestApp::App["my_component"]).not_to be TestApp::App["my_component"]
+        expect(Admin::Slice["my_component"]).not_to be Admin::Slice["my_component"]
+      end
+    end
+  end
+
   describe "Per-file opt-out via magic comment" do
     it "does not memoize a component with a # memoize: false magic comment" do
       with_tmp_directory(Dir.mktmpdir) do


### PR DESCRIPTION
One of the features that Dry System offers (via Dry Container) is container stubbing. This allows a container key to be stubbed to return a different object, after it has already been registered. This can only work reliably in test suites if component memoization is disabled, otherwise a stubbed object will be memoized and will outlive the lifecycle of the single test that provided the stub.