### PR TITLE
Fix template resolution for mailers inheriting from slice-level base class

### DIFF
--- a/lib/hanami/extensions/mailer/slice_configured_mailer.rb
+++ b/lib/hanami/extensions/mailer/slice_configured_mailer.rb
@@ -25,6 +25,7 @@ module Hanami
         def extended(mailer_class)
           configure_mailer(mailer_class)
           define_new
+          define_inherited
         end
 
         def inspect
@@ -41,6 +42,19 @@ module Hanami
               delivery_method: kwargs.fetch(:delivery_method) { resolve_delivery_method.() },
               **kwargs
             )
+          end
+        end
+
+        # Reconfigures the template name for each subclass.
+        def define_inherited
+          template_name = method(:template_name)
+
+          define_method(:inherited) do |subclass|
+            super(subclass)
+
+            if (template = template_name.(subclass))
+              subclass.config.template = template
+            end
           end
         end
 

--- a/spec/integration/mailers/mailers_spec.rb
+++ b/spec/integration/mailers/mailers_spec.rb
@@ -30,10 +30,20 @@ RSpec.describe "Mailers", :app_integration do
   end
 
   def write_welcome_mailer
+    # Mirror a realistic app, where concrete mailers all inherit from a base class.
+    write "app/mailer.rb", <<~RUBY
+      # auto_register: false
+
+      module TestApp
+        class Mailer < Hanami::Mailer
+        end
+      end
+    RUBY
+
     write "app/mailers/welcome.rb", <<~RUBY
       module TestApp
         module Mailers
-          class Welcome < Hanami::Mailer
+          class Welcome < TestApp::Mailer
             from "noreply@example.com"
             to { |user:| user[:email] }
             subject "Welcome!"


### PR DESCRIPTION
A concrete mailer inheriting from an app-level base class (e.g. `MyApp::Mailers::Welcome < MyApp::Mailer`) would be configured with the wrong template (`"mailer"`) and raise a TemplateNotFoundError when rendering.

This was due to the `SliceConfiguredMailer` only inferring a template name once per slice, rather than once per class. Fix this by adding a `define_inherited` hook to `SliceConfiguredMailer` that configures the template name for every subclass, mirroring how we do it in `SliceConfiguredView`.

Also update the `write_welcome_mailer` spec helper to mirror a generated app (concrete mailers inheriting from a base `Mailer`), so we have a range of tests executing this realistic arrangement.