### PR TITLE
Resolve slice-owned config via the slice, not the global app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 - Don't attempt to inherit mailer template when `hanami-view` if not bundled. (@katafrakt in #1611)
 - Return `false` from `Hanami::Slice.app?`, rather than raising `Hanami::AppLoadError`, when no app is defined. (@parndt in #1612)
+- Build `logger` and `inflector` providers registered on a slice from the slice's own config, rather than the app's. (@parndt in #1613)
 
 ### Security
 

--- a/lib/hanami/providers/inflector.rb
+++ b/lib/hanami/providers/inflector.rb
@@ -10,7 +10,7 @@ module Hanami
     class Inflector < Hanami::Provider::Source
       # @api private
       def start
-        register :inflector, Hanami.app.inflector
+        register :inflector, slice.inflector
       end
     end
   end

--- a/lib/hanami/providers/logger.rb
+++ b/lib/hanami/providers/logger.rb
@@ -28,7 +28,7 @@ module Hanami
       # @api public
       # @since 3.0.0
       def logger
-        @logger ||= Hanami.app.config.logger_instance
+        @logger ||= slice.config.logger_instance
       end
     end
 

--- a/spec/integration/slices/slice_providers_spec.rb
+++ b/spec/integration/slices/slice_providers_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe "Slices / Slice-registered providers", :app_integration do
+  specify "a logger provider registered on a slice builds the logger from the slice's own config" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~'RUBY'
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "slices/admin/config/slice.rb", <<~'RUBY'
+        require "stringio"
+
+        module Admin
+          class Slice < Hanami::Slice
+            # Provide our own logger rather than importing the app's
+            config.shared_app_component_keys -= ["logger"]
+            config.logger.stream = StringIO.new
+          end
+        end
+      RUBY
+
+      write "slices/admin/config/providers/logger.rb", <<~'RUBY'
+        require "hanami/providers/logger"
+
+        Admin::Slice.configure_provider(:logger)
+      RUBY
+
+      require "hanami/prepare"
+
+      Admin::Slice["logger"].info("hello from admin")
+
+      expect(Admin::Slice.config.logger.stream.string).to include "hello from admin"
+    end
+  end
+
+  specify "an inflector provider registered on a slice registers the slice's own inflector" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~'RUBY'
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "slices/admin/config/slice.rb", <<~'RUBY'
+        module Admin
+          class Slice < Hanami::Slice
+            # Provide our own inflector rather than importing the app's
+            config.shared_app_component_keys -= ["inflector"]
+
+            # Configuring inflections gives the slice an inflector instance of its own
+            config.inflections do |inflections|
+              inflections.acronym "API"
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/config/providers/inflector.rb", <<~'RUBY'
+        require "hanami/providers/inflector"
+
+        Admin::Slice.register_provider(:inflector, source: Hanami::Providers::Inflector)
+      RUBY
+
+      require "hanami/prepare"
+
+      expect(Admin::Slice["inflector"]).to be Admin::Slice.inflector
+      expect(Admin::Slice["inflector"]).not_to be TestApp::App.inflector
+    end
+  end
+end


### PR DESCRIPTION
`Providers::Inflector` registered `Hanami.app.inflector`, and `Providers::Logger` built its logger from `Hanami.app.config`, even though every provider source already knows the slice it is registered on.

When the app registers these providers (as it does automatically during prepare), the slice and the app are one and the same, so this changes nothing there. But provider sources can be registered on any slice, and a slice registering its own logger or inflector provider would get components built from the app's config, with its own config silently ignored:

```ruby
# slices/admin/config/slice.rb
module Admin
  class Slice < Hanami::Slice
    config.shared_app_component_keys -= ["logger"]
    config.logger.stream = "log/admin.log" # was ignored
  end
end

# slices/admin/config/providers/logger.rb
Admin::Slice.configure_provider(:logger)
```

Resolves via the provider's own slice instead, so these providers honour the slice they belong to. The behaviour is unchanged for app-registered providers.