### PR TITLE
Build the database URL from component ENV vars

### DIFF
--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -26,7 +26,7 @@ module Hanami
       end
 
       def finalize_config
-        return if @config_finalized
+        return self if @config_finalized
 
         apply_parent_config if apply_parent_config?
 
@@ -261,11 +261,149 @@ module Hanami
           end
         end
 
+        # Build URLs from component ENV vars for any gateways without a complete URL
+        gateway_names = [:default, *detect_gateway_names_from_env_components(env_var_prefix)]
+        (gateway_names - database_urls.keys).each do |gateway_name|
+          url = build_database_url_from_env(env_var_prefix, gateway_name)
+          database_urls[gateway_name] = url if url
+        end
+
         if Hanami.env?(:test)
           database_urls.transform_values! { Hanami::DB::Testing.database_url(_1) }
         end
 
         database_urls
+      end
+
+      # ENV vars (without any slice prefix or gateway name suffix) from which a database URL can be
+      # built when no complete URL is given.
+      #
+      # @api private
+      DATABASE_URL_COMPONENT_VARS = %w[
+        DATABASE_ADAPTER
+        DATABASE_USER
+        DATABASE_PASSWORD
+        DATABASE_HOST
+        DATABASE_PORT
+        DATABASE_NAME
+      ].freeze
+      private_constant :DATABASE_URL_COMPONENT_VARS
+
+      # Database URL schemes for the adapter names given in DATABASE_ADAPTER. Any other adapter
+      # name is used as the scheme as given.
+      #
+      # @api private
+      DATABASE_ADAPTER_SCHEMES = {
+        "mysql" => "mysql2",
+        "postgresql" => "postgres",
+        "sqlite3" => "sqlite"
+      }.freeze
+      private_constant :DATABASE_ADAPTER_SCHEMES
+
+      # Host to use when no DATABASE_HOST is given.
+      #
+      # @api private
+      DEFAULT_DATABASE_HOST = "localhost"
+      private_constant :DEFAULT_DATABASE_HOST
+
+      # Ports to use when no DATABASE_PORT is given, by database URL scheme. Schemes without an
+      # entry here get no port at all.
+      #
+      # @api private
+      DEFAULT_DATABASE_PORTS = {
+        "mysql2" => "3306",
+        "postgres" => "5432"
+      }.freeze
+      private_constant :DEFAULT_DATABASE_PORTS
+
+      # Returns the names of the gateways with component ENV vars carrying a gateway name suffix,
+      # such as DATABASE_HOST__EXTRA.
+      def detect_gateway_names_from_env_components(env_var_prefix)
+        DATABASE_URL_COMPONENT_VARS.flat_map { |var|
+          gateway_prefix = "#{env_var_prefix}#{var}__"
+
+          ENV.keys
+            .select { _1.start_with?(gateway_prefix) }
+            .map { _1.delete_prefix(gateway_prefix).downcase.to_sym }
+        }.uniq
+      end
+
+      # Builds the given gateway's database URL from component ENV vars, such as DATABASE_HOST and
+      # DATABASE_PORT.
+      #
+      # The host defaults to localhost, and the port to the adapter's default port, so an adapter
+      # alone is enough to connect to a database running locally.
+      #
+      # Returns nil if no components are given, or if no adapter is given.
+      def build_database_url_from_env(env_var_prefix, gateway_name)
+        gateway_suffix = "__#{gateway_name.to_s.upcase}" unless gateway_name == :default
+
+        components = DATABASE_URL_COMPONENT_VARS.to_h { |var|
+          [var, database_url_component_from_env(var, env_var_prefix, gateway_suffix)]
+        }
+
+        return if components.values.all?(&:nil?)
+
+        adapter = components["DATABASE_ADAPTER"]
+        return unless adapter
+
+        scheme = DATABASE_ADAPTER_SCHEMES.fetch(adapter, adapter)
+        components["DATABASE_HOST"] ||= DEFAULT_DATABASE_HOST
+        components["DATABASE_PORT"] ||= DEFAULT_DATABASE_PORTS[scheme]
+
+        name = components["DATABASE_NAME"]
+
+        "#{scheme}://#{database_url_authority(components)}#{"/#{name}" if name}"
+      end
+
+      # Returns the value of the first ENV var giving the component, from the most to the least
+      # specific:
+      #
+      #   {SLICE_NAME__}DATABASE_HOST{__GATEWAY_NAME}
+      #   {SLICE_NAME__}DATABASE_HOST
+      #   DATABASE_HOST__GATEWAY_NAME
+      #   DATABASE_HOST
+      #
+      # This way, gateways and slices can share the components they have in common, and give their
+      # own values for the components they do not.
+      def database_url_component_from_env(var, env_var_prefix, gateway_suffix)
+        vars = [
+          "#{env_var_prefix}#{var}#{gateway_suffix}",
+          "#{env_var_prefix}#{var}",
+          "#{var}#{gateway_suffix}",
+          var
+        ].uniq
+
+        vars.each do |env_var|
+          value = ENV[env_var]
+          return value unless value.nil? || value.empty?
+        end
+
+        nil
+      end
+
+      def database_url_authority(components)
+        userinfo = database_url_userinfo(components)
+        port = components["DATABASE_PORT"]
+
+        "#{"#{userinfo}@" if userinfo}#{components["DATABASE_HOST"]}#{":#{port}" if port}"
+      end
+
+      def database_url_userinfo(components)
+        user = components["DATABASE_USER"]
+        password = components["DATABASE_PASSWORD"]
+
+        if user && password
+          "#{escape_database_url_component(user)}:#{escape_database_url_component(password)}"
+        elsif user
+          escape_database_url_component(user)
+        elsif password
+          ":#{escape_database_url_component(password)}"
+        end
+      end
+
+      def escape_database_url_component(value)
+        value.gsub(/[^A-Za-z0-9\-._~]/) { |char| char.bytes.map { format("%%%02X", _1) }.join }
       end
 
       # @api private

--- a/spec/integration/db/database_url_from_env_spec.rb
+++ b/spec/integration/db/database_url_from_env_spec.rb
@@ -1,0 +1,348 @@
+# frozen_string_literal: true
+
+RSpec.describe "DB / Database URL from ENV components", :app_integration do
+  subject(:database_urls) {
+    Hanami.app.container.providers[:db].source.finalize_config.database_urls
+  }
+
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  def with_app(&blk)
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/.keep", ""
+
+      blk.call
+    end
+  end
+
+  it "prefers DATABASE_URL when it is given alongside component ENV vars" do
+    with_app do
+      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_PORT"] = "5432"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "sqlite://db/app.sqlite3")
+    end
+  end
+
+  it "builds the URL from all the component ENV vars" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "postgres"
+      ENV["DATABASE_USER"] = "hanami"
+      ENV["DATABASE_PASSWORD"] = "s3cret"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_PORT"] = "5432"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      allow(Hanami).to receive(:bundled?).and_call_original
+      allow(Hanami).to receive(:bundled?).with("pg").and_return(true)
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(
+        default: "postgres://hanami:s3cret@localhost:5432/app_development"
+      )
+    end
+  end
+
+  it "escapes the user and password" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_USER"] = "user@example.com"
+      ENV["DATABASE_PASSWORD"] = "p@ss word"
+      ENV["DATABASE_HOST"] = "localhost"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(
+        default: "sqlite://user%40example.com:p%40ss%20word@localhost"
+      )
+    end
+  end
+
+  it "omits the user, password and database name when they are not given" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_PORT"] = "5432"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "sqlite://localhost:5432")
+    end
+  end
+
+  it "omits the password when only the user is given" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_USER"] = "hanami"
+      ENV["DATABASE_HOST"] = "localhost"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "sqlite://hanami@localhost")
+    end
+  end
+
+  it "derives the scheme from an aliased adapter name" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "postgresql"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      allow(Hanami).to receive(:bundled?).and_call_original
+      allow(Hanami).to receive(:bundled?).with("pg").and_return(true)
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "postgres://localhost:5432/app_development")
+    end
+  end
+
+  it "derives the mysql2 scheme from a \"mysql\" adapter" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "mysql"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      allow(Hanami).to receive(:bundled?).and_call_original
+      allow(Hanami).to receive(:bundled?).with("mysql2").and_return(true)
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "mysql2://localhost:3306/app_development")
+    end
+  end
+
+  it "derives the sqlite scheme from a \"sqlite3\" adapter" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "sqlite3"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "sqlite://localhost/app_development")
+    end
+  end
+
+  it "uses an unrecognised adapter name as the scheme" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "trilogy"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "trilogy://localhost/app_development")
+    end
+  end
+
+  it "builds gateway URLs from component ENV vars with gateway name suffixes" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_NAME"] = "app_development"
+      ENV["DATABASE_HOST__EXTRA"] = "extra.example.com"
+      ENV["DATABASE_NAME__EXTRA"] = "extra_development"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(
+        default: "sqlite://localhost/app_development",
+        extra: "sqlite://extra.example.com/extra_development"
+      )
+    end
+  end
+
+  it "builds gateway URLs from the components shared with the default gateway" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_USER"] = "hanami"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_PORT"] = "5432"
+      ENV["DATABASE_NAME"] = "app_development"
+      ENV["DATABASE_NAME__EXTRA"] = "extra_development"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(
+        default: "sqlite://hanami@localhost:5432/app_development",
+        extra: "sqlite://hanami@localhost:5432/extra_development"
+      )
+    end
+  end
+
+  it "prefers a gateway's DATABASE_URL when it is given alongside component ENV vars" do
+    with_app do
+      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL__EXTRA"] = "sqlite://db/extra.sqlite3"
+      ENV["DATABASE_HOST__EXTRA"] = "extra.example.com"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(
+        default: "sqlite://db/app.sqlite3",
+        extra: "sqlite://db/extra.sqlite3"
+      )
+    end
+  end
+
+  it "builds a gateway URL from the default host and port when only its name is given" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_NAME"] = "app_development"
+      ENV["DATABASE_NAME__EXTRA"] = "extra_development"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(
+        default: "sqlite://localhost/app_development",
+        extra: "sqlite://localhost/extra_development"
+      )
+    end
+  end
+
+  it "does not build a gateway URL when no adapter is given for the gateway" do
+    with_app do
+      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_NAME__EXTRA"] = "extra_development"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "sqlite://db/app.sqlite3")
+    end
+  end
+
+  it "builds the URL from slice-prefixed component ENV vars" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/.keep", ""
+      write "slices/admin/relations/.keep", ""
+
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_HOST"] = "app.example.com"
+      ENV["ADMIN__DATABASE_HOST"] = "admin.example.com"
+      ENV["ADMIN__DATABASE_NAME"] = "admin_development"
+
+      require "hanami/prepare"
+
+      admin_database_urls =
+        Admin::Slice.container.providers[:db].source.finalize_config.database_urls
+
+      expect(database_urls).to eq(default: "sqlite://app.example.com")
+      expect(admin_database_urls).to eq(default: "sqlite://admin.example.com/admin_development")
+    end
+  end
+
+  it "builds slice gateway URLs from slice-prefixed, gateway-suffixed component ENV vars" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "app/relations/.keep", ""
+      write "slices/admin/relations/.keep", ""
+
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_HOST"] = "app.example.com"
+      ENV["ADMIN__DATABASE_HOST"] = "admin.example.com"
+      ENV["ADMIN__DATABASE_NAME__SPECIAL"] = "admin_special_development"
+      ENV["ADMIN__DATABASE_HOST__OTHER"] = "other.example.com"
+
+      require "hanami/prepare"
+
+      admin_database_urls =
+        Admin::Slice.container.providers[:db].source.finalize_config.database_urls
+
+      expect(database_urls).to eq(default: "sqlite://app.example.com")
+      expect(admin_database_urls).to eq(
+        default: "sqlite://admin.example.com",
+        special: "sqlite://admin.example.com/admin_special_development",
+        other: "sqlite://other.example.com"
+      )
+    end
+  end
+
+  it "defaults the host to localhost and the port to the adapter's default port" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "postgres"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      allow(Hanami).to receive(:bundled?).and_call_original
+      allow(Hanami).to receive(:bundled?).with("pg").and_return(true)
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "postgres://localhost:5432/app_development")
+    end
+  end
+
+  it "omits the port for an adapter without a default port" do
+    with_app do
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_USER"] = "hanami"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "sqlite://hanami@localhost/app_development")
+    end
+  end
+
+  it "raises an error when no adapter is given" do
+    with_app do
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      require "hanami/prepare"
+
+      expect { database_urls }.to raise_error(Hanami::ComponentLoadError, /database_url/)
+    end
+  end
+
+  it "transforms the built URL in test mode" do
+    with_app do
+      ENV["HANAMI_ENV"] = "test"
+      ENV["DATABASE_ADAPTER"] = "sqlite"
+      ENV["DATABASE_HOST"] = "localhost"
+      ENV["DATABASE_NAME"] = "app_development"
+
+      require "hanami/prepare"
+
+      expect(database_urls).to eq(default: "sqlite://localhost/app_test")
+    end
+  end
+end


### PR DESCRIPTION
This change makes Hanami build a database URL from its component environment variables. If `DATABASE_URL` is set, behavior stays the same. If it is not set but the component variables are, Hanami builds the URL from them.

Valid components are:

- `DATABASE_ADAPTER` (such as postgres, mysql2, sqlite)(**required**)
- `DATABASE_HOST` (**defaults to "localhost"**)
- `DATABASE_NAME`
- `DATABASE_PASSWORD`
- `DATABASE_PORT` (**defaults to the appropriate port for the given adapter**)
- `DATABASE_USER`

## Why

Many environments, such as docker, expect their own connection variables (`POSTGRES_PASSWORD`, `POSTGRES_USER`, and so on). Docker compose handles this well through its variable syntax:

```yaml
x-database-password: &database-password ${DATABASE_PASSWORD:-password}
x-database-user: &database-user ${DATABASE_USER:-postgres}

services:
  postgres:
    # ...
    environment:
        POSTGRES_PASSWORD: *database-password
        POSTGRES_USER: *database-user
```

But Hanami has always expected a `DATABASE_URL`. This makes environments like docker conflict with Hanami, because you must keep both sets of variables in sync. To change `DATABASE_PASSWORD`, you would have to update both `DATABASE_PASSWORD` and `DATABASE_URL`.

Hanami does offer a workaround today:

```ruby
Hanami.app.configure_provider :db do
  database = case Hanami.env
             when :development then "blog_development"
             when :test then "blog_test"
             else "blog"

  settings = {
    database:,
    host: ENV.fetch("DATABASE_HOST", "localhost"),
    password: ENV.fetch("DATABASE_PASSWORD", "password"),
    port: ENV.fetch("DATABASE_PORT", 5432),
    user: ENV.fetch("DATABASE_USER", "postgres"),
  }

  config.gateway :default do |gateway|
    gateway.database_url = format("postgres://%<user>s:%<password>s@%<host>s:%<port>s/%<database>s", settings)
  end
end
```

But writing this config by hand is a poor experience for our users.