### PR TITLE
Support preparing, booting, and serving a slice without an app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Added
 
+- Slices can be defined, prepared, booted, and served as Rack apps without an `Hanami::App` defined in the process. (@parndt in #1614)
+
 ### Changed
 
 ### Deprecated

--- a/lib/hanami/app.rb
+++ b/lib/hanami/app.rb
@@ -117,6 +117,9 @@ module Hanami
       def prepare_container_component_dirs; end
       def prepare_container_imports; end
 
+      # The app provisions its providers via #prepare_app_providers below
+      def prepare_host_providers; end
+
       # rubocop:disable Metrics/AbcSize
 
       def prepare_app_component_dirs

--- a/lib/hanami/extensions/action/slice_configured_action.rb
+++ b/lib/hanami/extensions/action/slice_configured_action.rb
@@ -170,11 +170,11 @@ module Hanami
         end
 
         def resolve_routes
-          slice.app["routes"] if slice.app.key?("routes")
+          slice.host["routes"] if slice.host.key?("routes")
         end
 
         def resolve_rack_monitor
-          slice.app["rack.monitor"] if slice.app.key?("rack.monitor")
+          slice.host["rack.monitor"] if slice.host.key?("rack.monitor")
         end
 
         def resolve_i18n

--- a/lib/hanami/extensions/view/context.rb
+++ b/lib/hanami/extensions/view/context.rb
@@ -36,11 +36,12 @@ module Hanami
           # @api private
           # @since 2.1.0
           def context_superclass(slice)
-            return Hanami::View::Context if Hanami.app.equal?(slice)
+            # A slice that is its own host builds straight on the framework context
+            return Hanami::View::Context if slice.host?
 
             begin
               slice.inflector.constantize(
-                slice.inflector.camelize("#{slice.app.slice_name.name}/views/context")
+                slice.inflector.camelize("#{slice.host.slice_name.name}/views/context")
               )
             rescue NameError => exception
               raise exception unless %i[Views Context].include?(exception.name)

--- a/lib/hanami/providers/i18n.rb
+++ b/lib/hanami/providers/i18n.rb
@@ -66,7 +66,7 @@ module Hanami
         unless config.backend
           translation_files = [
             BUNDLED_DEFAULTS_PATH,
-            *resolve_load_paths(Array(config.shared_load_path), root: slice.app.root),
+            *resolve_load_paths(Array(config.shared_load_path), root: slice.host.root),
             *resolve_load_paths(Array(config.load_path), root: slice.root)
           ].uniq
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -18,8 +18,9 @@ module Hanami
   # Each slice has its own config, and may optionally have its own settings, routes, as well as
   # other nested slices.
   #
-  # Slices expect an Hanami app to be defined (which itself is a slice). They will initialize their
-  # config as a copy of the app's, and will also configure certain components
+  # Slices are hosted by the Hanami app when one is defined (the app is itself a slice), and will
+  # initialize their config as a copy of the app's. A slice with no app in the process is its own
+  # {ClassMethods#host host}, and provisions its own config and base components.
   #
   # Slices must be _prepared_ and optionally _booted_ before they can be used (see
   # {ClassMethods.prepare} and {ClassMethods.boot}). A prepared slice will lazily load its
@@ -110,9 +111,40 @@ module Hanami
         Hanami.app? && eql?(app)
       end
 
+      # Returns the slice's host: the app, when one is defined in the process, or the slice
+      # itself, when it is running standalone.
+      #
+      # The host is the slice that provides shared facilities to the slices it hosts: config,
+      # base providers, shared components, and the routes helper. A standalone slice hosts
+      # itself.
+      #
+      # @return [Hanami::Slice]
+      #
+      # @api public
+      # @since 3.1.0
+      def host
+        Hanami.app? ? app : self
+      end
+
+      # Returns true if the slice is its own host.
+      #
+      # This is the case when the slice is the app, or when it is running standalone (with no
+      # app defined in the process).
+      #
+      # @return [Boolean]
+      #
+      # @see #host
+      #
+      # @api public
+      # @since 3.1.0
+      def host?
+        eql?(host)
+      end
+
       # Returns the slice's config.
       #
-      # A slice's config is copied from the app config at time of first access.
+      # A slice's config is copied from its host's config at time of first access. A slice that
+      # is its own host builds its own config.
       #
       # @return [Hanami::Config]
       #
@@ -121,10 +153,16 @@ module Hanami
       # @api public
       # @since 2.0.0
       def config
-        @config ||= app.config.dup.tap do |slice_config|
-          # Unset config from app that does not apply to ordinary slices
-          slice_config.root = nil
-        end
+        @config ||=
+          if host?
+            # A slice that is its own host builds its own config, exactly as an app does
+            Hanami::Config.new(app_name: slice_name, env: Hanami.env)
+          else
+            host.config.dup.tap do |slice_config|
+              # Unset config from the host that does not apply to ordinary slices
+              slice_config.root = nil
+            end
+          end
       end
 
       # Evaluates the block for a given app environment only.
@@ -209,7 +247,13 @@ module Hanami
         # to live in the app SLICES_DIR. For advanced cases, the correct slice root should be
         # explicitly configured at the beginning of the slice class body, before any calls to
         # `settings`.
-        config.root || app.root.join(SLICES_DIR, slice_name.to_s)
+        config.root ||
+          if host?
+            # A slice that is its own host gets the same default root as an app would
+            Pathname(Dir.pwd)
+          else
+            host.root.join(SLICES_DIR, slice_name.to_s)
+          end
       end
 
       # Returns the slice's root component directory, accounting for App as a special case.
@@ -231,7 +275,7 @@ module Hanami
       # @api public
       # @since 2.3.0
       def relative_source_path
-        source_path.relative_path_from(app.root)
+        source_path.relative_path_from(host.root)
       end
 
       # Returns the slice's configured inflector.
@@ -894,7 +938,33 @@ module Hanami
         prepare_container_base_config
         prepare_container_component_dirs
         prepare_container_imports
+        prepare_host_providers
         prepare_container_providers
+      end
+
+      # A slice that is its own host provisions the components it would otherwise import
+      # from the app. Mirrors App#prepare_app_providers, which the app uses instead (see
+      # the empty override in App::ClassMethods).
+      def prepare_host_providers
+        return unless host?
+
+        container.use(:notifications)
+
+        require_relative "providers/inflector"
+        register_provider(:inflector, source: Hanami::Providers::Inflector)
+
+        require_relative "providers/logger"
+        unless container.providers[:logger]
+          register_provider(:logger, source: Hanami::Providers::Logger)
+        end
+        container.providers[:logger].source.after(:start) do
+          container.decorate(:logger) { |logger| Hanami::UniversalLogger[logger] }
+        end
+
+        if Hanami.bundled?("rack")
+          require_relative "providers/rack"
+          register_provider(:rack, source: Hanami::Providers::Rack, namespace: true)
+        end
       end
 
       def prepare_settings
@@ -976,9 +1046,13 @@ module Hanami
       end
 
       def prepare_container_imports
+        # A slice that is its own host has nowhere to import from; it provisions these
+        # components itself (see #prepare_host_providers)
+        return if host?
+
         import(
           keys: config.shared_app_component_keys,
-          from: app.container,
+          from: host.container,
           as: nil
         )
       end
@@ -1152,7 +1226,12 @@ module Hanami
           end
 
           if Hanami.bundled?("hanami-assets") && config.assets.serve
-            use(Hanami::Middleware::Assets)
+            if slice.host?
+              # A slice that is its own host serves assets per its own config
+              use(Hanami::Middleware::Assets, config:)
+            else
+              use(Hanami::Middleware::Assets)
+            end
           end
 
           middleware_stack.update(config.middleware_stack)
@@ -1184,21 +1263,21 @@ module Hanami
 
       # Ensures an i18n provider is available in every slice.
       #
-      # For the app, this will always be a standalone provider. For slices, this will be a
-      # standalone provider unless the slice is configured to share the app's "i18n" component.
+      # A slice that is its own host will always register its own provider. Other slices will
+      # do so unless they are configured to share their host's "i18n" component.
       def register_i18n_provider?
-        return true if app?
+        return true if host?
 
         !config.shared_app_component_keys.include?("i18n")
       end
 
       # Ensures a mailers provider is available in every slice.
       #
-      # For the app, this will always be a standalone provider. For slices, this will be a
-      # standalone provider unless the slice is configured to share the app's
-      # "mailers.delivery_method" component.
+      # A slice that is its own host will always register its own provider. Other slices will
+      # do so unless they are configured to share their host's "mailers.delivery_method"
+      # component.
       def register_mailers_provider?
-        return true if app?
+        return true if host?
 
         !config.shared_app_component_keys.include?("mailers.delivery_method")
       end

--- a/lib/hanami/slice_configurable.rb
+++ b/lib/hanami/slice_configurable.rb
@@ -31,10 +31,6 @@ module Hanami
 
         inherited_mod = Module.new do
           define_method(:inherited) do |subclass|
-            unless Hanami.app?
-              raise ComponentLoadError, "Class #{klass} must be defined within an Hanami app"
-            end
-
             super(subclass)
 
             subclass.instance_variable_set(:@configured_for_slices, configured_for_slices.dup)
@@ -57,7 +53,20 @@ module Hanami
       def slice_for(klass)
         return unless klass.name
 
-        Hanami.app.with_slices.detect { |slice| klass.name.start_with?("#{slice.namespace}#{MODULE_DELIMITER}") }
+        slices.detect { |slice| klass.name.start_with?("#{slice.namespace}#{MODULE_DELIMITER}") }
+      end
+
+      def slices
+        Hanami.app? ? Hanami.app.with_slices : standalone_slices
+      end
+
+      # Standalone slices (no app in the process): every slice class still reachable via its
+      # constant, most specific namespace first
+      def standalone_slices
+        Hanami::Slice.subclasses
+          .reject { |slice| slice.name.nil? || slice <= Hanami::App }
+          .select { |slice| Object.const_defined?(slice.name) && Object.const_get(slice.name).equal?(slice) }
+          .sort_by { |slice| -slice.name.length }
       end
     end
 

--- a/spec/integration/slices/standalone_slice_spec.rb
+++ b/spec/integration/slices/standalone_slice_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+RSpec.describe "Slices / Standalone slices", :app_integration do
+  # No Hanami::App is ever defined in these examples. These modules are removed
+  # between examples by the :app_integration teardown.
+  let(:app_modules) { %i[PagesFeature BooksFeature ParentFeature] }
+
+  def write_slice(module_name, path_name)
+    write "#{path_name}/lib/#{path_name}.rb", <<~RUBY
+      require "hanami"
+
+      module #{module_name}
+        class Slice < Hanami::Slice
+          config.root = File.expand_path("../slice", __dir__)
+          config.logger.stream = File::NULL
+        end
+      end
+    RUBY
+
+    write "#{path_name}/slice/config/routes.rb", <<~RUBY
+      require "hanami/routes"
+
+      module #{module_name}
+        class Routes < Hanami::Routes
+          get "/pages", to: "index", as: :pages
+          get "/pages/:slug", to: "show", as: :page
+        end
+      end
+    RUBY
+
+    write "#{path_name}/slice/actions/index.rb", <<~RUBY
+      require "hanami/action"
+
+      module #{module_name}
+        module Actions
+          class Index < Hanami::Action
+            def handle(request, response)
+              response.body = "pages index (script_name=\#{request.env["SCRIPT_NAME"]})"
+            end
+          end
+        end
+      end
+    RUBY
+
+    write "#{path_name}/slice/actions/show.rb", <<~RUBY
+      require "hanami/action"
+
+      module #{module_name}
+        module Actions
+          class Show < Hanami::Action
+            def handle(request, response)
+              response.body = "page \#{request.params[:slug]}"
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  specify "a slice can be defined, prepared, and booted without an app" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write_slice("PagesFeature", "pages_feature")
+      require File.join(Dir.pwd, "pages_feature/lib/pages_feature")
+
+      expect(Hanami.app?).to be false
+
+      slice = PagesFeature::Slice
+
+      # With no app in the process, the slice is its own host
+      expect(slice.host).to be slice
+      expect(slice).to be_host
+
+      expect(slice.prepare).to be slice
+      expect(slice.prepared?).to be true
+
+      # Components load from the slice's own gem-shaped root
+      expect(slice["actions.index"]).to be_an_instance_of PagesFeature::Actions::Index
+
+      # The slice provisions the components it would otherwise import from the app
+      expect(slice["logger"]).to respond_to :info
+      expect(slice["inflector"]).to be slice.inflector
+      expect(slice["notifications"]).to be
+
+      expect(slice.boot).to be slice
+      expect(slice.booted?).to be true
+      expect(Hanami.app?).to be false
+    end
+  end
+
+  specify "a standalone slice builds its own config and defaults its root to the working directory" do
+    with_tmp_directory(Dir.mktmpdir) do
+      module BooksFeature
+        class Slice < Hanami::Slice
+        end
+      end
+
+      expect(BooksFeature::Slice.config).to be_an_instance_of Hanami::Config
+      expect(BooksFeature::Slice.config.env).to eq Hanami.env
+      expect(BooksFeature::Slice.root).to eq Pathname(Dir.pwd)
+    end
+  end
+
+  describe "serving a standalone slice as a Rack app" do
+    include Rack::Test::Methods
+
+    def app
+      PagesFeature::Slice
+    end
+
+    specify "routing, params, and named path generation work without an app" do
+      with_tmp_directory(Dir.mktmpdir) do
+        write_slice("PagesFeature", "pages_feature")
+        require File.join(Dir.pwd, "pages_feature/lib/pages_feature")
+
+        PagesFeature::Slice.prepare
+
+        get "/pages"
+        expect(last_response.status).to eq 200
+        expect(last_response.body).to eq "pages index (script_name=)"
+
+        get "/pages/about"
+        expect(last_response.status).to eq 200
+        expect(last_response.body).to eq "page about"
+
+        expect(PagesFeature::Slice.router.path(:page, slug: "about")).to eq "/pages/about"
+        expect(Hanami.app?).to be false
+      end
+    end
+  end
+
+  specify "a standalone slice can register nested slices" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write_slice("ParentFeature", "parent_feature")
+      require File.join(Dir.pwd, "parent_feature/lib/parent_feature")
+
+      write "admin/slice.rb", <<~RUBY
+        module ParentFeature
+          module Admin
+            class Slice < Hanami::Slice
+              config.root = __dir__
+            end
+          end
+        end
+      RUBY
+      require File.join(Dir.pwd, "admin/slice")
+
+      write "admin/actions/index.rb", <<~RUBY
+        require "hanami/action"
+
+        module ParentFeature
+          module Admin
+            module Actions
+              class Index < Hanami::Action
+              end
+            end
+          end
+        end
+      RUBY
+
+      ParentFeature::Slice.register_slice(:admin, ParentFeature::Admin::Slice)
+      ParentFeature::Slice.prepare
+
+      admin = ParentFeature::Slice.slices[:admin]
+      expect(admin).to be ParentFeature::Admin::Slice
+      expect(admin.parent).to be ParentFeature::Slice
+
+      admin.prepare
+      expect(admin["actions.index"]).to be_an_instance_of ParentFeature::Admin::Actions::Index
+    end
+  end
+
+  specify "subclassing a slice-configurable class outside any slice namespace is a no-op" do
+    expect {
+      Class.new(Hanami::Action)
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
An `Hanami::Slice` can now be defined, prepared, booted, and served as a Rack app with no `Hanami::App` defined in the process. Behaviour is unchanged when an app is present.

This is built on the concept of a slice's host: the app, when one is defined in the process, or the slice itself, when running standalone. The host provides shared facilities to the slices it hosts: config, base providers, shared components, and the routes helper. A slice that is its own host provisions for itself exactly what an app would otherwise provide, following the principle that the app is just the outermost slice:

- config: built fresh via `Hanami::Config.new`, as `App.inherited` does
- root: falls back to `Dir.pwd`, the same default an app gets
- providers: registers notifications, inflector, logger (with `UniversalLogger` decoration), and rack (when bundled) itself, mirroring `App#prepare_app_providers`, instead of importing them from an app
- `i18n/mailers` providers: always registered standalone (nothing to share from)

Slice-configurable classes (actions, views) previously raised `ComponentLoadError` when subclassed with no app defined. When no app is present, the owning slice is now resolved by scanning `Hanami::Slice` subclasses (most specific namespace first); only classes still reachable via their constant are considered, and subclassing outside any slice namespace is a no-op. Actions resolve routes and rack.monitor from their own slice, view contexts build on `Hanami::View::Context` directly, and the assets middleware receives the slice's own config rather than defaulting to the app's.