### PR TITLE
Add in-place code reloading via `Slice#reload!`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,12 @@ gem "hanami-webconsole", github: "hanami/hanami-webconsole", branch: "main"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
+# In-flight dry-system changes that in-place code reloading depends on: `load` for provider files,
+# and the zeitwerk plugin's `enable_reloading:` option.
+#
+# Remove once dry-rb/dry-system#297 is released.
+gem "dry-system", github: "dry-rb/dry-system", branch: "zeitwerk-enable-reloading"
+
 # For testing settings with types
 gem "dry-types"
 

--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -191,6 +191,26 @@ module Hanami
     #   @since 2.1.0
     setting :render_detailed_errors, default: false
 
+    # @!attribute [rw] code_reloading
+    #   Sets whether the app can be reloaded in place via `Hanami::Slice.reload!`.
+    #
+    #   This is an app-wide setting. Slices copy their config from the app, but only the app's
+    #   value is used: reloading applies to the app and all its slices together.
+    #
+    #   Enabling this makes each slice's Zeitwerk autoloader track the constants it defines, so
+    #   they can be unloaded later. Zeitwerk requires this to be set before the autoloader is set
+    #   up, which means it must be configured before the app is prepared.
+    #
+    #   Defaults to `true` in development mode, `false` in all others.
+    #
+    #   @return [Boolean]
+    #
+    #   @see Hanami::Slice::ClassMethods#reload!
+    #
+    #   @api public
+    #   @since 3.1.0
+    setting :code_reloading, default: false
+
     # @!attribute [rw] render_error_responses
     #   Sets a mapping of exception class names (as strings) to symbolic response status codes used
     #   for rendering error responses.
@@ -364,6 +384,7 @@ module Hanami
       self.root = Dir.pwd
       self.render_errors = (env == :production)
       self.render_detailed_errors = (env == :development)
+      self.code_reloading = (env == :development)
       load_from_env
 
       @actions = load_dependent_config("hanami-action") {

--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -194,12 +194,8 @@ module Hanami
     # @!attribute [rw] code_reloading
     #   Sets whether the app can be reloaded in place via `Hanami::Slice.reload!`.
     #
-    #   This is an app-wide setting. Slices copy their config from the app, but only the app's
-    #   value is used: reloading applies to the app and all its slices together.
-    #
-    #   Enabling this makes each slice's Zeitwerk autoloader track the constants it defines, so
-    #   they can be unloaded later. Zeitwerk requires this to be set before the autoloader is set
-    #   up, which means it must be configured before the app is prepared.
+    #   App-wide: slices copy their config from the app, but only the app's value is used. Must
+    #   be set before the app is prepared.
     #
     #   Defaults to `true` in development mode, `false` in all others.
     #

--- a/lib/hanami/constants.rb
+++ b/lib/hanami/constants.rb
@@ -34,6 +34,18 @@ module Hanami
   private_constant :SLICES_DIR
 
   # @api private
+  SLICE_CLASS_NAME = "Slice"
+  private_constant :SLICE_CLASS_NAME
+
+  # @api private
+  CONTAINER_CONST_NAME = "Container"
+  private_constant :CONTAINER_CONST_NAME
+
+  # @api private
+  DEPS_CONST_NAME = "Deps"
+  private_constant :DEPS_CONST_NAME
+
+  # @api private
   ROUTES_PATH = File.join(CONFIG_DIR, "routes")
   private_constant :ROUTES_PATH
 

--- a/lib/hanami/settings.rb
+++ b/lib/hanami/settings.rb
@@ -138,9 +138,8 @@ module Hanami
 
         slice_settings_path = File.join(slice.root, "#{SETTINGS_PATH}#{RB_EXT}")
 
-        # `load` rather than `require`, so that the file is evaluated again on every prepare and a
-        # reload picks up changes to it. The slice removes the `Settings` constant this defines
-        # when unloading, so the class is defined afresh rather than reopened.
+        # `load`, so the file is evaluated again on each prepare. The slice removes the `Settings`
+        # constant when unloading, so the class is defined afresh rather than reopened.
         load slice_settings_path if File.file?(slice_settings_path)
       end
     end

--- a/lib/hanami/settings.rb
+++ b/lib/hanami/settings.rb
@@ -136,13 +136,12 @@ module Hanami
       def require_slice_settings(slice)
         require "hanami/settings"
 
-        slice_settings_require_path = File.join(slice.root, SETTINGS_PATH)
+        slice_settings_path = File.join(slice.root, "#{SETTINGS_PATH}#{RB_EXT}")
 
-        begin
-          require slice_settings_require_path
-        rescue LoadError => exception
-          raise exception unless exception.path == slice_settings_require_path
-        end
+        # `load` rather than `require`, so that the file is evaluated again on every prepare and a
+        # reload picks up changes to it. The slice removes the `Settings` constant this defines
+        # when unloading, so the class is defined afresh rather than reopened.
+        load slice_settings_path if File.file?(slice_settings_path)
       end
     end
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -986,11 +986,6 @@ module Hanami
         instance_exec(container, &@prepare_container_block) if @prepare_container_block
         container.configured!
 
-        # Zeitwerk only tracks the constants it defines (and so can only unload them later) when
-        # reloading is enabled before `setup`. Both this class and `Hanami::App` call `setup` from
-        # `prepare_autoloader`, so this must happen here, ahead of either. See {ClassMethods#reload!}.
-        autoloader.enable_reloading if code_reloading?
-
         prepare_autoloader
         @autoloader_setup = true
 
@@ -1030,15 +1025,6 @@ module Hanami
         return config.code_reloading unless Hanami.app?
 
         app.config.code_reloading
-      end
-
-      # Returns the realpaths of the slice's provider files, which dry-system `require`s.
-      #
-      # TODO: Remove along with the `$LOADED_FEATURES` handling in `prepare_container_providers`.
-      def provider_file_paths
-        container.config.provider_dirs
-          .flat_map { |dir| Dir[File.join(root, dir, "**", "*#{RB_EXT}")] }
-          .filter_map { |path| File.realpath(path) if File.file?(path) }
       end
 
       def ensure_slice_name
@@ -1094,7 +1080,11 @@ module Hanami
           :zeitwerk,
           loader: autoloader,
           run_setup: false,
-          eager_load: false
+          eager_load: false,
+          # Zeitwerk only tracks the constants it defines (and so can only unload them later) when
+          # reloading is enabled ahead of `setup`. The plugin applies this from its
+          # `after(:configure)` hook, which runs before `prepare_autoloader` calls `setup`.
+          enable_reloading: code_reloading?
         )
       end
 
@@ -1166,18 +1156,10 @@ module Hanami
 
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def prepare_container_providers
-        on_unload do
-          # Stop providers so they can release the resources they hold (database connections, and
-          # so on) before the components holding them are discarded.
-          container.shutdown!
-
-          # Provider files are `require`d by dry-system, so dropping them from `$LOADED_FEATURES`
-          # is what allows them to be evaluated again against the newly built container.
-          #
-          # TODO: Remove once dry-system's `ProviderRegistrar` uses `load` for provider files, as
-          # its `ManifestRegistrar` already does for registrations.
-          provider_file_paths.each { |path| $LOADED_FEATURES.delete(path) }
-        end
+        # Stop providers so they can release the resources they hold (database connections, and so
+        # on) before the components holding them are discarded. dry-system `load`s provider files,
+        # so the freshly built container evaluates them again by itself.
+        on_unload { container.shutdown! }
 
         # Check here for the `routes` definition only, not `router` itself, because the
         # `router` requires the slice to be prepared before it can be loaded, and at this

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -40,10 +40,21 @@ module Hanami
       @_mutex.synchronize do
         subclass.class_eval do
           @_mutex = Mutex.new
-          @autoloader = Zeitwerk::Loader.new
-          @container = Class.new(Dry::System::Container)
+          build_container_and_autoloader
         end
       end
+    end
+
+    # Builds the slice's container and autoloader.
+    #
+    # Called when the slice is first defined, and again by {ClassMethods#reload!}, which discards
+    # the previous pair wholesale rather than attempting to invalidate them in place.
+    #
+    # @api private
+    # @since 3.1.0
+    def self.build_container_and_autoloader
+      @autoloader = Zeitwerk::Loader.new
+      @container = Class.new(Dry::System::Container)
     end
 
     module ClassMethods
@@ -355,6 +366,62 @@ module Hanami
       def shutdown
         slices.each(&:shutdown)
         container.shutdown!
+        self
+      end
+
+      # Reloads the slice in place, picking up changes to its source files.
+      #
+      # This tears down the slice and each of its nested slices - stopping providers, unloading
+      # autoloaded constants, and discarding the container, routes and settings - then prepares
+      # them again from scratch.
+      #
+      # Crucially, the slice class objects themselves are preserved, so an already-mounted Rack app
+      # (such as `run Hanami.app` in `config.ru`) remains valid across a reload.
+      #
+      # Slices are rediscovered from disk on each reload, so slices added, removed or redefined are
+      # picked up too. Note this means slice class objects are replaced, unlike the app class.
+      #
+      # `config/app.rb` is the one file that is never reloaded: it defines the app class that this
+      # method deliberately preserves, so changes to it still require a full restart.
+      #
+      # This is intended for development use only.
+      #
+      # @return [self]
+      #
+      # @see #prepare
+      #
+      # @api public
+      # @since 3.1.0
+      def reload!
+        # `@awaiting_reload_prepare` means an earlier reload tore this slice down but then raised
+        # while preparing it again (a syntax error in a reloaded file, most often). The slice is
+        # torn down but not prepared, so this reload must still run to give it another chance.
+        return self unless prepared? || @awaiting_reload_prepare
+
+        unless code_reloading?
+          raise SliceLoadError,
+            "#{self} cannot be reloaded because `config.code_reloading` was false when it was " \
+            "prepared. Set `config.code_reloading = true` on the app before preparing it."
+        end
+
+        # Skipped when a previous reload already tore the slice down but failed to prepare it
+        # again. Tearing down twice would raise, and there is nothing left to tear down anyway.
+        if prepared?
+          # Tear down nested slices first: their containers import from their parent's, so
+          # unwinding in the other order would leave them holding references into a dead container.
+          (slices.with_nested + [self]).each { |slice| slice.__send__(:teardown_for_reload) }
+
+          # Then discard the slice tree itself, so `prepare` rediscovers it from disk and picks up
+          # slices that have been added, removed or redefined.
+          discard_slices_for_reload
+
+          @awaiting_reload_prepare = true
+        end
+
+        prepare
+
+        @awaiting_reload_prepare = false
+
         self
       end
 
@@ -854,6 +921,11 @@ module Hanami
         instance_exec(container, &@prepare_container_block) if @prepare_container_block
         container.configured!
 
+        # Zeitwerk only tracks the constants it defines (and so can only unload them later) when
+        # reloading is enabled before `setup`. Both this class and `Hanami::App` call `setup` from
+        # `prepare_autoloader`, so this must happen here, ahead of either. See {ClassMethods#reload!}.
+        autoloader.enable_reloading if code_reloading?
+
         prepare_autoloader
 
         # Load child slices last, ensuring their parent is fully prepared beforehand
@@ -866,6 +938,122 @@ module Hanami
         self
       end
 
+      # Unwinds everything {#prepare} built up, leaving the slice class itself intact and ready to
+      # be prepared again.
+      #
+      # @api private
+      # @since 3.1.0
+      def teardown_for_reload
+        # Capture these before the container is replaced below.
+        reloadable_paths = required_reloadable_paths
+
+        # Stop providers so they can release resources (DB connections, and so on) before the
+        # components holding them are discarded.
+        container.shutdown!
+
+        # Drop every constant Zeitwerk defined for this slice, then retire the loader itself. A
+        # fresh loader is built below rather than reusing this one via `reload`, which would
+        # require `enable_reloading` to have been set before `setup`.
+        autoloader.unload
+        autoloader.unregister
+
+        remove_consts_for_reload
+
+        build_container_and_autoloader
+
+        # These files live under `config/` and so are `require`d rather than autoloaded. Dropping
+        # them from $LOADED_FEATURES is what allows them to be evaluated again against the newly
+        # built container.
+        reloadable_paths.each { |path| $LOADED_FEATURES.delete(path) }
+
+        remove_instance_variable(:@settings) if instance_variable_defined?(:@settings)
+        remove_instance_variable(:@routes) if instance_variable_defined?(:@routes)
+        @_router = nil
+        @rack_app = nil
+
+        @prepared = false
+        @booted = false
+
+        self
+      end
+
+      # Whether code reloading is enabled, which is always an app-wide decision.
+      #
+      # Slices copy their config from the app, so each one carries its own `code_reloading` value,
+      # but the app's is the only one consulted. Reloading a subset of slices is not coherent:
+      # slices import from their parent's container, so a slice that opted out would be left
+      # holding components from a container that the reload had already discarded.
+      #
+      # @api private
+      # @since 3.1.0
+      def code_reloading?
+        # A slice can be prepared without an app in place (in tests, mostly), in which case there
+        # is no app-wide value to defer to.
+        return config.code_reloading unless Hanami.app?
+
+        app.config.code_reloading
+      end
+
+      # Discards the slice registrar and everything it registered, so that {#prepare} builds the
+      # slice tree again from what is currently on disk.
+      #
+      # @api private
+      # @since 3.1.0
+      def discard_slices_for_reload
+        slices.unload_for_reload
+
+        remove_instance_variable(:@slices) if instance_variable_defined?(:@slices)
+        @slices_loaded = false
+
+        self
+      end
+
+      # Removes the constants that {#prepare} defines outside of the autoloader, and which Zeitwerk
+      # therefore does not unload.
+      #
+      # `Container` and `Deps` are set directly by `prepare_container_consts`, while `Routes` and
+      # `Settings` come from `require`d files under `config/`. In both cases the constant remaining
+      # defined would stop it being rebuilt: `prepare` refuses to run while `Container` exists, and
+      # the routes and settings are only loaded from disk when their constant is missing.
+      #
+      # @api private
+      # @since 3.1.0
+      def remove_consts_for_reload
+        consts = [
+          CONTAINER_CONST_NAME,
+          DEPS_CONST_NAME,
+          ROUTES_CLASS_NAME,
+          SETTINGS_CLASS_NAME
+        ]
+
+        consts.each do |const_name|
+          namespace.__send__(:remove_const, const_name) if namespace.const_defined?(const_name, false)
+        end
+      end
+
+      # Returns the realpaths of the slice's `require`d (rather than autoloaded) files that should
+      # be re-evaluated on reload: its routes, settings, providers and registrations.
+      #
+      # `config/app.rb` and the slice definitions in `config/slices/` are deliberately excluded:
+      # they define the app and slice classes themselves, which {ClassMethods#reload!} preserves.
+      #
+      # @api private
+      # @since 3.1.0
+      def required_reloadable_paths
+        dirs = container.config.provider_dirs + [container.config.registrations_dir]
+
+        paths = dirs.flat_map { |dir|
+          Dir[File.join(root, dir, "**", "*#{RB_EXT}")]
+        }
+
+        paths << root.join("#{ROUTES_PATH}#{RB_EXT}").to_s
+        paths << root.join("#{SETTINGS_PATH}#{RB_EXT}").to_s
+
+        paths.filter_map { |path|
+          File.realpath(path) if File.file?(path)
+        }
+      end
+
       def ensure_slice_name
         unless name
           raise SliceLoadError, "Slice must have a class name before it can be prepared"
@@ -873,10 +1061,11 @@ module Hanami
       end
 
       def ensure_slice_consts
-        if namespace.const_defined?(:Container) || namespace.const_defined?(:Deps)
+        if namespace.const_defined?(CONTAINER_CONST_NAME) || namespace.const_defined?(DEPS_CONST_NAME)
           raise(
             SliceLoadError,
-            "#{namespace}::Container and #{namespace}::Deps constants must not already be defined"
+            "#{namespace}::#{CONTAINER_CONST_NAME} and #{namespace}::#{DEPS_CONST_NAME} " \
+            "constants must not already be defined"
           )
         end
       end
@@ -902,8 +1091,8 @@ module Hanami
       end
 
       def prepare_container_consts
-        namespace.const_set :Container, container
-        namespace.const_set :Deps, container.injector
+        namespace.const_set CONTAINER_CONST_NAME, container
+        namespace.const_set DEPS_CONST_NAME, container.injector
       end
 
       def prepare_container_plugins
@@ -1057,7 +1246,15 @@ module Hanami
       end
 
       def prepare_slices
-        slices.load_slices.each(&:prepare)
+        # Slice classes are defined by `require`d files (`config/slices/`, `slices/*/config/`), so
+        # they survive a reload and must not be registered a second time. This means slices added
+        # or removed on disk are only picked up by a full restart.
+        unless @slices_loaded
+          slices.load_slices
+          @slices_loaded = true
+        end
+
+        slices.each(&:prepare)
         slices.freeze
       end
 

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -40,6 +40,7 @@ module Hanami
       @_mutex.synchronize do
         subclass.class_eval do
           @_mutex = Mutex.new
+          @unload_steps = []
           build_container_and_autoloader
         end
       end
@@ -47,13 +48,14 @@ module Hanami
 
     # Builds the slice's container and autoloader.
     #
-    # Called when the slice is first defined, and again by {ClassMethods#reload!}, which discards
-    # the previous pair wholesale rather than attempting to invalidate them in place.
+    # Called when the slice is first defined, and again on every {ClassMethods#unload!}, which
+    # discards the previous pair wholesale rather than attempting to invalidate them in place.
     #
     # @api private
     # @since 3.1.0
     def self.build_container_and_autoloader
       @autoloader = Zeitwerk::Loader.new
+      @autoloader_setup = false
       @container = Class.new(Dry::System::Container)
     end
 
@@ -371,9 +373,8 @@ module Hanami
 
       # Reloads the slice in place, picking up changes to its source files.
       #
-      # This tears down the slice and each of its nested slices - stopping providers, unloading
-      # autoloaded constants, and discarding the container, routes and settings - then prepares
-      # them again from scratch.
+      # This unloads the slice and each of its nested slices (see {#unload!}), then prepares them
+      # again from scratch.
       #
       # Crucially, the slice class objects themselves are preserved, so an already-mounted Rack app
       # (such as `run Hanami.app` in `config.ru`) remains valid across a reload.
@@ -388,39 +389,61 @@ module Hanami
       #
       # @return [self]
       #
+      # @see #unload!
       # @see #prepare
       #
       # @api public
       # @since 3.1.0
       def reload!
-        # `@awaiting_reload_prepare` means an earlier reload tore this slice down but then raised
-        # while preparing it again (a syntax error in a reloaded file, most often). The slice is
-        # torn down but not prepared, so this reload must still run to give it another chance.
-        return self unless prepared? || @awaiting_reload_prepare
+        unload!.prepare
+      end
 
-        unless code_reloading?
+      # Reverses {#prepare}, leaving the slice class itself intact and ready to be prepared again.
+      #
+      # Each step of `prepare` registers its own reversal via {#on_unload} as it completes, and
+      # this runs those in reverse order. Because the stack holds exactly the steps that finished,
+      # unloading a slice whose `prepare` raised part way through works too: only the work that was
+      # actually done gets undone.
+      #
+      # @return [self]
+      #
+      # @see #reload!
+      # @see #on_unload
+      #
+      # @api private
+      # @since 3.1.0
+      def unload!
+        # Zeitwerk can only unload the constants it defined if it was told to track them ahead of
+        # `setup`, which happens during `prepare`. Without that, those constants would linger and
+        # the slice would keep serving stale code once prepared again.
+        if @unload_steps.any? && !code_reloading?
           raise SliceLoadError,
-            "#{self} cannot be reloaded because `config.code_reloading` was false when it was " \
+            "#{self} cannot be unloaded because `config.code_reloading` was false when it was " \
             "prepared. Set `config.code_reloading = true` on the app before preparing it."
         end
 
-        # Skipped when a previous reload already tore the slice down but failed to prepare it
-        # again. Tearing down twice would raise, and there is nothing left to tear down anyway.
-        if prepared?
-          # Tear down nested slices first: their containers import from their parent's, so
-          # unwinding in the other order would leave them holding references into a dead container.
-          (slices.with_nested + [self]).each { |slice| slice.__send__(:teardown_for_reload) }
+        @unload_steps.reverse_each(&:call)
+        @unload_steps = []
 
-          # Then discard the slice tree itself, so `prepare` rediscovers it from disk and picks up
-          # slices that have been added, removed or redefined.
-          discard_slices_for_reload
+        @prepared = false
+        @booted = false
 
-          @awaiting_reload_prepare = true
-        end
+        self
+      end
 
-        prepare
-
-        @awaiting_reload_prepare = false
+      # Registers a step that {#unload!} runs to undo a piece of the work {#prepare} just did.
+      #
+      # Steps run in reverse order of registration, so registering a step next to the work it
+      # reverses is enough to have it unwound before whatever that work depended upon.
+      #
+      # @return [self]
+      #
+      # @see #unload!
+      #
+      # @api private
+      # @since 3.1.0
+      def on_unload(&block)
+        @unload_steps << block
 
         self
       end
@@ -814,6 +837,19 @@ module Hanami
         return @settings if instance_variable_defined?(:@settings)
 
         @settings = Settings.load_for_slice(self)
+
+        # The `Settings` class is defined by a `load`ed file under `config/`, so removing the
+        # constant is what allows the class to be defined afresh, rather than reopened, on the next
+        # prepare. Reopening it would re-declare its settings, which dry-configurable rejects.
+        on_unload do
+          remove_instance_variable(:@settings)
+
+          if namespace.const_defined?(SETTINGS_CLASS_NAME, false)
+            namespace.__send__(:remove_const, SETTINGS_CLASS_NAME)
+          end
+        end
+
+        @settings
       end
 
       # Returns the slice's routes, or nil if no routes are defined.
@@ -830,6 +866,18 @@ module Hanami
         return @routes if instance_variable_defined?(:@routes)
 
         @routes = load_routes
+
+        # As with the settings above, the `Routes` class comes from a `load`ed file under
+        # `config/`, so the constant must go for the class to be defined afresh next time.
+        on_unload do
+          remove_instance_variable(:@routes)
+
+          if namespace.const_defined?(ROUTES_CLASS_NAME, false)
+            namespace.__send__(:remove_const, ROUTES_CLASS_NAME)
+          end
+        end
+
+        @routes
       end
 
       # Returns the slice's router, if or nil if no routes are defined.
@@ -916,6 +964,23 @@ module Hanami
         ensure_slice_consts
         ensure_root
 
+        # Registered first, so it runs last: every unload step registered below expects the
+        # container and autoloader it was registered against to still be in place. In particular,
+        # `autoloader.unload` must come after the providers are stopped, since a provider's `stop`
+        # block may reference constants the autoloader defined.
+        #
+        # A fresh pair is built rather than reusing the loader via `Zeitwerk::Loader#reload`, so
+        # that each prepare starts from the same clean state as the very first one.
+        on_unload do
+          # Zeitwerk refuses to unload a loader it never set up, which is the state we're in if
+          # this prepare raised before reaching `prepare_autoloader`. Nothing was autoloaded in
+          # that case, so there is nothing to unload either.
+          autoloader.unload if @autoloader_setup
+          autoloader.unregister
+
+          build_container_and_autoloader
+        end
+
         prepare_all
 
         instance_exec(container, &@prepare_container_block) if @prepare_container_block
@@ -927,52 +992,25 @@ module Hanami
         autoloader.enable_reloading if code_reloading?
 
         prepare_autoloader
+        @autoloader_setup = true
 
         # Load child slices last, ensuring their parent is fully prepared beforehand
         # (useful e.g. for slices that may wish to access constants defined in the
         # parent's autoloaded directories)
         prepare_slices
 
+        # Registered last, so it runs first: both memos hold the router and Rack apps built from
+        # this slice and its children, all of which the steps above discard.
+        #
+        # These are memoized lazily (under `@_mutex`), but the step is registered here rather than
+        # at the point of memoization, because `router` memoizes from inside a `@_mutex` block and
+        # Ruby's mutexes are not reentrant.
+        on_unload do
+          @_router = nil
+          @rack_app = nil
+        end
+
         @prepared = true
-
-        self
-      end
-
-      # Unwinds everything {#prepare} built up, leaving the slice class itself intact and ready to
-      # be prepared again.
-      #
-      # @api private
-      # @since 3.1.0
-      def teardown_for_reload
-        # Capture these before the container is replaced below.
-        reloadable_paths = required_reloadable_paths
-
-        # Stop providers so they can release resources (DB connections, and so on) before the
-        # components holding them are discarded.
-        container.shutdown!
-
-        # Drop every constant Zeitwerk defined for this slice, then retire the loader itself. A
-        # fresh loader is built below rather than reusing this one via `reload`, which would
-        # require `enable_reloading` to have been set before `setup`.
-        autoloader.unload
-        autoloader.unregister
-
-        remove_consts_for_reload
-
-        build_container_and_autoloader
-
-        # These files live under `config/` and so are `require`d rather than autoloaded. Dropping
-        # them from $LOADED_FEATURES is what allows them to be evaluated again against the newly
-        # built container.
-        reloadable_paths.each { |path| $LOADED_FEATURES.delete(path) }
-
-        remove_instance_variable(:@settings) if instance_variable_defined?(:@settings)
-        remove_instance_variable(:@routes) if instance_variable_defined?(:@routes)
-        @_router = nil
-        @rack_app = nil
-
-        @prepared = false
-        @booted = false
 
         self
       end
@@ -994,64 +1032,13 @@ module Hanami
         app.config.code_reloading
       end
 
-      # Discards the slice registrar and everything it registered, so that {#prepare} builds the
-      # slice tree again from what is currently on disk.
+      # Returns the realpaths of the slice's provider files, which dry-system `require`s.
       #
-      # @api private
-      # @since 3.1.0
-      def discard_slices_for_reload
-        slices.unload_for_reload
-
-        remove_instance_variable(:@slices) if instance_variable_defined?(:@slices)
-        @slices_loaded = false
-
-        self
-      end
-
-      # Removes the constants that {#prepare} defines outside of the autoloader, and which Zeitwerk
-      # therefore does not unload.
-      #
-      # `Container` and `Deps` are set directly by `prepare_container_consts`, while `Routes` and
-      # `Settings` come from `require`d files under `config/`. In both cases the constant remaining
-      # defined would stop it being rebuilt: `prepare` refuses to run while `Container` exists, and
-      # the routes and settings are only loaded from disk when their constant is missing.
-      #
-      # @api private
-      # @since 3.1.0
-      def remove_consts_for_reload
-        consts = [
-          CONTAINER_CONST_NAME,
-          DEPS_CONST_NAME,
-          ROUTES_CLASS_NAME,
-          SETTINGS_CLASS_NAME
-        ]
-
-        consts.each do |const_name|
-          namespace.__send__(:remove_const, const_name) if namespace.const_defined?(const_name, false)
-        end
-      end
-
-      # Returns the realpaths of the slice's `require`d (rather than autoloaded) files that should
-      # be re-evaluated on reload: its routes, settings, providers and registrations.
-      #
-      # `config/app.rb` and the slice definitions in `config/slices/` are deliberately excluded:
-      # they define the app and slice classes themselves, which {ClassMethods#reload!} preserves.
-      #
-      # @api private
-      # @since 3.1.0
-      def required_reloadable_paths
-        dirs = container.config.provider_dirs + [container.config.registrations_dir]
-
-        paths = dirs.flat_map { |dir|
-          Dir[File.join(root, dir, "**", "*#{RB_EXT}")]
-        }
-
-        paths << root.join("#{ROUTES_PATH}#{RB_EXT}").to_s
-        paths << root.join("#{SETTINGS_PATH}#{RB_EXT}").to_s
-
-        paths.filter_map { |path|
-          File.realpath(path) if File.file?(path)
-        }
+      # TODO: Remove along with the `$LOADED_FEATURES` handling in `prepare_container_providers`.
+      def provider_file_paths
+        container.config.provider_dirs
+          .flat_map { |dir| Dir[File.join(root, dir, "**", "*#{RB_EXT}")] }
+          .filter_map { |path| File.realpath(path) if File.file?(path) }
       end
 
       def ensure_slice_name
@@ -1093,6 +1080,11 @@ module Hanami
       def prepare_container_consts
         namespace.const_set CONTAINER_CONST_NAME, container
         namespace.const_set DEPS_CONST_NAME, container.injector
+
+        on_unload do
+          namespace.__send__(:remove_const, CONTAINER_CONST_NAME)
+          namespace.__send__(:remove_const, DEPS_CONST_NAME)
+        end
       end
 
       def prepare_container_plugins
@@ -1174,6 +1166,19 @@ module Hanami
 
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def prepare_container_providers
+        on_unload do
+          # Stop providers so they can release the resources they hold (database connections, and
+          # so on) before the components holding them are discarded.
+          container.shutdown!
+
+          # Provider files are `require`d by dry-system, so dropping them from `$LOADED_FEATURES`
+          # is what allows them to be evaluated again against the newly built container.
+          #
+          # TODO: Remove once dry-system's `ProviderRegistrar` uses `load` for provider files, as
+          # its `ManifestRegistrar` already does for registrations.
+          provider_file_paths.each { |path| $LOADED_FEATURES.delete(path) }
+        end
+
         # Check here for the `routes` definition only, not `router` itself, because the
         # `router` requires the slice to be prepared before it can be loaded, and at this
         # point we're still in the process of preparing.
@@ -1246,16 +1251,17 @@ module Hanami
       end
 
       def prepare_slices
-        # Slice classes are defined by `require`d files (`config/slices/`, `slices/*/config/`), so
-        # they survive a reload and must not be registered a second time. This means slices added
-        # or removed on disk are only picked up by a full restart.
-        unless @slices_loaded
-          slices.load_slices
-          @slices_loaded = true
-        end
-
-        slices.each(&:prepare)
+        slices.load_slices.each(&:prepare)
         slices.freeze
+
+        # Discarding the registrar (rather than just unloading the slices it holds) is what lets
+        # the next prepare rediscover slices from disk, picking up any added, removed or redefined
+        # since. Slice class objects are therefore replaced by a reload, unlike the app class.
+        on_unload do
+          slices.unload!
+
+          remove_instance_variable(:@slices)
+        end
       end
 
       def routes?
@@ -1269,15 +1275,14 @@ module Hanami
       def load_routes
         return false unless Hanami.bundled?("hanami-router")
 
-        if root.directory?
-          routes_require_path = root.join(ROUTES_PATH).to_s
+        routes_path = root.join("#{ROUTES_PATH}#{RB_EXT}")
 
-          begin
-            require_relative "./routes"
-            require routes_require_path
-          rescue LoadError => exception
-            raise exception unless exception.path == routes_require_path
-          end
+        if root.directory? && routes_path.file?
+          require_relative "./routes"
+
+          # `load` rather than `require`, so that the file is evaluated again on every prepare and
+          # a reload picks up changes to it.
+          load routes_path.to_s
         end
 
         begin

--- a/lib/hanami/slice.rb
+++ b/lib/hanami/slice.rb
@@ -48,8 +48,7 @@ module Hanami
 
     # Builds the slice's container and autoloader.
     #
-    # Called when the slice is first defined, and again on every {ClassMethods#unload!}, which
-    # discards the previous pair wholesale rather than attempting to invalidate them in place.
+    # Called when the slice is first defined, and again on every {ClassMethods#unload!}.
     #
     # @api private
     # @since 3.1.0
@@ -373,19 +372,11 @@ module Hanami
 
       # Reloads the slice in place, picking up changes to its source files.
       #
-      # This unloads the slice and each of its nested slices (see {#unload!}), then prepares them
-      # again from scratch.
+      # Unloads the slice and its nested slices, then prepares them again. Slice classes are
+      # rediscovered from disk, but the app class object is preserved, so `run Hanami.app` in
+      # `config.ru` stays valid. `config/app.rb` is therefore never reloaded.
       #
-      # Crucially, the slice class objects themselves are preserved, so an already-mounted Rack app
-      # (such as `run Hanami.app` in `config.ru`) remains valid across a reload.
-      #
-      # Slices are rediscovered from disk on each reload, so slices added, removed or redefined are
-      # picked up too. Note this means slice class objects are replaced, unlike the app class.
-      #
-      # `config/app.rb` is the one file that is never reloaded: it defines the app class that this
-      # method deliberately preserves, so changes to it still require a full restart.
-      #
-      # This is intended for development use only.
+      # Intended for development use only.
       #
       # @return [self]
       #
@@ -398,24 +389,19 @@ module Hanami
         unload!.prepare
       end
 
-      # Reverses {#prepare}, leaving the slice class itself intact and ready to be prepared again.
+      # Reverses {#prepare}, leaving the slice class ready to be prepared again.
       #
-      # Each step of `prepare` registers its own reversal via {#on_unload} as it completes, and
-      # this runs those in reverse order. Because the stack holds exactly the steps that finished,
-      # unloading a slice whose `prepare` raised part way through works too: only the work that was
-      # actually done gets undone.
+      # Runs the steps registered via {#on_unload}, in reverse. The stack holds only the steps that
+      # finished, so this works after a `prepare` that raised part way through.
       #
       # @return [self]
       #
-      # @see #reload!
       # @see #on_unload
       #
       # @api private
       # @since 3.1.0
       def unload!
-        # Zeitwerk can only unload the constants it defined if it was told to track them ahead of
-        # `setup`, which happens during `prepare`. Without that, those constants would linger and
-        # the slice would keep serving stale code once prepared again.
+        # Zeitwerk can only unload constants it was told to track ahead of `setup`.
         if @unload_steps.any? && !code_reloading?
           raise SliceLoadError,
             "#{self} cannot be unloaded because `config.code_reloading` was false when it was " \
@@ -431,10 +417,10 @@ module Hanami
         self
       end
 
-      # Registers a step that {#unload!} runs to undo a piece of the work {#prepare} just did.
+      # Registers a step for {#unload!} to run, undoing work {#prepare} just did.
       #
-      # Steps run in reverse order of registration, so registering a step next to the work it
-      # reverses is enough to have it unwound before whatever that work depended upon.
+      # Steps run last-in-first-out, so a step registered next to its work is unwound before
+      # anything that work depended upon.
       #
       # @return [self]
       #
@@ -838,9 +824,8 @@ module Hanami
 
         @settings = Settings.load_for_slice(self)
 
-        # The `Settings` class is defined by a `load`ed file under `config/`, so removing the
-        # constant is what allows the class to be defined afresh, rather than reopened, on the next
-        # prepare. Reopening it would re-declare its settings, which dry-configurable rejects.
+        # Removing the constant lets the class be defined afresh next prepare. Reopening it would
+        # re-declare its settings, which dry-configurable rejects.
         on_unload do
           remove_instance_variable(:@settings)
 
@@ -867,8 +852,7 @@ module Hanami
 
         @routes = load_routes
 
-        # As with the settings above, the `Routes` class comes from a `load`ed file under
-        # `config/`, so the constant must go for the class to be defined afresh next time.
+        # As with the settings above, the constant must go for the class to be defined afresh.
         on_unload do
           remove_instance_variable(:@routes)
 
@@ -964,17 +948,11 @@ module Hanami
         ensure_slice_consts
         ensure_root
 
-        # Registered first, so it runs last: every unload step registered below expects the
-        # container and autoloader it was registered against to still be in place. In particular,
-        # `autoloader.unload` must come after the providers are stopped, since a provider's `stop`
-        # block may reference constants the autoloader defined.
-        #
-        # A fresh pair is built rather than reusing the loader via `Zeitwerk::Loader#reload`, so
-        # that each prepare starts from the same clean state as the very first one.
+        # Registered first, so it runs last: `autoloader.unload` must follow the provider shutdown
+        # below, whose `stop` blocks may reference autoloaded constants.
         on_unload do
-          # Zeitwerk refuses to unload a loader it never set up, which is the state we're in if
-          # this prepare raised before reaching `prepare_autoloader`. Nothing was autoloaded in
-          # that case, so there is nothing to unload either.
+          # Zeitwerk refuses to unload a loader it never set up, which is where a `prepare` that
+          # raised before `prepare_autoloader` leaves us.
           autoloader.unload if @autoloader_setup
           autoloader.unregister
 
@@ -994,12 +972,8 @@ module Hanami
         # parent's autoloaded directories)
         prepare_slices
 
-        # Registered last, so it runs first: both memos hold the router and Rack apps built from
-        # this slice and its children, all of which the steps above discard.
-        #
-        # These are memoized lazily (under `@_mutex`), but the step is registered here rather than
-        # at the point of memoization, because `router` memoizes from inside a `@_mutex` block and
-        # Ruby's mutexes are not reentrant.
+        # Registered here rather than where these are memoized: `router` memoizes inside a
+        # `@_mutex` block, and `on_unload` must not take a lock Ruby cannot re-enter.
         on_unload do
           @_router = nil
           @rack_app = nil
@@ -1010,18 +984,13 @@ module Hanami
         self
       end
 
-      # Whether code reloading is enabled, which is always an app-wide decision.
-      #
-      # Slices copy their config from the app, so each one carries its own `code_reloading` value,
-      # but the app's is the only one consulted. Reloading a subset of slices is not coherent:
-      # slices import from their parent's container, so a slice that opted out would be left
-      # holding components from a container that the reload had already discarded.
+      # Whether code reloading is enabled. Always an app-wide decision: slices import from their
+      # parent's container, so one opting out would hold components from a discarded container.
       #
       # @api private
       # @since 3.1.0
       def code_reloading?
-        # A slice can be prepared without an app in place (in tests, mostly), in which case there
-        # is no app-wide value to defer to.
+        # A slice can be prepared without an app in place (in tests, mostly).
         return config.code_reloading unless Hanami.app?
 
         app.config.code_reloading
@@ -1081,9 +1050,8 @@ module Hanami
           loader: autoloader,
           run_setup: false,
           eager_load: false,
-          # Zeitwerk only tracks the constants it defines (and so can only unload them later) when
-          # reloading is enabled ahead of `setup`. The plugin applies this from its
-          # `after(:configure)` hook, which runs before `prepare_autoloader` calls `setup`.
+          # Applied from the plugin's `after(:configure)` hook, so it lands before
+          # `prepare_autoloader` calls `setup`, which is Zeitwerk's deadline for it.
           enable_reloading: code_reloading?
         )
       end
@@ -1156,9 +1124,7 @@ module Hanami
 
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def prepare_container_providers
-        # Stop providers so they can release the resources they hold (database connections, and so
-        # on) before the components holding them are discarded. dry-system `load`s provider files,
-        # so the freshly built container evaluates them again by itself.
+        # Stop providers so they can release what they hold before it is discarded.
         on_unload { container.shutdown! }
 
         # Check here for the `routes` definition only, not `router` itself, because the
@@ -1236,9 +1202,7 @@ module Hanami
         slices.load_slices.each(&:prepare)
         slices.freeze
 
-        # Discarding the registrar (rather than just unloading the slices it holds) is what lets
-        # the next prepare rediscover slices from disk, picking up any added, removed or redefined
-        # since. Slice class objects are therefore replaced by a reload, unlike the app class.
+        # Discarding the registrar is what lets the next prepare rediscover slices from disk.
         on_unload do
           slices.unload!
 
@@ -1262,8 +1226,7 @@ module Hanami
         if root.directory? && routes_path.file?
           require_relative "./routes"
 
-          # `load` rather than `require`, so that the file is evaluated again on every prepare and
-          # a reload picks up changes to it.
+          # `load`, so the file is evaluated again on each prepare.
           load routes_path.to_s
         end
 

--- a/lib/hanami/slice_registrar.rb
+++ b/lib/hanami/slice_registrar.rb
@@ -73,20 +73,13 @@ module Hanami
     end
 
     # Unloads every registered slice, then removes the slice classes and namespace modules
-    # themselves, leaving nothing behind that would shadow what is on disk.
-    #
-    # The caller is expected to discard this registrar afterwards, so that the slices are
-    # discovered from disk again. This is what allows slices to be added, removed or redefined
-    # without restarting.
-    #
-    # The slice classes are therefore replaced by a reload, unlike the app class, which
-    # {Slice::ClassMethods#reload!} deliberately preserves.
+    # themselves. The caller discards this registrar afterwards, so the next prepare rediscovers
+    # slices from disk.
     #
     # @api private
     # @since 3.1.0
     def unload!
-      # Reverse order, mirroring how the slices were prepared, so a slice is unloaded before any
-      # it may have been able to reference.
+      # Reverse of the order they were prepared in.
       to_a.reverse_each(&:unload!)
 
       slices.each_key { |slice_name| remove_slice_consts(slice_name) }
@@ -126,12 +119,8 @@ module Hanami
     def load_slice(slice_name)
       slice_path = find_slice_require_path(slice_name)
 
-      # `load` rather than `require`, so that the file is evaluated again on every prepare and a
-      # reload picks up changes to it. The slice class and namespace module it defines are removed
-      # by `unload!` above, so they are defined afresh rather than reopened.
-      #
-      # `find_slice_require_path` returns an extension-less path, so add the extension: unlike
-      # `require`, `load` will not infer it.
+      # `load`, so the file is evaluated again on each prepare; `unload!` above removed the
+      # constants it defines. `find_slice_require_path` omits the extension, which `load` needs.
       load "#{slice_path}#{RB_EXT}" if slice_path
 
       slice_class =

--- a/lib/hanami/slice_registrar.rb
+++ b/lib/hanami/slice_registrar.rb
@@ -72,28 +72,26 @@ module Hanami
       slices.values
     end
 
-    # Unwinds this registrar ahead of a reload, so that its slices are discovered from disk again.
+    # Unloads every registered slice, then removes the slice classes and namespace modules
+    # themselves, leaving nothing behind that would shadow what is on disk.
     #
-    # Drops each registered slice's definition file from $LOADED_FEATURES and removes its slice
-    # class and namespace module, leaving nothing behind that would shadow what is on disk. This is
-    # what allows slices to be added, removed or redefined without restarting.
+    # The caller is expected to discard this registrar afterwards, so that the slices are
+    # discovered from disk again. This is what allows slices to be added, removed or redefined
+    # without restarting.
     #
-    # The slice classes themselves are discarded here (unlike the app class, which {Slice.reload!}
-    # preserves), so a reload replaces them with fresh objects.
+    # The slice classes are therefore replaced by a reload, unlike the app class, which
+    # {Slice::ClassMethods#reload!} deliberately preserves.
     #
     # @api private
     # @since 3.1.0
-    def unload_for_reload
-      slices.each_value { |slice| slice.slices.unload_for_reload }
+    def unload!
+      # Reverse order, mirroring how the slices were prepared, so a slice is unloaded before any
+      # it may have been able to reference.
+      to_a.reverse_each(&:unload!)
 
-      slices.each_key do |slice_name|
-        # `find_slice_require_path` returns an extension-less path, matching how `load_slice`
-        # passes it to `require`.
-        path = find_slice_require_path(slice_name.to_s)&.then { "#{_1}#{RB_EXT}" }
-        $LOADED_FEATURES.delete(File.realpath(path)) if path && File.file?(path)
+      slices.each_key { |slice_name| remove_slice_consts(slice_name) }
 
-        remove_slice_consts(slice_name)
-      end
+      self
     end
 
     def with_nested
@@ -122,12 +120,19 @@ module Hanami
     # or when a slice directory exists at `slices/[slice_name]`.
     #
     # If a slice definition file is found by `find_slice_require_path`, then `load_slice` will
-    # require the file before registering the slice class.
+    # load the file before registering the slice class.
     #
     # If a slice class is not found, registering the slice will generate the slice class.
     def load_slice(slice_name)
-      slice_require_path = find_slice_require_path(slice_name)
-      require slice_require_path if slice_require_path
+      slice_path = find_slice_require_path(slice_name)
+
+      # `load` rather than `require`, so that the file is evaluated again on every prepare and a
+      # reload picks up changes to it. The slice class and namespace module it defines are removed
+      # by `unload!` above, so they are defined afresh rather than reopened.
+      #
+      # `find_slice_require_path` returns an extension-less path, so add the extension: unlike
+      # `require`, `load` will not infer it.
+      load "#{slice_path}#{RB_EXT}" if slice_path
 
       slice_class =
         begin

--- a/lib/hanami/slice_registrar.rb
+++ b/lib/hanami/slice_registrar.rb
@@ -72,6 +72,30 @@ module Hanami
       slices.values
     end
 
+    # Unwinds this registrar ahead of a reload, so that its slices are discovered from disk again.
+    #
+    # Drops each registered slice's definition file from $LOADED_FEATURES and removes its slice
+    # class and namespace module, leaving nothing behind that would shadow what is on disk. This is
+    # what allows slices to be added, removed or redefined without restarting.
+    #
+    # The slice classes themselves are discarded here (unlike the app class, which {Slice.reload!}
+    # preserves), so a reload replaces them with fresh objects.
+    #
+    # @api private
+    # @since 3.1.0
+    def unload_for_reload
+      slices.each_value { |slice| slice.slices.unload_for_reload }
+
+      slices.each_key do |slice_name|
+        # `find_slice_require_path` returns an extension-less path, matching how `load_slice`
+        # passes it to `require`.
+        path = find_slice_require_path(slice_name.to_s)&.then { "#{_1}#{RB_EXT}" }
+        $LOADED_FEATURES.delete(File.realpath(path)) if path && File.file?(path)
+
+        remove_slice_consts(slice_name)
+      end
+    end
+
     def with_nested
       to_a.flat_map { |slice|
         # Return nested slices first so that their more specific namespaces may be picked up first
@@ -107,7 +131,7 @@ module Hanami
 
       slice_class =
         begin
-          inflector.constantize("#{slice_module_name(slice_name)}#{MODULE_DELIMITER}Slice")
+          inflector.constantize("#{slice_module_name(slice_name)}#{MODULE_DELIMITER}#{SLICE_CLASS_NAME}")
         rescue NameError => exception
           raise exception unless exception.name.to_s == inflector.camelize(slice_name) || exception.name.to_s == :Slice
         end
@@ -149,7 +173,20 @@ module Hanami
           parent_slice_namespace.const_set(inflector.camelize(slice_name), Module.new)
         end
 
-      slice_module.const_set(:Slice, Class.new(Hanami::Slice, &block))
+      slice_module.const_set(SLICE_CLASS_NAME, Class.new(Hanami::Slice, &block))
+    end
+
+    def remove_slice_consts(slice_name)
+      module_name = inflector.camelize(slice_name.to_s)
+      return unless parent_slice_namespace.const_defined?(module_name, false)
+
+      slice_module = parent_slice_namespace.const_get(module_name)
+
+      if slice_module.const_defined?(SLICE_CLASS_NAME, false)
+        slice_module.__send__(:remove_const, SLICE_CLASS_NAME)
+      end
+
+      parent_slice_namespace.__send__(:remove_const, module_name)
     end
 
     def slice_module_name(slice_name)

--- a/spec/integration/code_loading/reloading_spec.rb
+++ b/spec/integration/code_loading/reloading_spec.rb
@@ -1,0 +1,711 @@
+# frozen_string_literal: true
+
+RSpec.describe "Code loading / Reloading", :app_integration do
+  subject(:app) { Hanami.app }
+
+  def reload!
+    with_directory(@dir) { app.reload! }
+  end
+
+  describe "app code" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "app/greeter.rb", <<~'RUBY'
+          module TestApp
+            class Greeter
+              def call = "hello"
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+      end
+    end
+
+    specify "picks up changes to an existing component" do
+      expect(app["greeter"].call).to eq "hello"
+
+      with_directory(@dir) do
+        rewrite "app/greeter.rb", <<~'RUBY'
+          module TestApp
+            class Greeter
+              def call = "goodbye"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(app["greeter"].call).to eq "goodbye"
+    end
+
+    specify "picks up newly added files" do
+      expect(app.key?("farewell")).to be false
+
+      with_directory(@dir) do
+        write "app/farewell.rb", <<~'RUBY'
+          module TestApp
+            class Farewell
+              def call = "bye"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(app["farewell"].call).to eq "bye"
+    end
+
+    specify "drops components whose files have been deleted" do
+      expect(app["greeter"].call).to eq "hello"
+
+      FileUtils.rm File.join(@dir, "app", "greeter.rb")
+
+      reload!
+
+      expect(app.key?("greeter")).to be false
+    end
+
+    specify "replaces stale constants rather than reusing them" do
+      before_reload = TestApp::Greeter
+
+      reload!
+
+      expect(TestApp::Greeter).to be
+      expect(TestApp::Greeter).not_to equal before_reload
+    end
+
+    specify "preserves the app class object so `run Hanami.app` stays valid" do
+      app_class = Hanami.app
+
+      reload!
+
+      expect(Hanami.app).to equal app_class
+    end
+
+    specify "leaves the app prepared and resolvable afterwards" do
+      reload!
+
+      expect(app).to be_prepared
+      expect(app["greeter"]).to be_an_instance_of TestApp::Greeter
+    end
+
+    specify "reloads repeatedly" do
+      3.times do |i|
+        with_directory(@dir) do
+          rewrite "app/greeter.rb", <<~RUBY
+            module TestApp
+              class Greeter
+                def call = "hello #{i}"
+              end
+            end
+          RUBY
+        end
+
+        reload!
+
+        expect(app["greeter"].call).to eq "hello #{i}"
+      end
+    end
+  end
+
+  describe "routes" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "config/routes.rb", <<~'RUBY'
+          module TestApp
+            class Routes < Hanami::Routes
+              get "/original", to: ->(*) { [200, {}, ["original"]] }
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+      end
+    end
+
+    specify "picks up changes to config/routes.rb" do
+      expect(Rack::MockRequest.new(app).get("/original").body).to eq "original"
+
+      with_directory(@dir) do
+        rewrite "config/routes.rb", <<~'RUBY'
+          module TestApp
+            class Routes < Hanami::Routes
+              get "/changed", to: ->(*) { [200, {}, ["changed"]] }
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(Rack::MockRequest.new(app).get("/changed").body).to eq "changed"
+      expect(Rack::MockRequest.new(app).get("/original").status).to eq 404
+    end
+  end
+
+  describe "slices" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "slices/main/greeter.rb", <<~'RUBY'
+          module Main
+            class Greeter
+              def call = "main hello"
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+      end
+    end
+
+    specify "reloads code in nested slices" do
+      expect(Main::Slice["greeter"].call).to eq "main hello"
+
+      with_directory(@dir) do
+        rewrite "slices/main/greeter.rb", <<~'RUBY'
+          module Main
+            class Greeter
+              def call = "main goodbye"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(Main::Slice["greeter"].call).to eq "main goodbye"
+    end
+
+    specify "replaces slice class objects, keeping the registry pointed at the current one" do
+      # Unlike the app class, slice classes are rebuilt so that changes to their definition files
+      # take effect. Anything holding a slice class across a reload will hold a stale one.
+      slice_class = Main::Slice
+
+      reload!
+
+      expect(Main::Slice).not_to equal slice_class
+      expect(app.slices[:main]).to equal Main::Slice
+    end
+  end
+
+  describe "providers" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "config/providers/tracker.rb", <<~'RUBY'
+          # Logged to a file rather than memory: this provider file is re-evaluated on each
+          # reload, so anything held in a constant or ivar here would be reset along with it.
+          Hanami.app.register_provider(:tracker) do
+            start do
+              File.open(File.join(Hanami.app.root, "tracker.log"), "a") { _1.puts("started") }
+              register "tracker", Object.new
+            end
+
+            stop do
+              File.open(File.join(Hanami.app.root, "tracker.log"), "a") { _1.puts("stopped") }
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+      end
+    end
+
+    def tracker_events
+      path = File.join(@dir, "tracker.log")
+      File.exist?(path) ? File.readlines(path, chomp: true) : []
+    end
+
+    specify "stops providers on teardown and restarts them on demand" do
+      app.start(:tracker)
+      expect(tracker_events).to eq %w[started]
+
+      reload!
+
+      expect(tracker_events).to eq %w[started stopped]
+
+      app.start(:tracker)
+      expect(tracker_events).to eq %w[started stopped started]
+    end
+
+    specify "re-evaluates provider files, picking up their changes" do
+      app.start(:tracker)
+      expect(app["tracker"]).to be_an_instance_of Object
+
+      with_directory(@dir) do
+        rewrite "config/providers/tracker.rb", <<~'RUBY'
+          Hanami.app.register_provider(:tracker) do
+            start do
+              register "tracker", "replaced!"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+      app.start(:tracker)
+
+      expect(app["tracker"]).to eq "replaced!"
+    end
+  end
+
+  describe "settings" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "config/settings.rb", <<~'RUBY'
+          module TestApp
+            class Settings < Hanami::Settings
+              setting :one
+            end
+          end
+        RUBY
+
+        ENV["ONE"] = "first"
+        ENV["TWO"] = "second"
+
+        require "hanami/prepare"
+      end
+    end
+
+    after { ENV.delete("ONE"); ENV.delete("TWO") }
+
+    specify "picks up changes to config/settings.rb" do
+      expect(app["settings"].one).to eq "first"
+      expect(app["settings"]).not_to respond_to(:two)
+
+      with_directory(@dir) do
+        rewrite "config/settings.rb", <<~'RUBY'
+          module TestApp
+            class Settings < Hanami::Settings
+              setting :one
+              setting :two
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(app["settings"].one).to eq "first"
+      expect(app["settings"].two).to eq "second"
+    end
+  end
+
+  describe "slice churn" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "slices/main/greeter.rb", <<~'RUBY'
+          module Main
+            class Greeter
+              def call = "main"
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+      end
+    end
+
+    def reload! = with_directory(@dir) { app.reload! }
+
+    specify "picks up a slice added on disk" do
+      expect(app.slices.keys).to eq [:main]
+
+      with_directory(@dir) do
+        write "slices/admin/greeter.rb", <<~'RUBY'
+          module Admin
+            class Greeter
+              def call = "admin"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(app.slices.keys).to contain_exactly(:main, :admin)
+      expect(Admin::Slice["greeter"].call).to eq "admin"
+    end
+
+    specify "drops a slice removed from disk" do
+      expect(Main::Slice["greeter"].call).to eq "main"
+
+      FileUtils.rm_rf File.join(@dir, "slices", "main")
+
+      reload!
+
+      expect(app.slices.keys).to eq []
+    end
+
+    specify "picks up changes to a slice definition file" do
+      with_directory(@dir) do
+        write "config/slices/main.rb", <<~'RUBY'
+          module Main
+            class Slice < Hanami::Slice
+              register "marker", "before"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+      expect(Main::Slice["marker"]).to eq "before"
+
+      with_directory(@dir) do
+        rewrite "config/slices/main.rb", <<~'RUBY'
+          module Main
+            class Slice < Hanami::Slice
+              register "marker", "after!!"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(Main::Slice["marker"]).to eq "after!!"
+    end
+
+    specify "existing slices keep working across a reload that adds one" do
+      with_directory(@dir) do
+        write "slices/admin/greeter.rb", <<~'RUBY'
+          module Admin
+            class Greeter
+              def call = "admin"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(Main::Slice["greeter"].call).to eq "main"
+      expect(Admin::Slice["greeter"].call).to eq "admin"
+    end
+  end
+
+  describe "nested slices" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "slices/main/greeter.rb", <<~'RUBY'
+          module Main
+            class Greeter
+              def call = "main v1"
+            end
+          end
+        RUBY
+
+        write "slices/main/slices/nested/greeter.rb", <<~'RUBY'
+          module Main
+            module Nested
+              class Greeter
+                def call = "nested v1"
+              end
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+      end
+    end
+
+    specify "reloads code in nested slices" do
+      expect(Main::Slice["greeter"].call).to eq "main v1"
+      expect(Main::Nested::Slice["greeter"].call).to eq "nested v1"
+
+      with_directory(@dir) do
+        rewrite "slices/main/slices/nested/greeter.rb", <<~'RUBY'
+          module Main
+            module Nested
+              class Greeter
+                def call = "nested v2"
+              end
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(Main::Slice["greeter"].call).to eq "main v1"
+      expect(Main::Nested::Slice["greeter"].call).to eq "nested v2"
+    end
+
+    specify "picks up a nested slice added on disk" do
+      expect(Main::Slice.slices.keys).to eq [:nested]
+
+      with_directory(@dir) do
+        write "slices/main/slices/extra/greeter.rb", <<~'RUBY'
+          module Main
+            module Extra
+              class Greeter
+                def call = "extra"
+              end
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(Main::Slice.slices.keys).to contain_exactly(:nested, :extra)
+      expect(Main::Extra::Slice["greeter"].call).to eq "extra"
+    end
+  end
+
+  describe "when a reload raises" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "config/settings.rb", <<~'RUBY'
+          module TestApp
+            class Settings < Hanami::Settings
+              setting :one
+            end
+          end
+        RUBY
+
+        ENV["ONE"] = "ok"
+
+        require "hanami/prepare"
+      end
+    end
+
+    after { ENV.delete("ONE") }
+
+    specify "a later reload recovers once the offending file is fixed" do
+      expect(app["settings"].one).to eq "ok"
+
+      with_directory(@dir) do
+        rewrite "config/settings.rb", <<~'RUBY'
+          this_explodes_at_load_time!
+        RUBY
+      end
+
+      # Settings are loaded during `prepare`, so this leaves the app torn down.
+      expect { reload! }.to raise_error(NameError)
+      expect(app).not_to be_prepared
+
+      with_directory(@dir) do
+        rewrite "config/settings.rb", <<~'RUBY'
+          module TestApp
+            class Settings < Hanami::Settings
+              setting :one
+              setting :two
+            end
+          end
+        RUBY
+        ENV["TWO"] = "recovered"
+      end
+
+      reload!
+
+      expect(app).to be_prepared
+      expect(app["settings"].two).to eq "recovered"
+    end
+  end
+
+  describe "when code reloading is disabled" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+              config.code_reloading = false
+            end
+          end
+        RUBY
+
+        write "app/greeter.rb", <<~'RUBY'
+          module TestApp
+            class Greeter
+              def call = "hello"
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+      end
+    end
+
+    specify "the app works as normal" do
+      expect(app["greeter"].call).to eq "hello"
+    end
+
+    specify "the autoloader does no reloading bookkeeping" do
+      expect(app.autoloader.reloading_enabled?).to be false
+      expect(app.autoloader.unloadable_cpaths).to be_empty
+    end
+
+    specify "reloading raises rather than silently doing nothing" do
+      expect { reload! }.to raise_error(Hanami::SliceLoadError, /code_reloading/)
+    end
+  end
+
+  describe "code_reloading defaults" do
+    def config_for(env, name)
+      Hanami::Config.new(
+        app_name: Hanami::SliceName.new(double(name: name), inflector: Dry::Inflector.new),
+        env: env
+      )
+    end
+
+    specify "on in development, off everywhere else" do
+      expect(config_for(:development, "Dev::App").code_reloading).to be true
+      expect(config_for(:production, "Prod::App").code_reloading).to be false
+      expect(config_for(:test, "Test::App").code_reloading).to be false
+    end
+  end
+
+  describe "code_reloading is an app-wide decision" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        # Slices copy the app's config, so this slice carries its own value. It must be ignored:
+        # reloading only part of the tree would leave this slice importing from a discarded
+        # container.
+        write "config/slices/main.rb", <<~'RUBY'
+          module Main
+            class Slice < Hanami::Slice
+              config.code_reloading = false
+            end
+          end
+        RUBY
+
+        write "slices/main/greeter.rb", <<~'RUBY'
+          module Main
+            class Greeter
+              def call = "main v1"
+            end
+          end
+        RUBY
+
+        require "hanami/prepare"
+      end
+    end
+
+    specify "a slice opting out is ignored, and still reloads with the app" do
+      expect(Main::Slice.config.code_reloading).to be false
+      expect(Main::Slice.autoloader.reloading_enabled?).to be true
+
+      expect(Main::Slice["greeter"].call).to eq "main v1"
+
+      with_directory(@dir) do
+        rewrite "slices/main/greeter.rb", <<~'RUBY'
+          module Main
+            class Greeter
+              def call = "main v2"
+            end
+          end
+        RUBY
+      end
+
+      reload!
+
+      expect(Main::Slice["greeter"].call).to eq "main v2"
+    end
+  end
+end

--- a/spec/integration/code_loading/reloading_spec.rb
+++ b/spec/integration/code_loading/reloading_spec.rb
@@ -122,6 +122,62 @@ RSpec.describe "Code loading / Reloading", :app_integration do
     end
   end
 
+  describe "unloading" do
+    before do
+      @dir = make_tmp_directory
+
+      with_directory(@dir) do
+        write "config/app.rb", <<~'RUBY'
+          require "hanami"
+
+          module TestApp
+            class App < Hanami::App
+            end
+          end
+        RUBY
+
+        write "app/greeter.rb", <<~'RUBY'
+          module TestApp
+            class Greeter
+              def call = "hello"
+            end
+          end
+        RUBY
+      end
+    end
+
+    specify "unloading a prepared app leaves it unprepared, and preparable again" do
+      with_directory(@dir) { require "hanami/prepare" }
+
+      app.unload!
+
+      expect(app).not_to be_prepared
+      expect(defined?(TestApp::Greeter)).to be nil
+      expect(TestApp.const_defined?(:Container, false)).to be false
+
+      with_directory(@dir) { app.prepare }
+
+      expect(app).to be_prepared
+      expect(app["greeter"].call).to eq "hello"
+    end
+
+    specify "unloading an app that was never prepared does nothing" do
+      with_directory(@dir) { require "hanami/setup" }
+
+      expect { app.unload! }.not_to raise_error
+      expect(app).not_to be_prepared
+    end
+
+    specify "reloading an app that was never prepared simply prepares it" do
+      with_directory(@dir) { require "hanami/setup" }
+
+      reload!
+
+      expect(app).to be_prepared
+      expect(app["greeter"].call).to eq "hello"
+    end
+  end
+
   describe "routes" do
     before do
       @dir = make_tmp_directory


### PR DESCRIPTION
`Hanami::Slice.reload!` rebuilds a slice and its nested slices from scratch: it stops providers, unloads the constants Zeitwerk defined, discards the container, routes and settings, and prepares again. Slices are rediscovered from disk, so ones added, removed or redefined are picked up too.

The app class object is preserved, so `run Hanami.app` in config.ru stays valid across a reload. Slice classes are not, so anything holding one across a reload holds a stale one. `config/app.rb` is never reloaded, since it defines the app class a reload keeps.

Gated on `config.code_reloading`, which defaults to true in development and false elsewhere. With it off, Zeitwerk does no reloading bookkeeping and `reload!` raises rather than quietly doing nothing.