### PR TITLE
Only inherit mailer template when hanami-view is bundled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Fixed
 
+- Don't attempt to inherit mailer template when `hanami-view` if not bundled (@katafrakt in #1611)
+
 ### Security
 
 [unreleased]: https://github.com/hanami/hanami/compare/v3.0.0...HEAD

--- a/lib/hanami/extensions/mailer/slice_configured_mailer.rb
+++ b/lib/hanami/extensions/mailer/slice_configured_mailer.rb
@@ -52,7 +52,7 @@ module Hanami
           define_method(:inherited) do |subclass|
             super(subclass)
 
-            if (template = template_name.(subclass))
+            if Hanami.bundled?("hanami-view") && (template = template_name.(subclass))
               subclass.config.template = template
             end
           end

--- a/spec/integration/mailers/mailers_spec.rb
+++ b/spec/integration/mailers/mailers_spec.rb
@@ -391,5 +391,68 @@ RSpec.describe "Mailers", :app_integration do
         }.to raise_error(Hanami::ComponentLoadError)
       end
     end
+
+    context "when hanami-view is not bundled" do
+      before do
+        allow(Hanami).to receive(:bundled?).and_call_original
+        allow(Hanami).to receive(:bundled?).with("hanami-view").and_return(false)
+      end
+
+      def write_custom_mailer
+        write "app/mailer.rb", <<~RUBY
+          # auto_register: false
+
+          module TestApp
+            class Mailer < Hanami::Mailer
+            end
+          end
+        RUBY
+
+        write "app/mailers/welcome.rb", <<~RUBY
+          module TestApp
+            module Mailers
+              class Welcome < TestApp::Mailer
+                from "noreply@example.com"
+                to { |user:| user[:email] }
+                subject "Welcome!"
+
+                expose :user
+
+                private
+
+                def render_view(format, input)
+                  user = input[:user]
+
+                  case format
+                  when :html
+                    "<h1>Hello, \#{user[:name]}!</h1>\n"
+                  when :text
+                    "Hello, \#{user[:name]}!\n"
+                  end
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "renders the email" do
+        with_tmp_directory(Dir.mktmpdir) do
+          write_app
+          write_custom_mailer
+          require "hanami/prepare"
+
+          result = Hanami.app["mailers.welcome"].deliver(
+            user: {name: "Alice", email: "alice@example.com"}
+          )
+
+          expect(result.message.to).to eq(["alice@example.com"])
+          expect(result.message.subject).to eq("Welcome!")
+          expect(result.message.html_body).to eq("<h1>Hello, Alice!</h1>\n")
+          expect(result.message.text_body).to eq("Hello, Alice!\n")
+          expect(Hanami.app["mailers.delivery_method"].deliveries.length).to eq(1)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
With `hanami-view` not bundled, setting `config.template` fails with

```
     NoMethodError:
       undefined method 'template=' for an instance of Dry::Configurable::Config
     # ./vendor/bundle/ruby/4.0.0/gems/dry-configurable-1.4.0/lib/dry/configurable/config.rb:237:in 'Dry::Configurable::Config#method_missing'
     # ./vendor/bundle/ruby/4.0.0/gems/hanami-3.0.0/lib/hanami/extensions/mailer/slice_configured_mailer.rb:56:in 'block in define_inherited'
     # ./vendor/bundle/ruby/4.0.0/gems/dry-core-1.2.0/lib/dry/core/class_attributes.rb:95:in 'block (2 levels) in defines'
```

see https://github.com/hanami/hanami/pull/1609#discussion_r3507990930

verified in https://github.com/katafrakt/palaver/pull/55 as well