### PR TITLE
Make `Slice.app?` safe to call before an app is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Fixed
 
-- Don't attempt to inherit mailer template when `hanami-view` if not bundled (@katafrakt in #1611)
+- Don't attempt to inherit mailer template when `hanami-view` if not bundled. (@katafrakt in #1611)
+- Return `false` from `Hanami::Slice.app?`, rather than raising `Hanami::AppLoadError`, when no app is defined. (@parndt in #1612)
 
 ### Security
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -107,7 +107,7 @@ module Hanami
       # @api public
       # @since 2.2.0
       def app?
-        eql?(app)
+        Hanami.app? && eql?(app)
       end
 
       # Returns the slice's config.
@@ -1187,7 +1187,7 @@ module Hanami
       # For the app, this will always be a standalone provider. For slices, this will be a
       # standalone provider unless the slice is configured to share the app's "i18n" component.
       def register_i18n_provider?
-        return true if self == app
+        return true if app?
 
         !config.shared_app_component_keys.include?("i18n")
       end
@@ -1198,7 +1198,7 @@ module Hanami
       # standalone provider unless the slice is configured to share the app's
       # "mailers.delivery_method" component.
       def register_mailers_provider?
-        return true if self == app
+        return true if app?
 
         !config.shared_app_component_keys.include?("mailers.delivery_method")
       end

--- a/spec/integration/slices/slice_class_without_app_spec.rb
+++ b/spec/integration/slices/slice_class_without_app_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe "Slices / Slice class loaded before the app", :app_integration do
+  specify "a slice class can be defined before any app, and app? returns false" do
+    # A slice class shipped inside a gem may be required before the app class is defined
+    module Main
+      class Slice < Hanami::Slice
+      end
+    end
+
+    expect(Main::Slice.app?).to be false
+  end
+end


### PR DESCRIPTION
`Slice.app?` raised `Hanami::AppLoadError` when no `Hanami::App` subclass was defined in the process, because it delegated to `Slice.app` for the comparison. A slice class can be loaded before the app class is defined (for example, a slice class shipped inside a gem, required from the Gemfile), and a predicate should be safe to call at any time.

Return `false` instead when no app is defined, and use the predicate in place of bare `self == app` comparisons, which had the same problem.