### PR TITLE
Add `Slice.with_slices` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Added
 
-- Add `Hanami.slices`, returning the app and all (nested) slices. (@timriley)
+- Add `Hanami::Slice.with_slices`, returning the slice and all its nested slices. (@timriley in #1604)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Added
 
+- Add `Hanami.slices`, returning the app and all (nested) slices. (@timriley)
+
 ### Changed
 
 ### Deprecated

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -119,29 +119,6 @@ module Hanami
     instance_variable_defined?(:@_app)
   end
 
-  # Returns an array of all slices, including the app itself and all nested slices.
-  #
-  # This is useful when you need to operate across every container in your app, such as in test
-  # support code.
-  #
-  # Nested slices (with their more specific namespaces) are returned ahead of their parents, and the
-  # app is returned last. This ordering assists with matching a class to its most specific slice by
-  # detecting the first slice whose namespace it belongs to.
-  #
-  # @example
-  #   Hanami.slices # => [Main::Nested::Slice, Main::Slice, Admin::Slice, MyApp::App]
-  #
-  # @return [Array<Hanami::Slice>] all (nested) slices, with the app last
-  #
-  # @see .app
-  # @see Hanami::Slice
-  #
-  # @api public
-  # @since 3.0.0
-  def self.slices
-    app.slices.with_nested + [app]
-  end
-
   # @api private
   # @since 2.0.0
   def self.app=(klass)

--- a/lib/hanami.rb
+++ b/lib/hanami.rb
@@ -119,6 +119,29 @@ module Hanami
     instance_variable_defined?(:@_app)
   end
 
+  # Returns an array of all slices, including the app itself and all nested slices.
+  #
+  # This is useful when you need to operate across every container in your app, such as in test
+  # support code.
+  #
+  # Nested slices (with their more specific namespaces) are returned ahead of their parents, and the
+  # app is returned last. This ordering assists with matching a class to its most specific slice by
+  # detecting the first slice whose namespace it belongs to.
+  #
+  # @example
+  #   Hanami.slices # => [Main::Nested::Slice, Main::Slice, Admin::Slice, MyApp::App]
+  #
+  # @return [Array<Hanami::Slice>] all (nested) slices, with the app last
+  #
+  # @see .app
+  # @see Hanami::Slice
+  #
+  # @api public
+  # @since 3.0.0
+  def self.slices
+    app.slices.with_nested + [app]
+  end
+
   # @api private
   # @since 2.0.0
   def self.app=(klass)

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -394,6 +394,26 @@ module Hanami
         @slices ||= SliceRegistrar.new(self)
       end
 
+      # Returns an array of this slice and all of its nested slices.
+      #
+      # The nested slices are returned first (with their more specific namespaces ahead of their
+      # parents'), and this slice is returned last. This ordering means a class can be matched to
+      # its most specific slice by detecting the first slice whose namespace it belongs to. It is
+      # useful when you need to operate across every container, such as in test support code.
+      #
+      # @example
+      #   Hanami.app.with_slices # => [Main::Nested::Slice, Main::Slice, Admin::Slice, MyApp::App]
+      #
+      # @return [Array<Hanami::Slice>] this slice and all of its (nested) slices, this slice last
+      #
+      # @see #slices
+      #
+      # @api public
+      # @since 3.0.0
+      def with_slices
+        slices.with_nested + [self]
+      end
+
       # @overload register_slice(name, &block)
       #   Registers a nested slice with the given name.
       #

--- a/lib/hanami/slice_configurable.rb
+++ b/lib/hanami/slice_configurable.rb
@@ -57,7 +57,7 @@ module Hanami
       def slice_for(klass)
         return unless klass.name
 
-        Hanami.slices.detect { |slice| klass.name.start_with?("#{slice.namespace}#{MODULE_DELIMITER}") }
+        Hanami.app.with_slices.detect { |slice| klass.name.start_with?("#{slice.namespace}#{MODULE_DELIMITER}") }
       end
     end
 

--- a/lib/hanami/slice_configurable.rb
+++ b/lib/hanami/slice_configurable.rb
@@ -57,9 +57,7 @@ module Hanami
       def slice_for(klass)
         return unless klass.name
 
-        slices = Hanami.app.slices.with_nested + [Hanami.app]
-
-        slices.detect { |slice| klass.name.start_with?("#{slice.namespace}#{MODULE_DELIMITER}") }
+        Hanami.slices.detect { |slice| klass.name.start_with?("#{slice.namespace}#{MODULE_DELIMITER}") }
       end
     end
 

--- a/spec/integration/slices_spec.rb
+++ b/spec/integration/slices_spec.rb
@@ -448,8 +448,29 @@ RSpec.describe "Slices", :app_integration do
     end
   end
 
-  describe "Hanami.slices" do
-    specify "returns all (nested) slices, with nested slices before their parents and the app last" do
+  specify "Registering a slice with a block creates a slice class and evals the block" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            register_slice :main do
+              register "greeting", "hello world"
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      expect(Hanami.app.slices[:main]).to be Main::Slice
+      expect(Main::Slice["greeting"]).to eq "hello world"
+    end
+  end
+
+  describe "iterating over slices via .with_slices" do
+    specify "returns the slice and all its nested slices, with nested slices before their parents and the slice last" do
       with_tmp_directory(Dir.mktmpdir) do
         write "config/app.rb", <<~RUBY
           require "hanami"
@@ -478,33 +499,9 @@ RSpec.describe "Slices", :app_integration do
 
         require "hanami/prepare"
 
-        expect(Hanami.slices).to eq [Main::Nested::Slice, Main::Slice, Hanami.app]
+        expect(Hanami.app.with_slices).to eq [Main::Nested::Slice, Main::Slice, Hanami.app]
+        expect(Main::Slice.with_slices).to eq [Main::Nested::Slice, Main::Slice]
       end
-    end
-
-    specify "raises an error when the app is not loaded" do
-      expect { Hanami.slices }.to raise_error(Hanami::AppLoadError)
-    end
-  end
-
-  specify "Registering a slice with a block creates a slice class and evals the block" do
-    with_tmp_directory(Dir.mktmpdir) do
-      write "config/app.rb", <<~RUBY
-        require "hanami"
-
-        module TestApp
-          class App < Hanami::App
-            register_slice :main do
-              register "greeting", "hello world"
-            end
-          end
-        end
-      RUBY
-
-      require "hanami/prepare"
-
-      expect(Hanami.app.slices[:main]).to be Main::Slice
-      expect(Main::Slice["greeting"]).to eq "hello world"
     end
   end
 end

--- a/spec/integration/slices_spec.rb
+++ b/spec/integration/slices_spec.rb
@@ -448,6 +448,45 @@ RSpec.describe "Slices", :app_integration do
     end
   end
 
+  describe "Hanami.slices" do
+    specify "returns all (nested) slices, with nested slices before their parents and the app last" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "config/slices/main.rb", <<~RUBY
+          module Main
+            class Slice < Hanami::Slice
+            end
+          end
+        RUBY
+
+        write "slices/main/config/slices/nested.rb", <<~RUBY
+          module Main
+            module Nested
+              class Slice < Hanami::Slice
+              end
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+
+        expect(Hanami.slices).to eq [Main::Nested::Slice, Main::Slice, Hanami.app]
+      end
+    end
+
+    specify "raises an error when the app is not loaded" do
+      expect { Hanami.slices }.to raise_error(Hanami::AppLoadError)
+    end
+  end
+
   specify "Registering a slice with a block creates a slice class and evals the block" do
     with_tmp_directory(Dir.mktmpdir) do
       write "config/app.rb", <<~RUBY


### PR DESCRIPTION
This returns the slice itself and all nested slices. For the case of calling this on `Hanami.app`, it returns every slice in the app, including the app itself.

This encapsulates manual slice iteration code that had been spreading across all of our generated test setup files, and will allow those files to be simplified to a single call to `Hanami.app.with_slices`.