### PR TITLE
Add Hanami::ResolvableError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Added
 
+- Add `Hanami::ResolvableError`, letting an error describe how to fix it. Include the module and declare resolutions; the development error page renders a card for each, showing a command to copy, a snippet to paste or a list to work through. A resolution declaring `run` also gets a button that runs it. (@afomera in #1622)
+
 ### Changed
 
 ### Deprecated

--- a/lib/hanami/resolvable_error.rb
+++ b/lib/hanami/resolvable_error.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+module Hanami
+  # Lets an error describe how to fix it.
+  #
+  # An error that knows what went wrong usually also knows what to do about it. Include this in an
+  # error class and declare one or more resolutions; the development error page renders a card for
+  # each, and runs the ones that can be run.
+  #
+  #     class MissingCredentialError < StandardError
+  #       include Hanami::ResolvableError
+  #
+  #       attr_reader :key
+  #
+  #       def initialize(key)
+  #         @key = key
+  #         super("#{key} is not set")
+  #       end
+  #
+  #       resolution "Add it to .env.local" do
+  #         snippet "#{key}="
+  #         note "Restart the server afterwards."
+  #       end
+  #     end
+  #
+  # A resolution declaring `run` gets a button on the error page. One without it is guidance: a
+  # command to copy, a snippet to paste, a list to work through. Guidance covers most of what
+  # makes an error page useful and requires none of the machinery that executing code does, so
+  # reach for it first and add `run` only where there is something safe to automate.
+  #
+  #     class NoSeedDataError < StandardError
+  #       include Hanami::ResolvableError
+  #
+  #       resolution "Load the seed data" do
+  #         command "bundle exec hanami db seed"    # what to type by hand
+  #         run { |context| load context.app.root.join("config/db/seeds.rb").to_s }
+  #       end
+  #     end
+  #
+  # A resolution carrying both `run` and `command` is one fix offered two ways, not two competing
+  # fixes.
+  #
+  # ## The underlying convention
+  #
+  # This module is a convenience, not a requirement. The error page reads a duck-typed convention:
+  # an error is resolvable if it responds to `#resolutions`, returning objects that answer `#name`
+  # and any of `#call`, `#destructive?`, `#command`, `#snippet`, `#items` and `#note`.
+  #
+  # Anything satisfying that is resolvable with or without this module, which is what lets gems
+  # that do not depend on `hanami` offer resolutions of their own.
+  #
+  # @api public
+  # @since 3.1.0
+  module ResolvableError
+    # A resolution the error page can run.
+    #
+    # @api public
+    # @since 3.1.0
+    Runnable = Struct.new(
+      :name, :destructive, :command, :snippet, :items, :note, :error, :runner, keyword_init: true
+    ) do
+      # @api public
+      # @since 3.1.0
+      def destructive? = !!destructive
+
+      # Runs against the error, so the block reads the error's own facts.
+      #
+      # @api public
+      # @since 3.1.0
+      def call(context) = error.instance_exec(context, &runner)
+    end
+
+    # A resolution that only explains.
+    #
+    # Deliberately defines no `#call`: that is how the error page knows not to offer a button.
+    # Reporting a resolution as runnable and then having nothing to run would be worse than not
+    # offering it.
+    #
+    # @api public
+    # @since 3.1.0
+    Guidance = Struct.new(:name, :command, :snippet, :items, :note, keyword_init: true)
+
+    # @api private
+    # @since 3.1.0
+    Definition = Struct.new(:name, :destructive, :block, keyword_init: true)
+
+    # Collects one resolution's content.
+    #
+    # Anything this does not define is forwarded to the error, so a declaration can read the
+    # error's state directly even though it is written in the class body, where no instance
+    # exists yet.
+    #
+    # @api private
+    # @since 3.1.0
+    class Builder
+      # @api private
+      # @since 3.1.0
+      def initialize(error)
+        @error = error
+        @content = {items: []}
+      end
+
+      # @api public
+      # @since 3.1.0
+      def command(value) = @content[:command] = value
+
+      # @api public
+      # @since 3.1.0
+      def snippet(value) = @content[:snippet] = value
+
+      # @api public
+      # @since 3.1.0
+      def items(value) = @content[:items] = Array(value)
+
+      # @api public
+      # @since 3.1.0
+      def note(value) = @content[:note] = value
+
+      # Declaring this is what makes a resolution runnable.
+      #
+      # @api public
+      # @since 3.1.0
+      def run(&block) = @content[:runner] = block
+
+      # @api private
+      # @since 3.1.0
+      def to_h = @content
+
+      private
+
+      # @api private
+      # @since 3.1.0
+      def method_missing(name, ...)
+        return @error.public_send(name, ...) if @error.respond_to?(name)
+
+        super
+      end
+
+      # @api private
+      # @since 3.1.0
+      def respond_to_missing?(name, include_private = false)
+        @error.respond_to?(name) || super
+      end
+    end
+
+    # @api private
+    # @since 3.1.0
+    module ClassMethods
+      # Declares a resolution.
+      #
+      # The block is evaluated when the error page asks, not now, so it can read whatever the
+      # error was raised with.
+      #
+      # @param name [String] card heading, and button label when runnable
+      # @param destructive [Boolean] whether the page should require a confirming second click
+      #
+      # @return [Array<Definition>]
+      #
+      # @api public
+      # @since 3.1.0
+      def resolution(name, destructive: false, &block)
+        resolution_definitions << Definition.new(
+          name: name, destructive: destructive, block: block
+        )
+      end
+
+      # @return [Array<Definition>]
+      #
+      # @api private
+      # @since 3.1.0
+      def resolution_definitions
+        @resolution_definitions ||= []
+      end
+
+      # Copied rather than shared, so a subclass declaring a resolution cannot alter its parent's.
+      #
+      # @api private
+      # @since 3.1.0
+      def inherited(subclass)
+        super
+        subclass.instance_variable_set(:@resolution_definitions, resolution_definitions.dup)
+      end
+    end
+
+    # @api private
+    # @since 3.1.0
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    # The error's resolutions, in the order they were declared.
+    #
+    # @return [Array<Runnable, Guidance>]
+    #
+    # @api public
+    # @since 3.1.0
+    def resolutions
+      self.class.resolution_definitions.map { |definition| build_resolution(definition) }
+    end
+
+    private
+
+    # @api private
+    # @since 3.1.0
+    def build_resolution(definition)
+      builder = Builder.new(self)
+      builder.instance_eval(&definition.block) if definition.block
+      content = builder.to_h
+      runner = content.delete(:runner)
+
+      return Guidance.new(name: definition.name, **content) unless runner
+
+      Runnable.new(
+        name: definition.name, destructive: definition.destructive,
+        error: self, runner: runner, **content
+      )
+    end
+  end
+end

--- a/spec/integration/web/render_detailed_errors_spec.rb
+++ b/spec/integration/web/render_detailed_errors_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe "Web / Rendering detailed errors", :app_integration do
     end
   end
 
+  # These assert against the page's `data-webconsole-*` hooks rather than its markup, so that
+  # restyling the error page does not break this spec.
   describe "HTML request" do
     it "renders a detailed HTML error page" do
       get "/error", {}, "HTTP_ACCEPT" => "text/html"
@@ -53,8 +55,11 @@ RSpec.describe "Web / Rendering detailed errors", :app_integration do
       expect(last_response.status).to eq 500
 
       html = Capybara.string(last_response.body)
-      expect(html).to have_selector("header", text: "RuntimeError at /error")
-      expect(html).to have_selector("ul.frames li.application", text: "app/actions/error.rb")
+      expect(html).to have_selector("[data-webconsole-exception-class]", text: "RuntimeError")
+      expect(html).to have_selector("[data-webconsole-request-summary]", text: "/error")
+      expect(html).to have_selector(
+        "[data-webconsole-frame-kind='app']", text: "app/actions/error.rb"
+      )
     end
 
     it "renders a detailed HTML error page and returns a 404 status for a not found error" do
@@ -63,26 +68,41 @@ RSpec.describe "Web / Rendering detailed errors", :app_integration do
       expect(last_response.status).to eq 404
 
       html = Capybara.string(last_response.body)
-      expect(html).to have_selector("header", text: "Hanami::Router::NotFoundError at /__not_found__")
+      expect(html).to have_selector(
+        "[data-webconsole-exception-class]", text: "Hanami::Router::NotFoundError"
+      )
     end
   end
 
   describe "Other request types" do
     it "renders a detailed error page in text" do
+      get "/error", {}, "HTTP_ACCEPT" => "text/plain"
+
+      expect(last_response.status).to eq 500
+      expect(last_response.headers["content-type"]).to include "text/plain"
+
+      expect(last_response.body).to include "## RuntimeError"
+      expect(last_response.body).to match %r{### Backtrace.+app/actions/error\.rb}m
+    end
+
+    it "renders a detailed error page as JSON" do
       get "/error", {}, "HTTP_ACCEPT" => "application/json"
 
       expect(last_response.status).to eq 500
+      expect(last_response.headers["content-type"]).to include "application/json"
 
-      expect(last_response.body).to include "RuntimeError at /error"
-      expect(last_response.body).to match %r{App backtrace.+app/actions/error.rb}m
+      body = JSON.parse(last_response.body)
+      expect(body["error"]).to eq "RuntimeError"
+      expect(body["status"]).to eq 500
+      expect(body["backtrace"].join("\n")).to include "app/actions/error.rb"
     end
 
     it "renders a detailed error page in text and returns a 404 status for a not found error" do
-      get "/__not_found__", {}, "HTTP_ACCEPT" => "text/html"
+      get "/__not_found__", {}, "HTTP_ACCEPT" => "text/plain"
 
       expect(last_response.status).to eq 404
 
-      expect(last_response.body).to include "Hanami::Router::NotFoundError at /__not_found__"
+      expect(last_response.body).to include "## Hanami::Router::NotFoundError"
     end
   end
 

--- a/spec/unit/hanami/resolvable_error_spec.rb
+++ b/spec/unit/hanami/resolvable_error_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::ResolvableError do
+  let(:context) { Struct.new(:app, :slice, :request).new(:the_app, nil, nil) }
+
+  describe "guidance" do
+    subject(:error) do
+      Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        def key = "STRIPE_API_KEY"
+
+        resolution "Add it to .env.local" do
+          snippet "STRIPE_API_KEY="
+          note "Restart afterwards."
+        end
+      end.new("boom")
+    end
+
+    it "builds a resolution with the declared content" do
+      resolution = error.resolutions.first
+
+      expect(resolution.name).to eq("Add it to .env.local")
+      expect(resolution.snippet).to eq("STRIPE_API_KEY=")
+      expect(resolution.note).to eq("Restart afterwards.")
+    end
+
+    # This is the entire signal the error page uses to decide whether to offer a button, so a
+    # guidance resolution reporting itself as callable would put a button on nothing.
+    it "does not respond to #call" do
+      expect(error.resolutions.first).not_to respond_to(:call)
+    end
+
+    it "defaults items to an empty array" do
+      expect(error.resolutions.first.items).to eq([])
+    end
+  end
+
+  describe "runnable" do
+    subject(:error) do
+      Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        def pending = ["20250811103012_create_books.rb"]
+
+        resolution "Run pending migrations" do
+          command "bundle exec hanami db migrate"
+          items pending
+          run { |context| "migrated for #{context.app}" }
+        end
+      end.new("boom")
+    end
+
+    it "responds to #call once a run block is declared" do
+      expect(error.resolutions.first).to respond_to(:call)
+    end
+
+    it "runs the block against the error, with the context" do
+      expect(error.resolutions.first.call(context)).to eq("migrated for the_app")
+    end
+
+    it "carries a command alongside the button, as one fix offered two ways" do
+      resolution = error.resolutions.first
+
+      expect(resolution.command).to eq("bundle exec hanami db migrate")
+      expect(resolution).to respond_to(:call)
+    end
+
+    it "is not destructive by default" do
+      expect(error.resolutions.first).not_to be_destructive
+    end
+  end
+
+  describe "reading the error's own state" do
+    it "forwards anything the builder does not define to the error" do
+      error = Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        attr_reader :names
+
+        def initialize(names)
+          @names = names
+          super("boom")
+        end
+
+        resolution "Add them" do
+          items names
+          snippet names.map { "#{_1}=" }.join("\n")
+        end
+      end.new(%w[A B])
+
+      resolution = error.resolutions.first
+
+      expect(resolution.items).to eq(%w[A B])
+      expect(resolution.snippet).to eq("A=\nB=")
+    end
+
+    # NameError rather than NoMethodError: a bare identifier could be a local variable, so Ruby
+    # raises the parent class. Both carry did_you_mean suggestions, which is the part that
+    # matters when someone typos in a declaration.
+    it "raises for something neither the builder nor the error defines" do
+      error = Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        resolution("Broken") { nonsense }
+      end.new("boom")
+
+      expect { error.resolutions }.to raise_error(NameError, /nonsense/)
+    end
+
+    # Declarations sit in the class body, where no instance exists, so they cannot be evaluated
+    # until an error is actually raised.
+    it "evaluates the block per instance, not once at declaration" do
+      klass = Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        attr_reader :value
+
+        def initialize(value)
+          @value = value
+          super("boom")
+        end
+
+        resolution("Show it") { note value }
+      end
+
+      expect(klass.new("first").resolutions.first.note).to eq("first")
+      expect(klass.new("second").resolutions.first.note).to eq("second")
+    end
+  end
+
+  describe "destructive resolutions" do
+    subject(:error) do
+      Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        resolution "Roll back", destructive: true do
+          run { "rolled back" }
+        end
+      end.new("boom")
+    end
+
+    it "carries the flag through" do
+      expect(error.resolutions.first).to be_destructive
+    end
+  end
+
+  describe "several resolutions" do
+    subject(:error) do
+      Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        resolution("First") { note "one" }
+        resolution("Second") { run { "two" } }
+        resolution("Third") { note "three" }
+      end.new("boom")
+    end
+
+    it "keeps declaration order" do
+      expect(error.resolutions.map(&:name)).to eq(%w[First Second Third])
+    end
+
+    it "mixes guidance and runnable freely" do
+      expect(error.resolutions.map { _1.respond_to?(:call) }).to eq([false, true, false])
+    end
+  end
+
+  describe "inheritance" do
+    let(:parent) do
+      Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        resolution("Inherited") { note "from the parent" }
+      end
+    end
+
+    let(:child) do
+      Class.new(parent) do
+        resolution("Added") { note "from the child" }
+      end
+    end
+
+    it "inherits the parent's resolutions and appends its own" do
+      expect(child.new("boom").resolutions.map(&:name)).to eq(%w[Inherited Added])
+    end
+
+    it "does not alter the parent when the child declares one" do
+      child # force the subclass to be defined
+
+      expect(parent.new("boom").resolutions.map(&:name)).to eq(%w[Inherited])
+    end
+  end
+
+  describe "an error with no resolutions" do
+    it "returns an empty array rather than nil" do
+      error = Class.new(StandardError) { include Hanami::ResolvableError }.new("boom")
+
+      expect(error.resolutions).to eq([])
+    end
+  end
+
+  describe "the underlying convention" do
+    # The error page never sees this module. It reads `#resolutions` and duck-types what comes
+    # back, which is what lets gems that cannot depend on hanami offer resolutions too.
+    it "produces objects answering the duck-typed contract" do
+      error = Class.new(StandardError) do
+        include Hanami::ResolvableError
+
+        resolution("Fix it") { run { "done" } }
+      end.new("boom")
+
+      resolution = error.resolutions.first
+
+      expect(error).to respond_to(:resolutions)
+      expect(resolution).to respond_to(:name)
+      expect(resolution).to respond_to(:call)
+      expect(resolution).to respond_to(:destructive?)
+    end
+  end
+end


### PR DESCRIPTION
Building on top of the work in the hanami-webconsole that landed in main tonight, introducing "ResolvableErrors". 

This is an app-level include that applications can use to help provide errors with resolution recommendations or steps. IF they wanted to 

  Lets an error describe how to fix it. Include the module and declare
  resolutions; the development error page renders a card for each, and
  runs the ones that can be run.

```ruby
class MissingCredentialError < StandardError
  include Hanami::ResolvableError

  resolution "Add it to .env.local" do
    snippet "#{key}="
    note "Restart the server afterwards."
  end
end
```

or one with running something (which will provide a button on the error page)

```ruby
class NoSeedDataError < StandardError
  include Hanami::ResolvableError

  resolution "Load the seed data" do
    command "bundle exec hanami db seed" # what to type by hand
    run { |context| load context.app.root.join("config/db/seeds.rb").to_s }
  end
end
```

  A resolution declaring `run` gets a button. One without it is guidance:
  a command to copy, a snippet to paste, a list to work through. Guidance
  covers most of what makes an error page useful and needs none of the
  machinery that executing code does, so it is the default shape.

  This is a convenience, not a requirement. hanami-webconsole reads a
  duck-typed convention rather than this module, so gems that do not
  depend on hanami can offer resolutions too.
  
  
  `items` inside of a resolution is an array and will provide a list of _ahem_ items that is displayed as a type of bullet list. Snippet is a code sample. Note is a set of text Ala a paragraph. 