### PR TITLE
Load settings from YAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 
 ### Added
 
+- Load settings from `config/settings/default.yml` and `config/settings/[HANAMI_ENV].yml`, via the new`Hanami::Settings::YamlFileStore`. Values in `ENV` continue to take precedence. (@aaronmallen)
+
 ### Changed
 
 ### Deprecated

--- a/lib/hanami/config.rb
+++ b/lib/hanami/config.rb
@@ -48,16 +48,22 @@ module Hanami
     # @!attribute [rw] settings_store
     #   Sets the store used to retrieve {Hanami::Settings} values.
     #
-    #   Defaults to an instance of {Hanami::Settings::EnvStore}.
+    #   Defaults to a {Hanami::Settings::CompositeStore} that resolves each setting from, in order:
+    #   `ENV`, `config/settings/[HANAMI_ENV].yml`, then `config/settings/default.yml`.
+    #
+    #   The YAML files are read from the app root only, and are shared by the app and all its
+    #   slices, in the same way as `ENV`.
     #
     #   @return [#fetch]
     #
     #   @see Hanami::Settings
+    #   @see Hanami::Settings::CompositeStore#fetch
     #   @see Hanami::Settings::EnvStore#fetch
+    #   @see Hanami::Settings::YamlFileStore#fetch
     #
     #   @api public
     #   @since 2.0.0
-    setting :settings_store, default: Hanami::Settings::EnvStore.new
+    setting :settings_store
 
     # @!attribute [rw] slices
     #   Sets the slices to load when the app is preared or booted.
@@ -362,6 +368,7 @@ module Hanami
 
       # Apply default values that are only knowable at initialize-time (vs require-time)
       self.root = Dir.pwd
+      self.settings_store = default_settings_store
       self.render_errors = (env == :production)
       self.render_detailed_errors = (env == :development)
       load_from_env
@@ -535,6 +542,18 @@ module Hanami
     end
 
     private
+
+    # Returns the store used to retrieve settings values when none is configured.
+    #
+    # The YAML file paths are resolved lazily, since the root may be configured after this config is
+    # initialized.
+    def default_settings_store
+      Settings::CompositeStore.new(
+        Settings::EnvStore.new,
+        Settings::YamlFileStore.new { root.join(SETTINGS_PATH, "#{env}.yml") },
+        Settings::YamlFileStore.new { root.join(SETTINGS_PATH, "default.yml") }
+      )
+    end
 
     def load_from_env
       self.slices = ENV["HANAMI_SLICES"]&.split(",")&.map(&:strip)

--- a/lib/hanami/settings.rb
+++ b/lib/hanami/settings.rb
@@ -43,15 +43,25 @@ module Hanami
   # {Hanami::Slice::ClassMethods#prepare prepare} step, to ensure that the app boots only when valid
   # settings are present.
   #
-  # Setting values are loaded from a configurable store, which defaults to
-  # {Hanami::Settings::EnvStore}, which fetches the values from equivalent upper-cased keys in
-  # `ENV`. You can configure an alternative store via {Hanami::Config#settings_store}. Setting stores
-  # must implement a `#fetch` method with the same signature as `Hash#fetch`.
+  # Setting values are loaded from a configurable store, which defaults to a
+  # {Hanami::Settings::CompositeStore} resolving each value from, in order:
+  #
+  # 1. {Hanami::Settings::EnvStore}, which fetches the value from the equivalent upper-cased key in
+  #    `ENV`.
+  # 2. {Hanami::Settings::YamlFileStore}, for `config/settings/[HANAMI_ENV].yml`.
+  # 3. {Hanami::Settings::YamlFileStore}, for `config/settings/default.yml`.
+  #
+  # The YAML files are optional, and are read from the app root only: like `ENV`, they are shared by
+  # the app and all its slices.
+  #
+  # You can configure an alternative store via {Hanami::Config#settings_store}. Setting stores must
+  # implement a `#fetch` method with the same signature as `Hash#fetch`.
   #
   # [dry-c]: https://dry-rb.org/gems/dry-configurable/
   # [dry-t]: https://dry-rb.org/gems/dry-types/
   #
-  # @see Hanami::Settings::DotenvStore
+  # @see Hanami::Settings::EnvStore
+  # @see Hanami::Settings::YamlFileStore
   #
   # @api public
   # @since 2.0.0

--- a/lib/hanami/settings/yaml_file_store.rb
+++ b/lib/hanami/settings/yaml_file_store.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "date"
+require "dry/core/constants"
+require "erb"
+require "yaml"
+
+require_relative "../errors"
+
+module Hanami
+  class Settings
+    # A settings store that loads settings from a YAML file.
+    #
+    # The file is evaluated as ERB, then parsed as YAML, with its top-level keys becoming the
+    # setting names. It is read lazily, on the first fetch, and its contents are then memoized. A
+    # file that does not exist, or that is empty, results in an empty store.
+    #
+    # @example
+    #   # config/app.rb
+    #   config.settings_store = Hanami::Settings::YamlFileStore.new(config.root.join("my_settings.yml"))
+    #
+    # @example Resolving the path lazily
+    #   # Give a block to resolve the path when the settings are first fetched, rather than when the
+    #   # store is created.
+    #   config.settings_store = Hanami::Settings::YamlFileStore.new { config.root.join("my_settings.yml") }
+    #
+    # @api public
+    # @since 3.1.0
+    class YamlFileStore
+      # The classes permitted when parsing the YAML file.
+      #
+      # @api private
+      PERMITTED_CLASSES = [Date, DateTime, Symbol, Time].freeze
+      private_constant :PERMITTED_CLASSES
+
+      # @api private
+      EMPTY_STORE = Dry::Core::Constants::EMPTY_HASH
+      private_constant :EMPTY_STORE
+
+      # Returns a new instance of the store.
+      #
+      # Give either a path or a block returning a path. The block is called on the first fetch,
+      # which allows the path to depend on config (such as the root) that is not yet known when the
+      # store is created.
+      #
+      # @param path [Pathname, String, nil] the path to load the settings from
+      #
+      # @yieldreturn [Pathname, String] the path to load the settings from
+      #
+      # @api public
+      # @since 3.1.0
+      def initialize(path = nil, &block)
+        if path.nil? == block.nil?
+          raise ArgumentError, "give either a path or a block returning a path"
+        end
+
+        @path = path
+        @path_resolver = block
+      end
+
+      # Returns the path to the YAML file, resolving it from the block given at initialize-time, if
+      # any.
+      #
+      # @return [Pathname, String]
+      #
+      # @api public
+      # @since 3.1.0
+      def path
+        @path ||= @path_resolver.call
+      end
+
+      # @api private
+      def fetch(name, *args, &block)
+        store.fetch(name.to_sym, *args, &block)
+      end
+
+      private
+
+      def store
+        @store ||= load_store
+      end
+
+      def load_store
+        return EMPTY_STORE unless File.exist?(path)
+
+        contents = YAML.load(
+          ERB.new(File.read(path)).result,
+          aliases: true,
+          permitted_classes: PERMITTED_CLASSES,
+          symbolize_names: true
+        )
+
+        # An empty file (or one containing only comments) parses as `nil`.
+        return EMPTY_STORE if contents.nil?
+
+        unless contents.is_a?(Hash)
+          raise Hanami::Error, "Expected #{path} to contain a YAML mapping, but it contained a #{contents.class}."
+        end
+
+        contents.freeze
+      end
+    end
+  end
+end

--- a/spec/integration/settings/loading_from_yaml_files_spec.rb
+++ b/spec/integration/settings/loading_from_yaml_files_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+RSpec.describe "Settings / Loading from YAML files", :app_integration do
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  def with_app(&block)
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~'RUBY'
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/settings.rb", <<~'RUBY'
+        module TestApp
+          class Settings < Hanami::Settings
+            setting :database_url
+            setting :redis_url
+          end
+        end
+      RUBY
+
+      block.call
+    end
+  end
+
+  specify "settings are loaded from config/settings/default.yml" do
+    with_app do
+      write "config/settings/default.yml", <<~YAML
+        database_url: postgres://localhost/default
+        redis_url: redis://localhost/default
+      YAML
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["settings"].database_url).to eq "postgres://localhost/default"
+      expect(Hanami.app["settings"].redis_url).to eq "redis://localhost/default"
+    end
+  end
+
+  specify "settings in the env-specific file take precedence over default.yml" do
+    with_app do
+      write "config/settings/default.yml", <<~YAML
+        database_url: postgres://localhost/default
+        redis_url: redis://localhost/default
+      YAML
+
+      write "config/settings/development.yml", <<~YAML
+        database_url: postgres://localhost/development
+      YAML
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["settings"].database_url).to eq "postgres://localhost/development"
+      expect(Hanami.app["settings"].redis_url).to eq "redis://localhost/default"
+    end
+  end
+
+  specify "settings in ENV take precedence over the YAML files" do
+    with_app do
+      write "config/settings/default.yml", <<~YAML
+        database_url: postgres://localhost/default
+        redis_url: redis://localhost/default
+      YAML
+
+      write "config/settings/development.yml", <<~YAML
+        database_url: postgres://localhost/development
+      YAML
+
+      ENV["DATABASE_URL"] = "postgres://localhost/from_env"
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["settings"].database_url).to eq "postgres://localhost/from_env"
+      expect(Hanami.app["settings"].redis_url).to eq "redis://localhost/default"
+    end
+  end
+
+  specify "slices load settings from the app's YAML files" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~'RUBY'
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/settings/default.yml", <<~YAML
+        database_url: postgres://localhost/default
+      YAML
+
+      write "slices/main/config/settings.rb", <<~'RUBY'
+        module Main
+          class Settings < Hanami::Settings
+            setting :database_url
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      expect(Main::Slice["settings"].database_url).to eq "postgres://localhost/default"
+    end
+  end
+
+  specify "a store configured in the app class body replaces the default store" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~'RUBY'
+        require "hanami"
+
+        class TestStore
+          def fetch(name, *args, &block)
+            {database_url: "from_custom_store"}.fetch(name, *args, &block)
+          end
+        end
+
+        module TestApp
+          class App < Hanami::App
+            config.settings_store = TestStore.new
+          end
+        end
+      RUBY
+
+      write "config/settings.rb", <<~'RUBY'
+        module TestApp
+          class Settings < Hanami::Settings
+            setting :database_url
+          end
+        end
+      RUBY
+
+      write "config/settings/default.yml", <<~YAML
+        database_url: postgres://localhost/default
+      YAML
+
+      ENV["DATABASE_URL"] = "postgres://localhost/from_env"
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["settings"].database_url).to eq "from_custom_store"
+    end
+  end
+
+  specify "the YAML files are evaluated as ERB" do
+    with_app do
+      write "config/settings/default.yml", <<~YAML
+        database_url: <%= "postgres://localhost/erb" %>
+        redis_url: redis://localhost/default
+      YAML
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["settings"].database_url).to eq "postgres://localhost/erb"
+    end
+  end
+
+  specify "no YAML files are required" do
+    with_app do
+      ENV["DATABASE_URL"] = "postgres://localhost/from_env"
+      ENV["REDIS_URL"] = "redis://localhost/from_env"
+
+      require "hanami/prepare"
+
+      expect(Hanami.app["settings"].database_url).to eq "postgres://localhost/from_env"
+    end
+  end
+end

--- a/spec/unit/hanami/settings/yaml_file_store_spec.rb
+++ b/spec/unit/hanami/settings/yaml_file_store_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "hanami/settings/yaml_file_store"
+require "tmpdir"
+
+RSpec.describe Hanami::Settings::YamlFileStore do
+  subject(:store) { described_class.new(path) }
+
+  let(:root) { Pathname(Dir.mktmpdir) }
+  let(:path) { root.join("settings.yml") }
+
+  def write(contents)
+    File.write(path, contents)
+  end
+
+  after { FileUtils.remove_entry(root) }
+
+  describe "#initialize" do
+    it "raises when given neither a path nor a block" do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+
+    it "raises when given both a path and a block" do
+      expect { described_class.new(path) { path } }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#path" do
+    it "returns the given path" do
+      expect(store.path).to eq path
+    end
+
+    it "resolves the path from the given block" do
+      resolved = 0
+      store = described_class.new {
+        resolved += 1
+        path
+      }
+
+      expect(store.path).to eq path
+      expect(store.path).to eq path
+      expect(resolved).to eq 1
+    end
+
+    it "does not resolve the block until the path is needed" do
+      expect { described_class.new { raise "should not be called" } }.not_to raise_error
+    end
+  end
+
+  describe "#fetch" do
+    it "fetches values by name" do
+      write("database_url: postgres://localhost/database\n")
+
+      expect(store.fetch(:database_url)).to eq "postgres://localhost/database"
+      expect(store.fetch("database_url")).to eq "postgres://localhost/database"
+    end
+
+    it "returns nested values as hashes with symbol keys" do
+      write(<<~YAML)
+        redis:
+          url: redis://localhost
+      YAML
+
+      expect(store.fetch(:redis)).to eq(url: "redis://localhost")
+    end
+
+    it "evaluates the file as ERB before parsing it as YAML" do
+      write("database_url: <%= 'postgres://localhost/database' %>\n")
+
+      expect(store.fetch(:database_url)).to eq "postgres://localhost/database"
+    end
+
+    it "supports YAML aliases" do
+      write(<<~YAML)
+        defaults: &defaults
+          url: redis://localhost
+        redis:
+          <<: *defaults
+      YAML
+
+      expect(store.fetch(:redis)).to eq(url: "redis://localhost")
+    end
+
+    it "supports dates and times" do
+      write("expires_at: 2026-01-01\n")
+
+      expect(store.fetch(:expires_at)).to eq Date.new(2026, 1, 1)
+    end
+
+    it "returns the default value when the file does not have the key" do
+      write("database_url: postgres://localhost/database\n")
+
+      expect(store.fetch(:missing, "default")).to eq "default"
+    end
+
+    it "yields to the block when the file does not have the key and no default is given" do
+      write("database_url: postgres://localhost/database\n")
+
+      expect(store.fetch(:missing) { "from_block" }).to eq "from_block" # rubocop:disable Style/RedundantFetchBlock
+    end
+
+    it "raises KeyError when the file does not have the key and no default is given" do
+      write("database_url: postgres://localhost/database\n")
+
+      expect { store.fetch(:missing) }.to raise_error(KeyError)
+    end
+
+    it "returns a nil value given for a key" do
+      write("database_url:\n")
+
+      expect(store.fetch(:database_url, "default")).to be nil
+    end
+
+    it "reads the file only once" do
+      write("database_url: postgres://localhost/database\n")
+
+      expect(store.fetch(:database_url)).to eq "postgres://localhost/database"
+
+      write("database_url: postgres://localhost/other\n")
+
+      expect(store.fetch(:database_url)).to eq "postgres://localhost/database"
+    end
+
+    context "file does not exist" do
+      it "behaves as an empty store" do
+        expect(store.fetch(:database_url, "default")).to eq "default"
+        expect { store.fetch(:database_url) }.to raise_error(KeyError)
+      end
+    end
+
+    context "empty file" do
+      it "behaves as an empty store" do
+        write("# just a comment\n")
+
+        expect(store.fetch(:database_url, "default")).to eq "default"
+      end
+    end
+
+    context "file does not contain a mapping" do
+      it "raises an error naming the file" do
+        write("- one\n- two\n")
+
+        expect { store.fetch(:database_url) }
+          .to raise_error(Hanami::Error, /#{Regexp.escape(path.to_s)}.*Array/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Settings can now be loaded from YAML files at `config/settings/default.yml` and `config/settings/#{Hanami.env}.yml`, in addition to `ENV`.

## Why

Settings files are useful where `ENV` alone is awkward:

- They are evaluated as ERB, so a setting can be computed rather than just read.
- They keep non-secret, environment-varying config in the repo, reviewable in a diff, instead of spread across deployment environments.
- They give a natural home for shared defaults, with per-environment overrides layered on top.

```yaml
# config/settings/default.yml
database_url: <%= ENV.fetch("DATABASE_URL") %>
secret: <%= MySecretProvider.get("app_secret") %>
site_name: <%= Hanami.env?(:test) ? "test_site" : "site" %>
```

## How it works

The default settings store is now a `Hanami::Settings::CompositeStore` that resolves each setting from, in order:

1. `ENV` (via `Hanami::Settings::EnvStore`, as before)
2. `config/settings/#{Hanami.env}.yml`
3. `config/settings/default.yml`

Both files are optional. Each is evaluated as ERB, then parsed as YAML, with its top-level keys becoming setting names. Files are read lazily on the first fetch and then memoized, so an app that defines no settings never touches the filesystem.

Like `ENV` and `.env`, the files are read from the app root only and are shared by the app and all of its slices.

### `Hanami::Settings::YamlFileStore`

The new store is public API and can be used on its own:

```ruby
# config/app.rb
config.settings_store = Hanami::Settings::YamlFileStore.new(
  config.root.join("my_settings.yml")
)
```

It also accepts a block, for a path that depends on config not yet known when the store is built:

```ruby
config.settings_store = Hanami::Settings::YamlFileStore.new {
  config.root.join("my_settings.yml")
}
```

Details worth knowing:

- YAML aliases are enabled, and `Date`, `DateTime`, `Time` and `Symbol` values are permitted under Psych's safe load.
- A missing or empty file behaves as an empty store.
- A file whose top level is not a mapping raises a `Hanami::Error` naming the file, rather than failing obscurely later.

## Backwards compatibility

Fully backwards compatible. `ENV` keeps precedence over both files, so an existing app that configures its settings through the environment behaves exactly as it does today, whether or not the files are present.

Assigning `config.settings_store` still replaces the whole chain, `ENV` included. To add a store while keeping the defaults, compose it:

```ruby
config.settings_store = Hanami::Settings::CompositeStore.new(
  MyStore.new,
  config.settings_store
)
```