### PR TITLE
Enable ObjectSpace for JRuby tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
     env:
       COVERAGE: ${{ matrix.coverage }}
       RACK_MATRIX_VALUE: ${{ matrix.rack || '' }}
+      # Env below included from ./repo-sync-extensions/ci-env.yml
+      # Enable ObjectSpace for tests
+      JRUBY_OPTS: "-X+O"
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.github/workflows/repo-sync-extensions/ci-env.yml
+++ b/.github/workflows/repo-sync-extensions/ci-env.yml
@@ -1,0 +1,2 @@
+# Enable ObjectSpace for tests
+JRUBY_OPTS: "-X+O"


### PR DESCRIPTION
Currently we have 575 tests are failing on JRuby. But most of them are related to `ObjectSpace` not being available. This really obfuscates how far we are from supporting JRuby. After enabling `ObjectSpace` it's only 75 failures (and will be even fewer after merging https://github.com/hanami/hanami-cli/pull/434) – so IMO it's a nice first step.