### PR TITLE
Pass through a slice to the NotFound Errors for routing

### DIFF
--- a/lib/hanami/extensions/router/errors.rb
+++ b/lib/hanami/extensions/router/errors.rb
@@ -18,8 +18,21 @@ module Hanami
       # @since 2.1.0
       attr_reader :env
 
-      def initialize(env)
+      # Returns the slice whose router could not match the request.
+      #
+      # Its {Hanami::Slice::ClassMethods#router router} answers `#routes`, which is how error
+      # handling above the router (such as a detailed error page) can list the routes that were
+      # available.
+      #
+      # @return [Hanami::Slice, nil] the slice, or nil when the error was raised outside a slice
+      #
+      # @api public
+      # @since 3.1.0
+      attr_reader :slice
+
+      def initialize(env, slice: nil)
         @env = env
+        @slice = slice
 
         message = "No route found for #{env["REQUEST_METHOD"]} #{env["PATH_INFO"]}"
         super(message)
@@ -46,9 +59,20 @@ module Hanami
       # @since 2.1.0
       attr_reader :allowed_methods
 
-      def initialize(env, allowed_methods)
+      # Returns the slice whose router matched the path but not the method.
+      #
+      # @return [Hanami::Slice, nil] the slice, or nil when the error was raised outside a slice
+      #
+      # @see NotFoundError#slice
+      #
+      # @api public
+      # @since 3.1.0
+      attr_reader :slice
+
+      def initialize(env, allowed_methods, slice: nil)
         @env = env
         @allowed_methods = allowed_methods
+        @slice = slice
 
         message = "Only #{allowed_methods.join(', ')} requests are allowed at #{env["PATH_INFO"]}"
         super(message)

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -1107,8 +1107,8 @@ module Hanami
 
         error_handlers = {}.tap do |hsh|
           if render_errors || render_detailed_errors
-            hsh[:not_allowed] = ROUTER_NOT_ALLOWED_HANDLER
-            hsh[:not_found] = ROUTER_NOT_FOUND_HANDLER
+            hsh[:not_allowed] = router_not_allowed_handler(slice)
+            hsh[:not_found] = router_not_found_handler(slice)
           end
         end
 
@@ -1168,15 +1168,20 @@ module Hanami
         config.render_detailed_errors && Hanami.bundled?("hanami-webconsole")
       end
 
-      ROUTER_NOT_ALLOWED_HANDLER = -> env, allowed_http_methods {
-        raise Hanami::Router::NotAllowedError.new(env, allowed_http_methods)
-      }.freeze
-      private_constant :ROUTER_NOT_ALLOWED_HANDLER
+      # The errors raised for unmatched requests carry the slice that was routing them, so that
+      # error handling further up the stack (such as the detailed error page rendered by
+      # hanami-webconsole) can reach its routes.
+      def router_not_allowed_handler(slice)
+        -> env, allowed_http_methods {
+          raise Hanami::Router::NotAllowedError.new(env, allowed_http_methods, slice: slice)
+        }.freeze
+      end
 
-      ROUTER_NOT_FOUND_HANDLER = -> env {
-        raise Hanami::Router::NotFoundError.new(env)
-      }.freeze
-      private_constant :ROUTER_NOT_FOUND_HANDLER
+      def router_not_found_handler(slice)
+        -> env {
+          raise Hanami::Router::NotFoundError.new(env, slice: slice)
+        }.freeze
+      end
 
       def assets_dir?
         source_path.join("assets").directory?

--- a/spec/integration/web/render_detailed_errors_spec.rb
+++ b/spec/integration/web/render_detailed_errors_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe "Web / Rendering detailed errors", :app_integration do
     end
   end
 
+  # These assert against the page's `data-webconsole-*` hooks rather than its markup, so that
+  # restyling the error page does not break this spec.
   describe "HTML request" do
     it "renders a detailed HTML error page" do
       get "/error", {}, "HTTP_ACCEPT" => "text/html"
@@ -53,8 +55,11 @@ RSpec.describe "Web / Rendering detailed errors", :app_integration do
       expect(last_response.status).to eq 500
 
       html = Capybara.string(last_response.body)
-      expect(html).to have_selector("header", text: "RuntimeError at /error")
-      expect(html).to have_selector("ul.frames li.application", text: "app/actions/error.rb")
+      expect(html).to have_selector("[data-webconsole-exception-class]", text: "RuntimeError")
+      expect(html).to have_selector("[data-webconsole-request-summary]", text: "/error")
+      expect(html).to have_selector(
+        "[data-webconsole-frame-kind='app']", text: "app/actions/error.rb"
+      )
     end
 
     it "renders a detailed HTML error page and returns a 404 status for a not found error" do
@@ -63,26 +68,41 @@ RSpec.describe "Web / Rendering detailed errors", :app_integration do
       expect(last_response.status).to eq 404
 
       html = Capybara.string(last_response.body)
-      expect(html).to have_selector("header", text: "Hanami::Router::NotFoundError at /__not_found__")
+      expect(html).to have_selector(
+        "[data-webconsole-exception-class]", text: "Hanami::Router::NotFoundError"
+      )
     end
   end
 
   describe "Other request types" do
     it "renders a detailed error page in text" do
+      get "/error", {}, "HTTP_ACCEPT" => "text/plain"
+
+      expect(last_response.status).to eq 500
+      expect(last_response.headers["content-type"]).to include "text/plain"
+
+      expect(last_response.body).to include "## RuntimeError"
+      expect(last_response.body).to match %r{### Backtrace.+app/actions/error\.rb}m
+    end
+
+    it "renders a detailed error page as JSON" do
       get "/error", {}, "HTTP_ACCEPT" => "application/json"
 
       expect(last_response.status).to eq 500
+      expect(last_response.headers["content-type"]).to include "application/json"
 
-      expect(last_response.body).to include "RuntimeError at /error"
-      expect(last_response.body).to match %r{App backtrace.+app/actions/error.rb}m
+      body = JSON.parse(last_response.body)
+      expect(body["error"]).to eq "RuntimeError"
+      expect(body["status"]).to eq 500
+      expect(body["backtrace"].join("\n")).to include "app/actions/error.rb"
     end
 
     it "renders a detailed error page in text and returns a 404 status for a not found error" do
-      get "/__not_found__", {}, "HTTP_ACCEPT" => "text/html"
+      get "/__not_found__", {}, "HTTP_ACCEPT" => "text/plain"
 
       expect(last_response.status).to eq 404
 
-      expect(last_response.body).to include "Hanami::Router::NotFoundError at /__not_found__"
+      expect(last_response.body).to include "## Hanami::Router::NotFoundError"
     end
   end
 

--- a/spec/integration/web/router_errors_spec.rb
+++ b/spec/integration/web/router_errors_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+RSpec.describe "Web / Router errors", :app_integration do
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File.new("/dev/null", "w")
+            config.render_errors = true
+          end
+        end
+      RUBY
+
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Routes
+            get "/books", to: "books.index", as: :books
+            post "/books", to: "books.create"
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+    end
+  end
+
+  let(:router) { Hanami.app.router }
+
+  describe "not found" do
+    subject(:error) do
+      router.call(Rack::MockRequest.env_for("/missing", method: "GET"))
+    rescue Hanami::Router::NotFoundError => exception
+      exception
+    end
+
+    it "carries the slice that was routing the request" do
+      expect(error.slice).to be Hanami.app
+    end
+
+    it "makes the slice's routes available" do
+      routes = error.slice.router.routes.map { |route| "#{route.http_method} #{route.path}" }
+
+      expect(routes).to include("GET /books", "POST /books")
+    end
+  end
+
+  describe "not allowed" do
+    subject(:error) do
+      router.call(Rack::MockRequest.env_for("/books", method: "DELETE"))
+    rescue Hanami::Router::NotAllowedError => exception
+      exception
+    end
+
+    it "carries the slice that was routing the request" do
+      expect(error.slice).to be Hanami.app
+    end
+
+    it "carries the allowed methods" do
+      expect(error.allowed_methods).to include("GET", "POST")
+    end
+  end
+end

--- a/spec/unit/hanami/router/errors/not_allowed_error_spec.rb
+++ b/spec/unit/hanami/router/errors/not_allowed_error_spec.rb
@@ -24,4 +24,14 @@ RSpec.describe(Hanami::Router::NotAllowedError) do
   it "returns the allowed methods" do
     expect(error.allowed_methods).to be allowed_methods
   end
+
+  it "returns no slice by default" do
+    expect(error.slice).to be nil
+  end
+
+  it "returns the slice it was given" do
+    slice = Class.new
+
+    expect(described_class.new(env, allowed_methods, slice: slice).slice).to be slice
+  end
 end

--- a/spec/unit/hanami/router/errors/not_found_error_spec.rb
+++ b/spec/unit/hanami/router/errors/not_found_error_spec.rb
@@ -19,4 +19,14 @@ RSpec.describe(Hanami::Router::NotFoundError) do
   it "returns the env" do
     expect(error.env).to be env
   end
+
+  it "returns no slice by default" do
+    expect(error.slice).to be nil
+  end
+
+  it "returns the slice it was given" do
+    slice = Class.new
+
+    expect(described_class.new(env, slice: slice).slice).to be slice
+  end
 end


### PR DESCRIPTION
Passing through a slice provides the errors and other systems a way to get the routes from the slice router which can then be used to be displayed on the error page down the stack. 

See: https://github.com/hanami/hanami-router/pull/306