### PR TITLE
Allow sharing of "mailers.delivery_method"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,17 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Security
 
-[unreleased]: https://github.com/hanami/hanami/compare/v3.0.0.rc1...HEAD
+[unreleased]: https://github.com/hanami/hanami/compare/v3.0.0...HEAD
+
+## [3.0.0]
+
+### Added
+
+- Integrate hanami-mailer gem when bundled. (@timriley in #1597, #1600, #1606)
+
+    Load templates from `templates/mailers/`. Register a `"mailers.delivery_method"`, which is either an SMTP mailer when `SMTP_ADDRESS`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_AUTHENTICATION` env vars are present. These can also be prefixed with a slice name. Register a test delivery always in the test env, and also in other envs when the env vars are absent.
+
+[3.0.0]: https://github.com/hanami/hanami/compare/v2.3.2...v3.0.0
 
 ## [3.0.0.rc1] - 2026-06-16
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -1029,7 +1029,7 @@ module Hanami
           require_relative "providers/mailers"
 
           # Only register the provider if the user hasn't provided their own.
-          unless container.providers[:mailers]
+          if register_mailers_provider? && !container.providers[:mailers]
             register_provider(:mailers, namespace: true, source: Providers::Mailers)
           end
         end
@@ -1190,6 +1190,17 @@ module Hanami
         return true if self == app
 
         !config.shared_app_component_keys.include?("i18n")
+      end
+
+      # Ensures a mailers provider is available in every slice.
+      #
+      # For the app, this will always be a standalone provider. For slices, this will be a
+      # standalone provider unless the slice is configured to share the app's
+      # "mailers.delivery_method" component.
+      def register_mailers_provider?
+        return true if self == app
+
+        !config.shared_app_component_keys.include?("mailers.delivery_method")
       end
 
       def register_db_provider?

--- a/spec/integration/mailers/mailers_spec.rb
+++ b/spec/integration/mailers/mailers_spec.rb
@@ -165,6 +165,42 @@ RSpec.describe "Mailers", :app_integration do
       end
     end
 
+    it "shares the app's delivery method with slices via shared_app_component_keys" do
+      ENV["SMTP_ADDRESS"] = "smtp.example.com"
+
+      with_tmp_directory(Dir.mktmpdir) do
+        write "config/app.rb", <<~RUBY
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+              config.shared_app_component_keys += ["mailers.delivery_method"]
+            end
+          end
+        RUBY
+        write "slices/admin/mailers/welcome.rb", <<~RUBY
+          module Admin
+            module Mailers
+              class Welcome < Hanami::Mailer
+                from "noreply@example.com"
+                to "user@example.com"
+                subject "Hi"
+              end
+            end
+          end
+        RUBY
+        require "hanami/prepare"
+
+        app_delivery_method = Hanami.app["mailers.delivery_method"]
+        expect(app_delivery_method).to be_a(Hanami::Mailer::Delivery::SMTP)
+
+        # The slice imports the app's delivery method instead of registering its own :mailers
+        # provider, so it resolves the very same instance.
+        admin = Hanami.app.slices[:admin]
+        expect(admin["mailers.delivery_method"]).to be(app_delivery_method)
+      end
+    end
+
     it "warns (without raising) in production when no SMTP is configured" do
       ENV["HANAMI_ENV"] = "production"
       logger_stream = StringIO.new


### PR DESCRIPTION
When `"mailers.delivery_method"` is in `config.shared_app_component_keys`, do not register a `:mailers` provider in slices. This allows for a user to set up a custom `:mailers` provider and then share the resulting delivery_method across all their app's slices. This follows the same pattern we use for the `:i18n` provider.