### PR TITLE
Resolve the app routes helper for slice view contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ A complete Hanami app is composed of multiple gems. For a complete overview of c
 - Return `false` from `Hanami::Slice.app?`, rather than raising `Hanami::AppLoadError`, when no app is defined. (@parndt in #1612)
 - Build `logger` and `inflector` providers registered on a slice from the slice's own config, rather than the app's. (@parndt in #1613)
 - Register only ROM classes from the `relations`, `db/commands` and `db/mappers` directories, leaving any other classes in those directories untouched. (@aaronmallen in #1629)
+- Resolve the `routes` helper in slice view contexts from the app, so views and actions in a slice generate the same named paths. (@aaronmallen in #1630)
 
 ### Security
 

--- a/lib/hanami/extensions/view/slice_configured_context.rb
+++ b/lib/hanami/extensions/view/slice_configured_context.rb
@@ -38,7 +38,7 @@ module Hanami
         # This includes the following app components:
         #   - the configured inflector as `inflector`
         #   - "routes" from the app container as `routes`
-        #   - "assets" from the app container as `assets`
+        #   - "assets" from the slice container as `assets`
         #   - "i18n" from the slice container as `i18n`
         def define_new
           inflector = slice.inflector
@@ -56,8 +56,12 @@ module Hanami
           end
         end
 
+        # Resolves from the app, not the slice, because a slice defining its own routes registers
+        # its own "routes" component, which knows only that slice's names and none of the prefix it
+        # is mounted at. Actions resolve the app's helper, so this keeps a view and an action in the
+        # same slice in agreement.
         def resolve_routes
-          slice["routes"] if slice.key?("routes")
+          slice.app["routes"] if slice.app.key?("routes")
         end
 
         def resolve_assets

--- a/spec/integration/view/context/routes_spec.rb
+++ b/spec/integration/view/context/routes_spec.rb
@@ -60,6 +60,83 @@ RSpec.describe "App view / Context / Routes", :app_integration do
     end
   end
 
+  it "accesses app routes from a slice context, including the prefix the slice is mounted at" do
+    with_tmp_directory(Dir.mktmpdir) do
+      write "config/app.rb", <<~RUBY
+        require "hanami"
+
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "config/routes.rb", <<~RUBY
+        module TestApp
+          class Routes < Hanami::Routes
+            root to: "home.index"
+
+            slice :main, at: "/main"
+          end
+        end
+      RUBY
+
+      write "app/actions/home/index.rb", <<~RUBY
+        require "hanami/action"
+
+        module TestApp
+          module Actions
+            module Home
+              class Index < Hanami::Action
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/config/routes.rb", <<~RUBY
+        module Main
+          class Routes < Hanami::Routes
+            get "/posts", to: "posts.index", as: :posts
+          end
+        end
+      RUBY
+
+      write "slices/main/actions/posts/index.rb", <<~RUBY
+        require "hanami/action"
+
+        module Main
+          module Actions
+            module Posts
+              class Index < Hanami::Action
+              end
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/views/context.rb", <<~RUBY
+        require "hanami/view/context"
+
+        module Main
+          module Views
+            class Context < Hanami::View::Context
+            end
+          end
+        end
+      RUBY
+
+      require "hanami/prepare"
+
+      context = Main::Views::Context.new
+
+      # The slice's own "routes" component knows this route as :posts at "/posts", missing the
+      # prefix it is mounted at, and does not know :root at all.
+      expect(context.routes.path(:main_posts)).to eq "/main/posts"
+      expect(context.routes.path(:root)).to eq "/"
+    end
+  end
+
   it "can inject routes" do
     module TestApp
       class App < Hanami::App


### PR DESCRIPTION
## The problem

A slice that defines its own `config/routes.rb` gets a `"routes"` component registered
in its own container (`Hanami::Slice#prepare_container_providers`). That helper wraps
the slice's own router, which is built from that slice's routes file alone and knows
nothing about the prefix the slice is mounted at.

`SliceConfiguredContext#resolve_routes` injects that slice-local helper into the
slice's view context. Two things follow:

1. A view in one slice cannot link to a route in another slice, or to an app route.
   `routes.path(:root)` raises `Hanami::Router::MissingRouteError`.
2. For a slice mounted at a prefix, the names it *can* reach generate paths without
   that prefix. `slice :main, at: "/main"` gives a view `"/posts"` where the app router
   gives `"/main/posts"`. Silently wrong links, no exception.

`SliceConfiguredAction#resolve_routes` already resolves `slice.app["routes"]`, so an
action and a view in the same slice disagree about what a named path is. The docstring
on `SliceConfiguredContext#define_new` also already claims `"routes" from the app
container`, so the code contradicts its own documentation.

## Reproduction

```ruby
# config/routes.rb
module TestApp
  class Routes < Hanami::Routes
    root to: "home.index"
    slice :main, at: "/main"
  end
end

# slices/main/config/routes.rb
module Main
  class Routes < Hanami::Routes
    get "/posts", to: "posts.index", as: :posts
  end
end

Main::Views::Context.new.routes.path(:posts)      # => "/posts", missing the /main prefix
Main::Views::Context.new.routes.path(:root)       # => raises MissingRouteError
Main::Slice["routes"].path(:main_posts)           # => raises MissingRouteError
TestApp::App["routes"].path(:main_posts)          # => "/main/posts"
```

## The change

Resolve `"routes"` from the app, matching `SliceConfiguredAction`.

Also corrects one line of the same docstring: it listed `"assets"` as coming from the
app container, where the code resolves it from the slice. Per-slice assets are
deliberate, so the comment was the wrong half.

## Behavior change

This changes which names a slice view can use, and it is not purely additive.

Mounting a slice with `slice :main, at: "/main"` prefixes route *names* as well as
paths, because `Hanami::Router#scope` falls back to the path when no `as:` is given
(`as || path`). So a slice view that today writes `routes.path(:posts)` must write
`routes.path(:main_posts)` after this change.

Actions in that slice already use `:main_posts`, so this makes the two agree, but it
will break existing slice views that relied on slice-local names. Slices mounted at
`"/"` take no name prefix and are unaffected.

Flagging it so you can decide whether this belongs in a patch or in 3.1.
