### PR TITLE
Add configuration option for migration table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 ## [Unreleased]
 
 ### Added
+- Add a new database configuration option: `migrations_table`.  It defaults to `:schema_migrations`.
 
 ### Changed
 

--- a/lib/hanami/config/db.rb
+++ b/lib/hanami/config/db.rb
@@ -17,6 +17,8 @@ module Hanami
 
       setting :log_level, default: :debug
 
+      setting :migrations_table, default: :schema_migrations
+
       private
 
       def method_missing(name, *args, &block)


### PR DESCRIPTION
This is a sibling commit to https://github.com/hanami/hanami-cli/pull/433, which reads the configured value and uses it as the name of the table that stores the applied migrations (previously, this table was always called `schema_migrations`).