### PR TITLE
Use exposures over params for view auto-rendering args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Fixed
 
+- Prefer response exposures over request params when preparing input for the view as part of an action auto-rendering. (@timriley in #1620)
 - Don't attempt to inherit mailer template when `hanami-view` if not bundled. (@katafrakt in #1611)
 - Return `false` from `Hanami::Slice.app?`, rather than raising `Hanami::AppLoadError`, when no app is defined. (@parndt in #1612)
 - Build `logger` and `inflector` providers registered on a slice from the slice's own config, rather than the app's. (@parndt in #1613)

--- a/lib/hanami/extensions/action.rb
+++ b/lib/hanami/extensions/action.rb
@@ -37,6 +37,12 @@ module Hanami
       #
       # @since 2.0.0
       module InstanceMethods
+        # Options accepted by `Hanami::View#call` itself, which must never be given from request
+        # params.
+        #
+        # @api private
+        VIEW_RESERVED_KEYS = %i[format context layout].freeze
+
         # @api private
         attr_reader :view
 
@@ -89,16 +95,25 @@ module Hanami
 
         private
 
-        # @api private
         def build_response(**options)
           options = options.merge(view_options: method(:view_options))
           super(**options)
         end
 
-        # @api private
         def finish(req, res, halted)
-          res.render(view, **req.params) if !halted && auto_render?(res)
+          res.render(view, **view_input(req, res)) if !halted && auto_render?(res)
           super
+        end
+
+        # Returns the input for the automatically rendered view.
+        #
+        # Includes response exposures as well as request params. Exposures are given precedence;
+        # these are server-set and should not be overridden by the client.
+        #
+        # Drops any keys matching the keywords for `Hanami::View#call` itself, since these are
+        # behavioral controls and the client should have no say over how the view renders.
+        def view_input(req, res)
+          {**req.params.to_h.except(*VIEW_RESERVED_KEYS), **res.exposures}
         end
 
         # @api private

--- a/spec/integration/action/view_rendering/automatic_rendering_spec.rb
+++ b/spec/integration/action/view_rendering/automatic_rendering_spec.rb
@@ -44,6 +44,99 @@ RSpec.describe "App action / View rendering / Automatic rendering", :app_integra
     end
   end
 
+  it "Prefers exposures over params of the same name" do
+    within_app do
+      write "app/actions/profile/show.rb", <<~RUBY
+        module TestApp
+          module Actions
+            module Profile
+              class Show < TestApp::Action
+                def handle(req, res)
+                  res[:favorite_number] = 123
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/views/profile/show.rb", <<~RUBY
+        module TestApp
+          module Views
+            module Profile
+              class Show < TestApp::View
+                expose :name, :favorite_number
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/templates/profile/show.html.slim", <<~'SLIM'
+        h1 Hello, #{name}. Your favorite number is #{favorite_number}, right?
+      SLIM
+
+      require "hanami/prepare"
+
+      action = TestApp::App["actions.profile.show"]
+      response = action.(name: "Jennifer", favorite_number: 456)
+      rendered = response.body[0]
+
+      expect(rendered).to eq "<html><body><h1>Hello, Jennifer. Your favorite number is 123, right?</h1></body></html>"
+    end
+  end
+
+  it "Ignores params matching the keywords of Hanami::View#call" do
+    within_app do
+      write "app/actions/profile/show.rb", <<~RUBY
+        module TestApp
+          module Actions
+            module Profile
+              class Show < TestApp::Action
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/views/profile/show.rb", <<~RUBY
+        module TestApp
+          module Views
+            module Profile
+              class Show < TestApp::View
+                expose :name
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "app/templates/layouts/admin.html.slim", <<~SLIM
+        html
+          body
+            h2 Admin
+            == yield
+      SLIM
+
+      write "app/templates/profile/show.html.slim", <<~'SLIM'
+        h1 Hello, #{name}.
+      SLIM
+
+      write "app/templates/profile/show.json.slim", <<~'SLIM'
+        | {"name": "#{name}"}
+      SLIM
+
+      require "hanami/prepare"
+
+      action = TestApp::App["actions.profile.show"]
+      response = action.(name: "Jennifer", format: "json", layout: "admin", context: "nope")
+      rendered = response.body[0]
+
+      expect(rendered).to eq "<html><body><h1>Hello, Jennifer.</h1></body></html>"
+      expect(response.status).to eq 200
+    end
+  end
+
   it "Does not render a view automatically when #render? returns false " do
     within_app do
       write "app/actions/profile/show.rb", <<~RUBY


### PR DESCRIPTION
When an action auto-renders its view, prefer response exposures over request params for the view's input.

When a response exposure is set, this is an explicit intention set in code. It should not be overridden by client-provided params, which can lead to unexpected or unwanted behavior.

Fixes #1619.

I'll release this soon as a 3.0 patch release.

For 3.1, I'll propose that we remove the params passthrough to the view altogether. It's better app authors to be explicit about this, I think. To smooth the transition we'll keep a module that preserves the 3.0 behaviour but adds a warning when a param is passed through, so it's easy to track down and fix any issues.