### PR TITLE
Register only ROM classes from the DB component directories

### DIFF
--- a/lib/hanami/providers/db.rb
+++ b/lib/hanami/providers/db.rb
@@ -309,7 +309,31 @@ module Hanami
             "#{target.slice_name.name}/#{path}/#{component_name}"
           ).then { target.inflector.constantize(_1) }
 
+          next unless rom_component_class?(component_type, component_class)
+
           @rom_config.public_send(:"register_#{component_type}", component_class)
+        end
+      end
+
+      # Returns true if the class is a ROM component of the given type.
+      #
+      # Only these classes are registered with ROM, which leaves apps free to keep their own
+      # classes alongside their ROM components in the same directories.
+      def rom_component_class?(component_type, component_class)
+        return false unless component_class.is_a?(Class)
+
+        case component_type
+        when :relation
+          component_class < ROM::Relation
+        when :command
+          component_class < ROM::Command
+        when :mapper
+          # ROM mappers may be built from either of these two unrelated classes. ROM::Transformer
+          # must be required explicitly, so it may not be loaded at this point.
+          component_class < ROM::Mapper ||
+            (defined?(ROM::Transformer) && component_class < ROM::Transformer)
+        else
+          false
         end
       end
     end

--- a/spec/integration/db/relations_spec.rb
+++ b/spec/integration/db/relations_spec.rb
@@ -57,4 +57,62 @@ RSpec.describe "DB / Relations", :app_integration do
       expect(post[:title]).to eq "Hi from nested relation"
     end
   end
+
+  it "does not register classes that are not ROM relations" do
+    with_tmp_directory(@dir = Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+            config.logger.stream = File::NULL
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      # A class of the app's own making, living alongside the ROM relations
+      write "app/relations/cached_posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class CachedPosts
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL"] = "sqlite::memory"
+
+      require "hanami/prepare"
+
+      Hanami.app.prepare :db
+
+      # Manually run a migration and add a test record
+      gateway = TestApp::App["db.gateway"]
+      migration = gateway.migration do
+        change do
+          create_table :posts do
+            primary_key :id
+            column :title, :text
+          end
+        end
+      end
+      migration.apply(gateway, :up)
+      gateway.connection.execute("INSERT INTO posts (title) VALUES ('Hi from posts relation')")
+
+      post = TestApp::App["relations.posts"].to_a[0]
+      expect(post[:title]).to eq "Hi from posts relation"
+
+      expect(TestApp::App["db.rom"].relations.elements.keys).to eq [:posts]
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Hanami::Providers::DB#register_rom_components` globs every Ruby file under `relations/`, `db/commands/` and `db/mappers/`, constantizes it, and hands the result straight to ROM. ROM then tries to build a component out of whatever it was given.

That leaves no room for an app to keep its own classes in those directories. An app of mine stores Redis-backed relations next to its SQL ones, and the only way to boot was to patch ROM itself:

```ruby
module Extension
  def register_relation(*klasses)
    super(*klasses.reject { it <= ::MyApp::Redis::Relation })
  end
end

ROM::Setup.prepend(Extension)
```

Patching another gem to undo what Hanami just did is the wrong shape for this.

## Change

Check each constant before registering it, and skip anything that is not a ROM component of that type:

- `relations/` requires `< ROM::Relation`
- `db/commands/` requires `< ROM::Command`
- `db/mappers/` requires `< ROM::Mapper` or `< ROM::Transformer`

Non-class constants, such as a bare module, are skipped as well.

Mappers need both base classes because ROM builds them from two hierarchies that share no ancestor. `ROM::Transformer` is not loaded by `require "rom"`, so a `defined?` guard keeps the check from raising in apps that never use it.

## Why `ROM::Relation` and not `Hanami::DB::Relation`

The provider accepts any ROM adapter: `Adapters::ADAPTER_CLASSES` falls back to a generic `Adapter` for every name other than `:sql`. Relations for rom-yaml, rom-http and the rest inherit from `ROM::Relation[:that_adapter]`, never from `Hanami::DB::Relation`. Filtering on `Hanami::DB::Relation` would drop them.