### PR TITLE
Use "pastie" SQL log theme; rename theme env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Changed
 
+- Syntax highlight SQL in logs when the rouge gem is bundled. (@timriley in #1570, #1607)
+
 ### Deprecated
 
 ### Removed

--- a/lib/hanami/logger/sql_formatter.rb
+++ b/lib/hanami/logger/sql_formatter.rb
@@ -26,9 +26,9 @@ module Hanami
     # highlighted using Rouge's SQL lexer. This is a soft dependency; if Rouge is not installed,
     # queries output as plain, unhighlighted text.
     #
-    # The Rouge theme defaults to "base16.solarized" and can be customized by setting the
-    # `HANAMI_SQL_THEME` environment variable to any Rouge theme name. See `Rouge::Theme.registry`
-    # for available themes.
+    # The Rouge theme defaults to "pastie" and can be customized by setting the
+    # `HANAMI_LOG_SYNTAX_THEME` environment variable to any Rouge theme name. See
+    # `Rouge::Theme.registry` for available themes.
     #
     # @see Hanami::Logger::SQLLogger
     #
@@ -67,8 +67,8 @@ module Hanami
           return nil
         end
 
-        theme_name = ENV.fetch("HANAMI_SQL_THEME", "base16.solarized")
-        theme_class = Rouge::Theme.find(theme_name) || Rouge::Themes::Base16::Solarized
+        theme_name = ENV.fetch("HANAMI_LOG_SYNTAX_THEME", "pastie")
+        theme_class = Rouge::Theme.find(theme_name) || Rouge::Themes::Pastie
         formatter = Rouge::Formatters::Terminal256.new(theme_class.new)
 
         lexer = Rouge::Lexers::SQL.new

--- a/spec/unit/hanami/logger/sql_formatter_spec.rb
+++ b/spec/unit/hanami/logger/sql_formatter_spec.rb
@@ -6,9 +6,11 @@ require "stringio"
 
 RSpec.describe Hanami::Logger::SQLFormatter do
   # Returns true when the string contains the 256-colour escape sequences emitted by
-  # Rouge::Formatters::Terminal256 (e.g. "\e[38;5;203m").
+  # Rouge::Formatters::Terminal256.
   def rouge_highlighted?(str)
-    str.match?(/\e\[38;5;\d+m/)
+    # Matches a 256-colour foreground code (e.g. "\e[38;5;203m"), optionally followed by extra
+    # attributes like bold (e.g. "\e[38;5;28;01m"), which themes such as "pastie" emit.
+    str.match?(/\e\[38;5;\d+(?:;\d+)*m/)
   end
 
   def build_logger(stream:, colorize:)
@@ -87,18 +89,18 @@ RSpec.describe Hanami::Logger::SQLFormatter do
     end
   end
 
-  describe "HANAMI_SQL_THEME environment variable" do
+  describe "HANAMI_LOG_SYNTAX_THEME environment variable" do
     around do |example|
-      original = ENV["HANAMI_SQL_THEME"]
+      original = ENV["HANAMI_LOG_SYNTAX_THEME"]
       example.run
     ensure
-      ENV["HANAMI_SQL_THEME"] = original
+      ENV["HANAMI_LOG_SYNTAX_THEME"] = original
     end
 
-    it "uses the named theme when HANAMI_SQL_THEME is set to a valid theme name" do
+    it "uses the named theme when HANAMI_LOG_SYNTAX_THEME is set to a valid theme name" do
       default_output = capture(colorize: true)
 
-      ENV["HANAMI_SQL_THEME"] = "monokai"
+      ENV["HANAMI_LOG_SYNTAX_THEME"] = "monokai"
       monokai_output = capture(colorize: true)
 
       # Both should be highlighted, but with different colour codes
@@ -106,8 +108,8 @@ RSpec.describe Hanami::Logger::SQLFormatter do
       expect(monokai_output).not_to eq(default_output)
     end
 
-    it "falls back to Gruvbox without raising when HANAMI_SQL_THEME names an unknown theme" do
-      ENV["HANAMI_SQL_THEME"] = "totally_nonexistent_theme"
+    it "falls back to the default theme without raising when HANAMI_LOG_SYNTAX_THEME names an unknown theme" do
+      ENV["HANAMI_LOG_SYNTAX_THEME"] = "totally_nonexistent_theme"
 
       expect { capture(colorize: true) }.not_to raise_error
       expect(rouge_highlighted?(capture(colorize: true))).to be true


### PR DESCRIPTION
The pastie theme works even better than base16.solarized across light and dark terminals.

While we’re here, rename the HANAMI_SQL_THEME to HANAMI_LOG_SYNTAX_THEME to make it easier to reuse for any other syntax highlighting we may want to do in future.